### PR TITLE
[1.1.2] Trailing whitespace in dhcpd.subnet.conf.j2

### DIFF
--- a/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
+++ b/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
@@ -32,14 +32,15 @@
       {% set ipxe_rom_filename = (ipxe_architecture + '/standard_' + ipxe_driver + 'ipxe.efi') %}
     {% else %}  {# Assume everything else is pcbios #}
       {% set ipxe_rom_filename = (ipxe_architecture + '/standard_undionly.kpxe') %}
-    {% endif %}
+    {% endif -%}
 
-    {% for nic, nic_args in hostvars[host]['network_interfaces'].items() %}
+    {%- for nic, nic_args in hostvars[host]['network_interfaces'].items() %}
       {% if (nic_args.network is defined and not none) and (nic_args.network == item) and (nic_args.ip4 is defined and not none) %}
+
         {% if nic_args.mac is defined and not none %}
-  host {{host}} { 
+  host {{host}} {
     option host-name "{{host}}";
-    hardware ethernet {{nic_args.mac}}; 
+    hardware ethernet {{nic_args.mac}};
     fixed-address {{nic_args.ip4}};
     filename "{{ipxe_rom_filename}}";
   }
@@ -71,11 +72,12 @@
   }
         {% endif %}
       {% endif %}
-    {% endfor %}
+    {% endfor -%}
 
-    {% if hostvars[host]['bmc'] is defined %}
+    {%- if hostvars[host]['bmc'] is defined %}
       {% set bmc_args = hostvars[host]['bmc'] %}
       {% if (bmc_args.network is defined and not none) and (bmc_args.network == item) and (bmc_args.name is defined and not none) and (bmc_args.ip4 is defined and not none) %}
+
         {% if bmc_args.mac is defined and not none %}
     host {{bmc_args.name}} {
       option host-name "{{bmc_args.name}}";
@@ -110,4 +112,3 @@
     {% endif %}
   {% endif %}
 {% endfor %}
-


### PR DESCRIPTION
Hello,
When we define several networks (ice1-2, ice1-3, ...), the `dhcpd.subnet.conf.j2` template generate many **trailing whitespace and blank line**s in DHCP configuration files.
This is not a problem to run the DHCP service, but the configuration files generate is too big and not very clean.

For fix this issue, please merge my patch.

Regards,