### PR TITLE
[1.1.2] DHCPD doesn't work with multi-subnets and mutli-hosts

### DIFF
--- a/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
+++ b/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
@@ -37,21 +37,21 @@
     {% for nic, nic_args in hostvars[host]['network_interfaces'].items() %}
       {% if (nic_args.network is defined and not none) and (nic_args.network == item) and (nic_args.ip4 is defined and not none) %}
         {% if nic_args.mac is defined and not none %}
-  host {{host}} { 
+  host {{host}}-{{item}} { 
     option host-name "{{host}}";
     hardware ethernet {{nic_args.mac}}; 
     fixed-address {{nic_args.ip4}};
     filename "{{ipxe_rom_filename}}";
   }
         {% elif nic_args.dhcp_client_identifier is defined and not none %}
-  host {{host}} {
+  host {{host}}-{{item}} {
     option host-name "{{host}}";
     option dhcp-client-identifier {{nic_args.dhcp_client_identifier}};
     fixed-address {{nic_args.ip4}};
     filename "{{ipxe_rom_filename}}";
   }
         {% elif nic_args.host_identifier is defined and not none %}
-  host {{host}} {
+  host {{host}}-{{item}} {
     option host-name "{{host}}";
     host_identifier {{nic_args.host-identifier}};
     fixed-address {{nic_args.ip4}};


### PR DESCRIPTION
Hello,
Sometimes we need to have multiple host machine interfaces in several different subnet.
in this case, the DHCP service does not start. 
It indicates that you can't have more than one host-name.
In fact the host-names are identical but this is prohibited by the DHCP service operation.

Inventory example:
```
    equipment_typeM:
      hosts:
        mynode:
          network_interfaces:
            enp0s3:
              ip4: 10.11.0.1
              mac: 08:00:27:84:e3:35
              network: ice1-1
            ens3f0:
              ip4: 192.168.1.254
              mac: 90:e2:ba:e1:04:9e
              network: ice1-2
            ens3f1:
              ip4: 192.168.0.254
              mac: 90:e2:ba:e1:04:9f
              network: ice1-3
```

With this inventory, the DHCP file generated is :
```
mynode-ice1-1 {
    option host-name "mynode";
    hardware ethernet 08:00:27:84:e3:35; 
    fixed-address 10.11.0.1;
}
mynode-ice1-2 {
    option host-name "mynode";
    hardware ethernet 90:e2:ba:e1:04:9e; 
    fixed-address 192.168.1.254;
}
mynode-ice1-3 {
    option host-name "mynode";
    hardware ethernet90:e2:ba:e1:04:9f; 
    fixed-address 192.168.0.254;
}
```
The three DHCP host-name are different and the service can started.

For fix this issue, I propose this patch.

Regards