### PR TITLE
fix: add target variable to example playbooks

### DIFF
--- a/resources/examples/simple_cluster/playbooks/login1.yml
+++ b/resources/examples/simple_cluster/playbooks/login1.yml
@@ -1,6 +1,6 @@
 ---
 - name: login1
-  hosts: login1
+  hosts: "{{ target | default('login1') }}"
   roles:
 
     - role: set_hostname

--- a/resources/examples/simple_cluster/playbooks/management1.yml
+++ b/resources/examples/simple_cluster/playbooks/management1.yml
@@ -1,6 +1,6 @@
 ---
 - name: management1
-  hosts: "management1"
+  hosts: "{{ target | default('management1') }}"
   roles:
 
     - role: set_hostname


### PR DESCRIPTION
Allow to use `--extra-vars target=foo` whatever the playbook.