### PR TITLE
[master] [advanced_dhcp_server] whitespace too long, buffer overflow.

### DIFF
--- a/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
+++ b/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
@@ -15,17 +15,17 @@
 
 {% for host in range %}
   {% if hostvars[host]['network_interfaces'] is defined %}
-    {# Define iPXE rom to use #}
+    {#- Define iPXE rom to use #}
     {% if hostvars[host]['equipment_profile']['ipxe_driver'] == 'snponly' %} {# Select driver first #}
       {% set ipxe_driver = 'snponly_' %}
     {% elif hostvars[host]['equipment_profile']['ipxe_driver'] == 'snp' %}
       {% set ipxe_driver = 'snp_' %}
-    {% else %}  {# Assume everything else is default driver #}
+    {% else %}{# Assume everything else is default driver #}
       {% set ipxe_driver = '' %}
     {% endif %}
     {% if hostvars[host]['equipment_profile']['hardware']['cpu']['architecture'] == 'arm64' %} {# Now select architecture #}
       {% set ipxe_architecture = 'arm64' %}
-    {% else %}  {# Assume everything else is x86_64 #}
+    {% else %}{# Assume everything else is x86_64 #}
       {% set ipxe_architecture = 'x86_64' %}
     {% endif %}
     {% if hostvars[host]['equipment_profile']['ipxe_embed'] == 'dhcpretry' %} {# Now select embed script #}
@@ -35,7 +35,7 @@
     {% endif %}
     {% if hostvars[host]['equipment_profile']['ipxe_platform'] == 'efi' %} {# Finally, build file name depending of platform and previous parameters #}
       {% set ipxe_rom_filename = (ipxe_architecture + '/' + ipxe_embed + '_' + ipxe_driver + 'ipxe.efi') %}
-    {% else %}  {# Assume everything else is pcbios #}
+    {% else %}{# Assume everything else is pcbios #}
       {% set ipxe_rom_filename = (ipxe_architecture + '/' + ipxe_embed + '_undionly.kpxe') %}
     {% endif %}
 


### PR DESCRIPTION
When a second file /etc/dhcp/dhcpd.{{item}}.conf is generated, the dhcpd service crashes.
Indeed, there are whitespaces before the declaration of the hosts.

```
[root@pm-mgt0 nodes]# /usr/sbin/dhcpd -t -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd --no-pid
Internet Systems Consortium DHCP Server 4.3.6
Copyright 2004-2017 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/
WARNING: Host declarations are global. They are not limited to the scope you declared them in.
/etc/dhcp/dhcpd.ice1-2.conf line 0: whitespace too long, buffer overflow.
^
Exiting
```