### PR TITLE
feat: security.ssh.hostkey_checking=true|false

### DIFF
--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/security.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/security.yml
@@ -1,0 +1,4 @@
+---
+security:
+  ssh:
+    hostkey_checking: true # enable or disable hostkey checking

--- a/resources/examples/simple_cluster/inventory/group_vars/all/security.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/security.yml
@@ -1,0 +1,4 @@
+---
+security:
+  ssh:
+    hostkey_checking: true # enable or disable hostkey checking

--- a/roles/core/ssh_master/readme.rst
+++ b/roles/core/ssh_master/readme.rst
@@ -9,20 +9,19 @@ This role configure the ssh access of know hosts to make this access through nod
 Instructions
 ^^^^^^^^^^^^
 
-This role will generate a Configuration file in */root/.ssh/config*.
+This role will generate a configuration file in */root/.ssh/config*.
 
-This file will contains all hosts of the Ansible inventory (or all hosts of the current iceberg if using icebergs mode), with the following parameters:
+This file will contains all hosts of the Ansible inventory (or all hosts of the
+current iceberg if using icebergs mode), with the following parameters:
 
 .. code-block:: text
 
   Host freya
-      StrictHostKeyChecking no
-      UserKnownHostsFile=/dev/null
       Hostname %h-ice1-1
 
-This ensure no issues when redeploying an hosts.
-
-Also, note that for this example host, **freya**, the target hostname for ssh is %h-ice1-1, which means **freya-ice1-1**. This can be seen when invoking ssh with verbosity:
+Note that for this example host, **freya**, the target hostname for ssh is
+%h-ice1-1, which translates to **freya-ice1-1**. This can be seen when invoking
+ssh with verbosity:
 
 .. code-block:: text
 
@@ -42,9 +41,40 @@ Also, note that for this example host, **freya**, the target hostname for ssh is
   debug2: ssh_connect_direct
   debug1: Connecting to freya-ice1-1 [10.11.2.1] port 22.
 
-You can see here ssh is not trying to reach **freya** but is using **freya-ice-1-1**. This has been made to ensure whatever the direct resolution is in /etc/hosts file or DNS, ssh and so Ansible will always use the management network of the target host.
+You can see here ssh is not trying to reach **freya** but is using
+**freya-ice-1-1**. This has been made to ensure whatever the direct resolution
+is in /etc/hosts or DNS, ssh and so Ansible will always use the management
+network of the target host.
 
-Note that this file generation is kind of "sensible", and will surely be the first one to break in case of uncoherent inventory. If this happens, check your inventory, fix it, and remove manually /root/.ssh/config and relaunch its generation.
+Also, keep in mind that when redeploying a host its SSH key changes, which
+requires to remove the former host key from the known_hosts file, then add the
+new key. It is possible to achieve this with the commands below:
+
+.. code-block:: bash
+
+  # for host in $(nodeset -e $NODES); do \
+      sed -i -e "/^${host}/d" /root/.ssh/known_hosts; \
+  done
+  # clush -o '-o StrictHostKeyChecking=no' -w $NODES dmidecode -s system-uuid
+
+It is possible to disable the strict host key checking with the parameter
+*ssh_master_disable_hosts_check: true* in the inventory. This was the default
+behaviour prior BlueBanquise 1.3. The ssh configuration file will include the
+following parameters:
+
+.. code-block:: text
+
+  Host freya
+      StrictHostKeyChecking no
+      UserKnownHostsFile=/dev/null
+      Hostname %h-ice1-1
+
+This ensure no issues when redeploying an host, at the cost of security.
+
+Note that this file generation is kind of "sensible", and will surely be the
+first one to break in case of uncoherent inventory. If this happens, check your
+inventory, fix it, and remove manually /root/.ssh/config and relaunch its
+generation.
 
 To be done
 ^^^^^^^^^^

--- a/roles/core/ssh_master/readme.rst
+++ b/roles/core/ssh_master/readme.rst
@@ -57,10 +57,18 @@ new key. It is possible to achieve this with the commands below:
   done
   # clush -o '-o StrictHostKeyChecking=no' -w $NODES dmidecode -s system-uuid
 
-It is possible to disable the strict host key checking with the parameter
-*ssh_master_disable_hosts_check: true* in the inventory. This was the default
-behaviour prior BlueBanquise 1.3. The ssh configuration file will include the
-following parameters:
+It is possible to disable the strict host key checking in the inventory with the
+configuration below:
+
+.. code-block:: yaml
+
+   ---
+   security:
+     ssh:
+       hostkey_checking: false
+
+This was the default behaviour prior BlueBanquise 1.3. The ssh configuration
+file will include the following parameters:
 
 .. code-block:: text
 

--- a/roles/core/ssh_master/templates/config.j2
+++ b/roles/core/ssh_master/templates/config.j2
@@ -3,8 +3,8 @@
 {# Macro to avoid redundancy #}
 {% macro write_host(host,macro_node_main_network) %}
 Host {{host}}
-    {% if ssh_master_disable_hosts_check is defined and
-          ssh_master_disable_hosts_check == true %}
+    {% if security.ssh.hostkey_checking is not defined or
+          security.ssh.hostkey_checking == false %}
     StrictHostKeyChecking no
     UserKnownHostsFile=/dev/null
     {% endif %}

--- a/roles/core/ssh_master/templates/config.j2
+++ b/roles/core/ssh_master/templates/config.j2
@@ -1,9 +1,13 @@
+#jinja2: lstrip_blocks: "True"
 {% import "macros/network.j2" as macro_network with context %}
 {# Macro to avoid redundancy #}
 {% macro write_host(host,macro_node_main_network) %}
 Host {{host}}
+    {% if ssh_master_disable_hosts_check is defined and
+          ssh_master_disable_hosts_check == true %}
     StrictHostKeyChecking no
     UserKnownHostsFile=/dev/null
+    {% endif %}
     Hostname %h-{{macro_node_main_network}}
 {% endmacro %}
 #### Blue Banquise file ####


### PR DESCRIPTION
Set security.ssh.hostkey_checking=false to apply the following
parameters to the hosts in /root/.ssh/config:

  StrictHostKeyChecking no
  UserKnownHostsFile=/dev/null

Default to false if not defined to keep backward compatibility with existing setup.
Set to true in example inventories for new setup.