### PR TITLE
fix: define default parameters in role repositories_client

### DIFF
--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/repositories.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/repositories.yml
@@ -2,4 +2,4 @@ repositories:
   - bluebanquise
   - os
 
-remove_distro_repositories: True
+disable_distro_repositories: True

--- a/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/repositories.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/repositories.yml
@@ -2,4 +2,4 @@ repositories:
   - bluebanquise
   - os
 
-remove_distro_repositories: True
+disable_distro_repositories: True

--- a/roles/core/repositories_client/defaults/main.yml
+++ b/roles/core/repositories_client/defaults/main.yml
@@ -1,3 +1,28 @@
+# System repositories, internal to the cluster
+#
+# It can be expanded to change settings for a repo with a dict, using
+# YAML's flow styles or block styles:
+#
+#   repositories:
+#     - bluebanquise
+#     - { name: 'os', gpgcheck: 1 }  # Flow style
+#     - name: epel                   # Block style
+#       gpgcheck: 1
+#
+# Available settings: name, baseurl, enabled, gpgcheck, gpgkey and proxy.
+#
+repositories:
+  - bluebanquise
+  - os
+
+# Additional repositories can be added to the external.yml configuration files
+# to logically segregate internal and external repositories in the inventory.
+#
+# external_repositories:
+#   - name: epel
+#     baseurl: 'https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/'
+#     proxy: 'https://proxy:8080'
+
 # Disable the CentOS repositories enabled by default after the installation of
 # the OS. (boolean)
 disable_distro_repositories: False

--- a/roles/core/repositories_client/defaults/main.yml
+++ b/roles/core/repositories_client/defaults/main.yml
@@ -1,0 +1,3 @@
+# Disable the CentOS repositories enabled by default after the installation of
+# the OS. (boolean)
+disable_distro_repositories: False

--- a/roles/core/repositories_client/tasks/centos_7.yml
+++ b/roles/core/repositories_client/tasks/centos_7.yml
@@ -1,5 +1,7 @@
 ---
 
+- include_tasks: deprecation.yml
+
 - name: Disable CentOS-Base distro repositories
   ini_file:
     path: "/etc/yum.repos.d/CentOS-Base.repo"
@@ -8,7 +10,7 @@
     value: '0'
     no_extra_spaces: yes
   loop: [ 'base', 'updates', 'extras' ]
-  when: remove_distro_repositories is defined and remove_distro_repositories
+  when: disable_distro_repositories
   notify: yum-clean-metadata
 
 - name: Set baseurl prefix

--- a/roles/core/repositories_client/tasks/centos_8.yml
+++ b/roles/core/repositories_client/tasks/centos_8.yml
@@ -1,5 +1,7 @@
 ---
 
+- include_tasks: deprecation.yml
+
 - name: Disable CentOS distro repositories
   ini_file:
     path: "/etc/yum.repos.d/{{ item.file }}.repo"
@@ -11,7 +13,7 @@
     - { file: CentOS-AppStream, section: AppStream }
     - { file: CentOS-Base, section: BaseOS }
     - { file: CentOS-Extras, section: extras }
-  when: remove_distro_repositories is defined and remove_distro_repositories
+  when: disable_distro_repositories
   notify: yum-clean-metadata
 
 - name: Set baseurl prefix

--- a/roles/core/repositories_client/tasks/deprecation.yml
+++ b/roles/core/repositories_client/tasks/deprecation.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Deprecate remove_distro_repositories - Warning
+  fail:
+    msg: "Variable `remove_distro_repositories` is deprecated and will be
+ removed in a future release. Use `disable_distro_repositories` instead."
+  when: remove_distro_repositories is defined
+  ignore_errors: True
+
+- name: Deprecate remove_distro_repositories - Backward compatibility
+  set_fact:
+    disable_distro_repositories: remove_distro_repositories
+  when: remove_distro_repositories is defined


### PR DESCRIPTION
Set a default value in the role `repositories_client` for parameters `repositories` and `disable_distro_repositories`.

Rename parameter `remove_distro_repositories` to `disable_distro_repositories` because the purpose of this parameter is to disable the repositories, not to remove them.

Add a (dirty) deprecation warning (fail+ignore_errors) to inform users.