### PR TITLE
Molecule test for display tunning and dns client

### DIFF
--- a/roles/core/display_tuning/.yamllint
+++ b/roles/core/display_tuning/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/core/display_tuning/molecule/default/INSTALL.rst
+++ b/roles/core/display_tuning/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/roles/core/display_tuning/molecule/default/converge.yml
+++ b/roles/core/display_tuning/molecule/default/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
 
   vars:
-    j2_current_iceberg_number: 0
+    j2_current_iceberg_number: 1
 
   tasks:
     - name: "Include display_tuning"

--- a/roles/core/display_tuning/molecule/default/converge.yml
+++ b/roles/core/display_tuning/molecule/default/converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge
+  hosts: all
+
+  vars:
+    j2_current_iceberg_number: 0
+
+  tasks:
+    - name: "Include display_tuning"
+      include_role:
+        name: "display_tuning"

--- a/roles/core/display_tuning/molecule/default/molecule.yml
+++ b/roles/core/display_tuning/molecule/default/molecule.yml
@@ -1,0 +1,35 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:  |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubi8}-ansible:latest"
+    command: "/lib/systemd/systemd"
+    capabilities:
+      - "SYS_ADMIN"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+scenario:
+  name: default
+  test_sequence:
+    - lint
+    - destroy
+    #- dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - verify

--- a/roles/core/display_tuning/molecule/default/molecule.yml
+++ b/roles/core/display_tuning/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint:  |
   flake8
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubi8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"

--- a/roles/core/display_tuning/molecule/default/prepare.yml
+++ b/roles/core/display_tuning/molecule/default/prepare.yml
@@ -1,0 +1,14 @@
+---
+- name: Prepare
+  hosts: all
+
+  tasks:
+    - name: "update cache apt"
+      apt: update_cache=yes
+      when: ansible_os_family == "Debian"
+
+    - name: "update cache yum"
+      yum:
+        name: '*'
+        state: latest
+      when: ansible_os_family == "RedHat"

--- a/roles/core/display_tuning/molecule/default/prepare.yml
+++ b/roles/core/display_tuning/molecule/default/prepare.yml
@@ -6,9 +6,3 @@
     - name: "update cache apt"
       apt: update_cache=yes
       when: ansible_os_family == "Debian"
-
-    - name: "update cache yum"
-      yum:
-        name: '*'
-        state: latest
-      when: ansible_os_family == "RedHat"

--- a/roles/core/display_tuning/molecule/default/verify.yml
+++ b/roles/core/display_tuning/molecule/default/verify.yml
@@ -1,6 +1,4 @@
 ---
-# This is an example playbook to execute Ansible tests.
-
 - name: Verify
   hosts: all
   tasks:

--- a/roles/core/display_tuning/molecule/default/verify.yml
+++ b/roles/core/display_tuning/molecule/default/verify.yml
@@ -1,0 +1,20 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Check that files exists
+    stat:
+      path: "{{ item }}"
+    register: stat_results
+    with_items:
+      - /usr/bin/free_root_disk
+      - /root/.screenrc
+      - /root/.vimrc
+      - /root/.bashrc
+
+  - name: assert files exist
+    assert:
+      that: "{{ item }}.stat.exists"
+    loop: "{{ stat_results.results }}"

--- a/roles/core/display_tuning/tasks/main.yml
+++ b/roles/core/display_tuning/tasks/main.yml
@@ -20,4 +20,3 @@
     src: vimrc
     dest: /root/.vimrc
     mode: 0644
-

--- a/roles/core/dns_client/.yamllint
+++ b/roles/core/dns_client/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/core/dns_client/molecule/default/INSTALL.rst
+++ b/roles/core/dns_client/molecule/default/INSTALL.rst
@@ -1,0 +1,24 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'
+
+Important: this role cannot be tested correctly since it touches the /etc/resolv.conf which is not possible in a docker image.

--- a/roles/core/dns_client/molecule/default/converge.yml
+++ b/roles/core/dns_client/molecule/default/converge.yml
@@ -1,0 +1,16 @@
+---
+- name: Converge
+  hosts: all
+
+  vars:
+    domain_name: .localhost
+    j2_node_main_network: en0
+    networks:
+      en0:
+        services_ip:
+          dns_ip: 127.0.0.1
+
+  tasks:
+    - name: "Include dns_client"
+      include_role:
+        name: "dns_client"

--- a/roles/core/dns_client/molecule/default/molecule.yml
+++ b/roles/core/dns_client/molecule/default/molecule.yml
@@ -1,0 +1,35 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:  |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubi8}-ansible:latest"
+    command: "/lib/systemd/systemd"
+    capabilities:
+      - "SYS_ADMIN"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+scenario:
+  name: default
+  test_sequence:
+    - lint
+    - destroy
+    # - dependency
+    # - syntax
+    # - create
+    # - prepare
+    # - converge
+    # - verify

--- a/roles/core/dns_client/molecule/default/molecule.yml
+++ b/roles/core/dns_client/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint:  |
   flake8
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubi8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"
@@ -28,8 +28,8 @@ scenario:
     - lint
     - destroy
     # - dependency
-    # - syntax
-    # - create
-    # - prepare
-    # - converge
-    # - verify
+    - syntax
+    - create
+    - prepare
+    - converge
+    - verify

--- a/roles/core/dns_client/molecule/default/prepare.yml
+++ b/roles/core/dns_client/molecule/default/prepare.yml
@@ -3,6 +3,11 @@
   hosts: all
 
   tasks:
+    - name: "Umount Docker's /etc/resolv.conf"
+      mount:
+        path: /etc/resolv.conf
+        state: unmounted
+
     - name: "update cache apt"
       apt: update_cache=yes
       when: ansible_facts.os_family == "Debian"

--- a/roles/core/dns_client/molecule/default/verify.yml
+++ b/roles/core/dns_client/molecule/default/verify.yml
@@ -1,0 +1,15 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Check that files exists
+      stat:
+        path: "{{ item }}"
+      register: stat_results
+      with_items:
+        - /etc/resolv.conf
+
+    - name: assert files exist
+      assert:
+        that: "{{ item }}.stat.exists"
+      loop: "{{ stat_results.results }}"

--- a/roles/core/dns_client/vars/main.yml
+++ b/roles/core/dns_client/vars/main.yml
@@ -1,1 +1,2 @@
+---
 role_version: 1.0.2


### PR DESCRIPTION
- Added molecule test in display_tuning.
- Added molecule test in dns_client - warning the testing is limited to linters since /etc/resolv.conf cannot be touched within a container.