### PR TITLE
fix: rename param used to disable the distro repos

### DIFF
--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/repositories.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/repositories.yml
@@ -2,4 +2,4 @@ repositories:
   - bluebanquise
   - os
 
-remove_distro_repositories: True
+disable_distro_repositories: True

--- a/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/repositories.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/repositories.yml
@@ -2,4 +2,4 @@ repositories:
   - bluebanquise
   - os
 
-remove_distro_repositories: True
+disable_distro_repositories: True

--- a/roles/core/repositories_client/tasks/centos_7.yml
+++ b/roles/core/repositories_client/tasks/centos_7.yml
@@ -1,5 +1,7 @@
 ---
 
+- include_tasks: deprecation.yml
+
 - name: Disable CentOS-Base distro repositories
   ini_file:
     path: "/etc/yum.repos.d/CentOS-Base.repo"
@@ -8,7 +10,7 @@
     value: '0'
     no_extra_spaces: yes
   loop: [ 'base', 'updates', 'extras' ]
-  when: remove_distro_repositories is defined and remove_distro_repositories
+  when: disable_distro_repositories is defined and disable_distro_repositories
   notify: yum-clean-metadata
 
 - name: Set baseurl prefix

--- a/roles/core/repositories_client/tasks/centos_8.yml
+++ b/roles/core/repositories_client/tasks/centos_8.yml
@@ -1,5 +1,7 @@
 ---
 
+- include_tasks: deprecation.yml
+
 - name: Disable CentOS distro repositories
   ini_file:
     path: "/etc/yum.repos.d/{{ item.file }}.repo"
@@ -11,7 +13,7 @@
     - { file: CentOS-AppStream, section: AppStream }
     - { file: CentOS-Base, section: BaseOS }
     - { file: CentOS-Extras, section: extras }
-  when: remove_distro_repositories is defined and remove_distro_repositories
+  when: disable_distro_repositories is defined and disable_distro_repositories
   notify: yum-clean-metadata
 
 - name: Set baseurl prefix

--- a/roles/core/repositories_client/tasks/deprecation.yml
+++ b/roles/core/repositories_client/tasks/deprecation.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Deprecate remove_distro_repositories - Warning
+  fail:
+    msg: "Variable `remove_distro_repositories` is deprecated and will be
+ removed in a future release. Use `disable_distro_repositories` instead."
+  when: remove_distro_repositories is defined
+  ignore_errors: True
+
+- name: Deprecate remove_distro_repositories - Backward compatibility
+  set_fact:
+    disable_distro_repositories: remove_distro_repositories
+  when: remove_distro_repositories is defined


### PR DESCRIPTION
Rename parameter `remove_distro_repositories` to
`disable_distro_repositories` because the purpose of this parameter is
to disable the repositories, not to remove them.

Add a (dirty) deprecation warning (fail+ignore_errors) to inform users.