### PR TITLE
fix: create variable execpath for conman.conf.j2

### DIFF
--- a/roles/core/conman/tasks/main.yml
+++ b/roles/core/conman/tasks/main.yml
@@ -1,4 +1,24 @@
 ---
+- name: Gathering OS specific variables
+  # This task gathers variables defined in OS specific files.
+  #
+  # Search vars in:
+  #  - <distribution>_<major>.yml    # eg. CentOS_8.yml
+  #  - <os_family>_<major>.yml       # eg. RedHat_8.yml
+  #  - <distribution>.yml            # eg. CentOS.yml
+  #  - <os_family>.yml               # eg. RedHat.yml
+  #
+  # If no OS specific file is found, the role will default to vars/main.yml
+  #
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "vars/{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_major_version }}.yml"
+        - "vars/{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version }}.yml"
+        - "vars/{{ ansible_facts.distribution | replace(' ','_') }}.yml"
+        - "vars/{{ ansible_facts.os_family }}.yml"
+      skip: True
+
 - name: Install conman and ipmitool
   package:
     name:

--- a/roles/core/conman/templates/conman.conf.j2
+++ b/roles/core/conman/templates/conman.conf.j2
@@ -1,11 +1,7 @@
 #### Blue Banquise file ####
 ## {{ansible_managed}}
 
-{% if (equipment_profile['operating_system']['distribution'] | lower) in ['redhat', 'centos'] and equipment_profile['operating_system']['distribution_major_version'] < 8 %}
-SERVER execpath="/usr/share/conman/exec"
-{% else %}
-SERVER execpath="/usr/lib/conman/exec"
-{% endif %}
+SERVER execpath="{{ execpath }}"
 SERVER syslog="daemon"
 SERVER logdir="/var/log/conman"
 GLOBAL log="/var/log/conman/%N.log"

--- a/roles/core/conman/vars/RedHat_7.yml
+++ b/roles/core/conman/vars/RedHat_7.yml
@@ -1,0 +1,1 @@
+execpath: "/usr/share/conman/exec"

--- a/roles/core/conman/vars/main.yml
+++ b/roles/core/conman/vars/main.yml
@@ -1,1 +1,2 @@
 role_version: 1.0.2
+execpath: "/usr/lib/conman/exec"


### PR DESCRIPTION
Alternative to #172 
Check OS info from facts instead of inventory

Create a new variables `execpath` and get its value from the vars/
directory using `with_first_found`.

Search vars in:
 - `<distribution>_<major>.yml`    # eg. CentOS_8.yml
 - `<os_family>_<major>.yml`       # eg. RedHat_8.yml
 - `<distribution>.yml`            # eg. CentOS.yml
 - `<os_family>.yml`               # eg. RedHat.yml
