### PR TITLE
fix: disable CentOS default repositories

### DIFF
--- a/roles/core/repositories_client/readme.rst
+++ b/roles/core/repositories_client/readme.rst
@@ -6,15 +6,56 @@ Description
 
 This role simply configure repositories for client hosts.
 
+CentOS
+""""""
+
+Since the content of the ISO DVD is copied in the os/ directory of the
+repository server, this role disable CentOS default repositories.
+
+For CentOS 7, all repositories *base*, *updates* and *extras* are disabled and
+replaced by the *os* repo.
+
+For CentOS 8, instead of disabling the default OS repositories *BaseOS* and
+*AppStream*, the role will update the repo configuration to use paths
+*.../os/BaseOS/* and *.../os/AppStream/*. The role still disables the *Extras*
+repository which is enabled by default but not shipped with the ISO DVD. If one
+need to add the *Extras* repo, it is advised to add it to the inventory like
+any other repository.
+
+.. code-block:: yaml
+
+  repositories:
+    - Extras
+    - bluebanquise
+    - os
+
+There is a use case of people running CentOS 7 with a local clone of the *base*
+repository but still using the online *updates* repository. You can keep this
+behaviour by adding this repo to the external_repositories parameter in your
+inventory. Please consider using the mirror closest to your location.
+
+.. code-block:: yaml
+
+  external_repositories:
+    - name: "CentOS-Updates"
+      baseurl: "http://mirror.centos.org/centos/7/updates/x86_64/"
+      gpgcheck: 1
+      gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
+
+Note that the `update repository does not exist anymore in CentOS 8
+<https://wiki.centos.org/FAQ/CentOS8#I_don.27t_see_the_updates_repo_for_CentOS-8>`_.
+
 Instructions
 ^^^^^^^^^^^^
 
-See repositries_server role instructions for more details.
+See repositories_server role instructions for more details.
 
 To be done
 ^^^^^^^^^^
 
-Need to clear up the Ubuntu repositories process, still not clear how to handle own made repos and officials repos as Ubuntu add local repos everywhere in the sources.list file.
+Need to clear up the Ubuntu repositories process, still not clear how to handle
+own made repos and officials repos as Ubuntu add local repos everywhere in the
+sources.list file.
 
 Changelog
 ^^^^^^^^^

--- a/roles/core/repositories_client/tasks/centos_7.yml
+++ b/roles/core/repositories_client/tasks/centos_7.yml
@@ -1,6 +1,8 @@
 ---
-
 - name: Disable CentOS-Base distro repositories
+  # In BlueBanquise, the CentOS 7 system repository is installed with the
+  # special repository 'os', thus we disable default repositories if 'os' is
+  # configured.
   ini_file:
     path: "/etc/yum.repos.d/CentOS-Base.repo"
     section: "{{ item }}"
@@ -8,7 +10,7 @@
     value: '0'
     no_extra_spaces: yes
   loop: [ 'base', 'updates', 'extras' ]
-  when: remove_distro_repositories is defined and remove_distro_repositories
+  when: ( 'os' in repositories ) or ( item.name is defined and item.name == 'os' )
   notify: yum-clean-metadata
 
 - name: Set baseurl prefix

--- a/roles/core/repositories_client/tasks/centos_8.yml
+++ b/roles/core/repositories_client/tasks/centos_8.yml
@@ -1,17 +1,19 @@
 ---
-
-- name: Disable CentOS distro repositories
+- name: Disable CentOS Extras repository
+  # In BlueBanquise, the CentOS 8 system repositories are installed with the
+  # special repository 'os', which splits to BaseOS and AppStream.
+  # The repository Extras is enabled by default in CentOS but is not shipped
+  # with the ISO DVD, thus we disable it if 'os' is configured.
+  # If you need to configure the Extras repository, consider adding it as you
+  # would add any other repository to the configuration. See the documentation
+  # for details on how to proceed.
   ini_file:
-    path: "/etc/yum.repos.d/{{ item.file }}.repo"
-    section: "{{ item.section }}"
+    path: "/etc/yum.repos.d/CentOS-Extras.repo"
+    section: "extras"
     option: enabled
     value: '0'
     no_extra_spaces: yes
-  with_items:
-    - { file: CentOS-AppStream, section: AppStream }
-    - { file: CentOS-Base, section: BaseOS }
-    - { file: CentOS-Extras, section: extras }
-  when: remove_distro_repositories is defined and remove_distro_repositories
+  when: ( 'os' in repositories ) or ( item.name is defined and item.name == 'os' )
   notify: yum-clean-metadata
 
 - name: Set baseurl prefix
@@ -30,14 +32,27 @@
   with_items: "{{ repositories | union(external_repositories|default([])) }}"
   when: ( item != 'os' ) and ( item.name is not defined or item.name != 'os' )
 
-- name: "Setting repositories os ({{ item.1 }})"
+- name: "Setting OS repositories"
+  # CentOS configure BaseOS in /etc/yum.repos.d/CentOS-Base.repo and AppStream
+  # in /etc/yum.repos.d/Centos-AppStream.repo. These are the operating system
+  # repositories, thus installed with the special repository 'os' in
+  # BlueBanquise.
   yum_repository:
-    name: "{{ item.1 }}"
-    description: "{{ item.1 }} gen by Ansible"
-    baseurl: "{{ item.0.baseurl | default(baseurl_prefix + 'os/' + item.1) }}"
-    enabled: "{{ item.0.enabled | default(1) }}"
-    gpgcheck: "{{ item.0.gpgcheck | default(0) }}"
-    gpgkey: "{{ item.0.gpgkey | default(omit) }}"
-    proxy: "{{ item.0.proxy | default(omit) }}"
-  loop: "{{ repositories | product(['AppStream', 'BaseOS']) | list }}"
-  when: ( item.0 == 'os' ) or ( item.0.name is defined and item.0.name == 'os' )
+    name: "{{ item.repoid }}"
+    description: "{{ item.repoid }} gen by Ansible"
+    baseurl: "{{ item.baseurl | default(baseurl_prefix + 'os/' + item.repoid) }}"
+    file: "{{ item.file }}"
+    enabled: "{{ item.enabled | default(1) }}"
+    gpgcheck: "{{ item.gpgcheck | default(0) }}"
+    gpgkey: "{{ item.gpgkey | default(omit) }}"
+    proxy: "{{ item.proxy | default(omit) }}"
+  loop:
+  # Combine BaseOS and AppStream with 'os' parameters if any. Otherwise, this
+  # will configure BaseOS and AppStream with default values.
+    - "{{ repositories|selectattr('name', 'defined')
+          |selectattr('name', 'match', 'os')|list
+          |combine({'file':'CentOS-Base','repoid':'BaseOS'}) }}"
+    - "{{ repositories|selectattr('name', 'defined')
+          |selectattr('name', 'match', 'os')|list
+          |combine({'file':'CentOS-AppStream','repoid':'AppStream'}) }}"
+  when: ( 'os' in repositories ) or ( item.name is defined and item.name == 'os' )

--- a/roles/core/repositories_client/tasks/redhat_8.yml
+++ b/roles/core/repositories_client/tasks/redhat_8.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Set baseurl prefix
   set_fact:
     baseurl_prefix: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/{{ equipment_profile['operating_system']['distribution'] }}/{{ equipment_profile['operating_system']['distribution_version'] }}/{{ equipment_profile['hardware']['cpu']['architecture'] }}/"
@@ -16,14 +15,22 @@
   with_items: "{{ repositories | union(external_repositories|default([])) }}"
   when: ( item != 'os' ) and ( item.name is not defined or item.name != 'os' )
 
-- name: "Setting repositories os ({{ item.1 }})"
+- name: "Setting OS repositories"
   yum_repository:
-    name: "{{ item.1 }}"
-    description: "{{ item.1 }} gen by Ansible"
-    baseurl: "{{ item.0.baseurl | default(baseurl_prefix + 'os/' + item.1) }}"
-    enabled: "{{ item.0.enabled | default(1) }}"
-    gpgcheck: "{{ item.0.gpgcheck | default(0) }}"
-    gpgkey: "{{ item.0.gpgkey | default(omit) }}"
-    proxy: "{{ item.0.proxy | default(omit) }}"
-  loop: "{{ repositories | product(['AppStream', 'BaseOS']) | list }}"
-  when: ( item.0 == 'os' ) or ( item.0.name is defined and item.0.name == 'os' )
+    name: "{{ item.repoid }}"
+    description: "{{ item.repoid }} gen by Ansible"
+    baseurl: "{{ item.baseurl | default(baseurl_prefix + 'os/' + item.repoid) }}"
+    enabled: "{{ item.enabled | default(1) }}"
+    gpgcheck: "{{ item.gpgcheck | default(0) }}"
+    gpgkey: "{{ item.gpgkey | default(omit) }}"
+    proxy: "{{ item.proxy | default(omit) }}"
+  loop:
+  # Combine BaseOS and AppStream with 'os' parameters if any. Otherwise, this
+  # will configure BaseOS and AppStream with default values.
+    - "{{ repositories|selectattr('name', 'defined')
+          |selectattr('name', 'match', 'os')|list
+          |combine({'repoid':'BaseOS'}) }}"
+    - "{{ repositories|selectattr('name', 'defined')
+          |selectattr('name', 'match', 'os')|list
+          |combine({'repoid':'AppStream'}) }}"
+  when: ( 'os' in repositories ) or ( item.name is defined and item.name == 'os' )


### PR DESCRIPTION
This is a rework of 37b824c.

Centos 7:
Disable default repositories since the content of the ISO DVD is copied
in the os/ directory.

CentOS 8:
Instead of disabling the default OS repositories then configure new ones
in different files, use yum_repository parameter `file` to replace
existing configuration for BaseOS and AppStream.
Disable the Extras repository which is enabled by default but not
shipped with the ISO DVD. If one need to add the Extras repo, I would
recommend to add it to the inventory like any other repository.

Remove the now useless tunable `remove_distro_repositories`.

This commit also changes the logic to split `os` to `BaseOS` and
`AppStream` for CentOS/RHEL 8.