### PR TITLE
fix: improve DNS forward and reverse templates (#158)

### DIFF
--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/external.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/external.yml
@@ -14,7 +14,7 @@ external_dns:
   dns_client: # set directly on client side in resolv.conf
     - 208.67.220.220
 
-# Hosts defined here will be automatically added into /etc/hosts and into DNS configuration
+# Hosts defined here will be automatically added into /etc/hosts
 external_hosts:
   sphenisc.com: 213.186.33.3
 

--- a/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/external.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/external.yml
@@ -13,7 +13,7 @@ external_dns:
   dns_client: # set directly on client side in resolv.conf
     - 208.67.220.220
 
-# Hosts defined here will be automatically added into /etc/hosts and into DNS configuration
+# Hosts defined here will be automatically added into /etc/hosts
 external_hosts:
   sphenisc.com: 213.186.33.3
 

--- a/roles/core/dns_server/templates/forward.j2
+++ b/roles/core/dns_server/templates/forward.j2
@@ -2,6 +2,7 @@
 ;## {{ansible_managed}}
 
 $TTL 86400
+$ORIGIN {{domain_name}}.
 @ IN SOA  {{inventory_hostname}}.{{domain_name}}. root.{{domain_name}}. (
   2011071001  ;Serial
   3600        ;Refresh
@@ -10,9 +11,6 @@ $TTL 86400
   86400       ;Minimum TTL
 )
 @ IN NS {{inventory_hostname}}.{{domain_name}}.
-@ IN A {{network_interfaces[j2_node_main_network_interface]['ip4']}}
-
-{{inventory_hostname}} IN A {{network_interfaces[j2_node_main_network_interface]['ip4']}}
 
 {% for host in groups['all'] %}
 {% if hostvars[host]['network_interfaces'] is defined and not none %}
@@ -43,11 +41,3 @@ $TTL 86400
 {% endif %}
 {% endif %}
 {% endfor %}
-
-;## External hosts
-
-{% if external_hosts is defined and external_hosts is not none and external_hosts %}
-{% for host in external_hosts %}
-{{host}} IN A {{external_hosts[host]}}
-{% endfor %}
-{% endif %}

--- a/roles/core/dns_server/templates/reverse.j2
+++ b/roles/core/dns_server/templates/reverse.j2
@@ -2,6 +2,7 @@
 ;## {{ansible_managed}}
 
 $TTL 86400
+$ORIGIN in-addr.arpa.
 @ IN SOA  {{inventory_hostname}}.{{domain_name}}. root.{{domain_name}}. (
   2011071001  ;Serial
   3600        ;Refresh
@@ -10,7 +11,6 @@ $TTL 86400
   86400       ;Minimum TTL
 )
 @ IN NS {{inventory_hostname}}.{{domain_name}}.
-@ IN PTR {{domain_name}}.
 
 {% for host in groups['all'] %}
 {% if hostvars[host]['network_interfaces'] is defined and not none %}
@@ -36,12 +36,3 @@ $TTL 86400
 {% endif %}
 {% endif %}
 {% endfor %}
-
-;## External hosts
-
-{% if external_hosts is defined and external_hosts is not none and external_hosts %}
-{% for host in external_hosts %}
-{{external_hosts[host].split('.')[3]}}.{{external_hosts[host].split('.')[2]}}.{{external_hosts[host].split('.')[1]}}.{{external_hosts[host].split('.')[0]}} IN PTR {{host}}.
-{% endfor %}
-{% endif %}
-


### PR DESCRIPTION
Fixes several caveats with the zone templates:

 - Add $ORIGIN
 - Remove useless Address record for the domain
 - Remove inventory_hostname defined twice (explicitly + in the loop)
 - Remove external_hosts, cannot be defined in the zone

Closes: #146
(cherry picked from commit 1c1ea2d7970afcdd0f6cdfbd3ce22fadcfd99cab)