### PR TITLE
fix: correct loop in dns_server handlers

### DIFF
--- a/roles/core/dns_server/handlers/main.yml
+++ b/roles/core/dns_server/handlers/main.yml
@@ -3,7 +3,7 @@
   service:
     name: "{{ item }}"
     state: restarted
-  loop: "{{ services_to_start[(ansible_distribution|lower|replace(' ','_'))]['_'+ansible_distribution_major_version] }}"
+  loop: "{{ services_to_start }}"
   when:
     - "'service' not in ansible_skip_tags"
     - (start_services | bool)

--- a/roles/core/dns_server/tasks/main.yml
+++ b/roles/core/dns_server/tasks/main.yml
@@ -17,7 +17,7 @@
         - "vars/{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version }}.yml"
         - "vars/{{ ansible_facts.distribution | replace(' ','_') }}.yml"
         - "vars/{{ ansible_facts.os_family }}.yml"
-      skip: True
+      skip: true
 
 - name: Install packages
   package:


### PR DESCRIPTION
Fix a bug introduced in ea0f6b7f, I forgot the file handlers/main.yml.

Also update `skip: true` to remove a warning reported by ansible-lint.