### PR TITLE
feat: default to major distro for pxe boot images

### DIFF
--- a/resources/documentation/install_first_management.rst
+++ b/resources/documentation/install_first_management.rst
@@ -46,21 +46,8 @@ Boot images include the installer system which starts the deployment after PXE
 boot, while packages repositories include the software that will be installed
 on the systems.
 
-Boot images repositories structure follows a specific pattern and includes the
-minor release version in the path:
-
-.. code-block:: bash
-
-                  Distribution    Version   Architecture    Repository
-                        +             +       +               +
-                        |             +--+    |               |
-                        +-----------+    |    |    +----------+
-                                    |    |    |    |
-                                    v    v    v    v
-       /var/www/html/repositories/centos/7.6/x86_64/os/
-
-Packages repositories structure follows a specific pattern, which defaults to
-the major release version in the path:
+Boot images and packages repositories structure follows a specific pattern,
+which defaults to the major release version in the path:
 
 .. code-block:: bash
 
@@ -89,15 +76,15 @@ Download:
 
 **If on standard system:**
 
-Mount iso and copy content to web server directory: (replace centos/7.6 by
-centos/8.0, redhat/8.0, redhat/7.7, etc depending of your system)
+Mount iso and copy content to web server directory: (replace centos/7 by
+centos/8, redhat/8, redhat/7, etc depending of your system)
 
 .. code-block:: bash
 
-  mkdir -p /var/www/html/repositories/centos/7.6/x86_64/os/
+  mkdir -p /var/www/html/repositories/centos/7/x86_64/os/
   mount CentOS-7-x86_64-Everything-1810.iso /mnt
-  cp -a /mnt/* /var/www/html/repositories/centos/7.6/x86_64/os/
-  restorecon -Rv /var/www/html/repositories/centos/7.6/x86_64/os
+  cp -a /mnt/* /var/www/html/repositories/centos/7/x86_64/os/
+  restorecon -Rv /var/www/html/repositories/centos/7/x86_64/os
 
 **If in test VM:**
 
@@ -105,20 +92,12 @@ Simply mount iso from /dev/cdrom to save space:
 
 .. code-block:: bash
 
-  mkdir -p /var/www/html/repositories/centos/7.6/x86_64/os/
-  mount /dev/cdrom /var/www/html/repositories/centos/7.6/x86_64/os/
+  mkdir -p /var/www/html/repositories/centos/7/x86_64/os/
+  mount /dev/cdrom /var/www/html/repositories/centos/7/x86_64/os/
 
 Now, create first repository manually. Procedure is different between Centos 7 and 8.
 
 **Centos/RHEL 7:**
-
-Copy the packages to the web server directory.
-
-.. code-block:: bash
-
-  mkdir -p /var/www/html/repositories/centos/7/x86_64/os/
-  cp -a /mnt/{Packages,repodata} /var/www/html/repositories/centos/7/x86_64/os/
-  restorecon -Rv /var/www/html/repositories/centos/7/x86_64/os/
 
 Create file */etc/yum.repos.d/os.repo* with the following content:
 
@@ -131,14 +110,6 @@ Create file */etc/yum.repos.d/os.repo* with the following content:
   enabled=1
 
 **Centos/RHEL 8:**
-
-Copy the packages to the web server directory.
-
-.. code-block:: bash
-
-  mkdir -p /var/www/html/repositories/centos/8/x86_64/os/
-  cp -a /mnt/{BaseOS,AppStream} /var/www/html/repositories/centos/8/x86_64/os/
-  restorecon -Rv /var/www/html/repositories/centos/8/x86_64/os/
 
 Create file */etc/yum.repos.d/BaseOS.repo* with the following content:
 

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/all_equipments/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/all_equipments/equipment_profile.yml
@@ -23,7 +23,8 @@ equipment_profile:
   operating_system:
     distribution: centos # centos, redhat, debian, ubuntu, opensuse, etc.
     distribution_major_version: 8
-    distribution_version: 8.0
+    # Define a minor distribution version to use for pxe_stack
+    #distribution_version: 8.0
     # Overwrite the default $releasever on the target
     #repositories_releasever: "8.0"
 

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_sandy_SMP/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_sandy_SMP/equipment_profile.yml
@@ -14,7 +14,6 @@ equipment_profile:
   operating_system:
     distribution: centos
     distribution_major_version: 8
-    distribution_version: 8.0
 
   equipment_type: server
 

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_sandy_compute/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_sandy_compute/equipment_profile.yml
@@ -9,7 +9,6 @@ equipment_profile:
   operating_system:
     distribution: centos
     distribution_major_version: 8
-    distribution_version: 8.0
 
   equipment_type: server
 

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_sandy_login/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_sandy_login/equipment_profile.yml
@@ -9,7 +9,6 @@ equipment_profile:
   operating_system:
     distribution: centos
     distribution_major_version: 8
-    distribution_version: 8.0
 
   equipment_type: server
 

--- a/resources/examples/simple_cluster/inventory/group_vars/all/all_equipments/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/all_equipments/equipment_profile.yml
@@ -23,7 +23,8 @@ equipment_profile:
   operating_system:
     distribution: centos # centos, redhat, debian, ubuntu, opensuse, etc.
     distribution_major_version: 8
-    distribution_version: 8.0
+    # Define a minor distribution version to use for pxe_stack
+    #distribution_version: 8.0
     # Overwrite the default $releasever on the target
     #repositories_releasever: "8.0"
 

--- a/resources/examples/simple_cluster/inventory/group_vars/equipment_typeC/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/equipment_typeC/equipment_profile.yml
@@ -9,7 +9,6 @@ equipment_profile:
   operating_system:
     distribution: centos
     distribution_major_version: 7
-    distribution_version: 7.6
 
   equipment_type: server
 

--- a/resources/examples/simple_cluster/inventory/group_vars/equipment_typeL/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/equipment_typeL/equipment_profile.yml
@@ -9,7 +9,6 @@ equipment_profile:
   operating_system:
     distribution: centos
     distribution_major_version: 7
-    distribution_version: 7.6
 
   equipment_type: server
 

--- a/resources/examples/simple_cluster/inventory/group_vars/equipment_typeM/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/equipment_typeM/equipment_profile.yml
@@ -12,7 +12,6 @@ equipment_profile:
   operating_system:
     distribution: centos
     distribution_major_version: 7
-    distribution_version: 7.6
 
   equipment_type: server
 

--- a/roles/core/pxe_stack/readme.rst
+++ b/roles/core/pxe_stack/readme.rst
@@ -4,14 +4,18 @@ PXE Stack
 Description
 ^^^^^^^^^^^
 
-This role provides the whole PXE stack. It is a key feature of the stack (and we are prood of it :-D).
+This role provides the whole PXE stack. It is a key feature of the stack (and
+we are proud of it :-D).
 
 Instructions
 ^^^^^^^^^^^^
 
-This role will deploy all the needed files, binaries, and scripts to deploy remote hosts using PXE (or even USB and CD boot).
+This role will deploy all the needed files, binaries, and scripts to deploy
+remote hosts using PXE (or even USB and CD boot).
 
-The role take place just after the dhcp in the PXE deployment, and will configure all the iPXE chain needed after dhcp provided hosts with next-server ip and filename to use.
+The role takes place just after the dhcp in the PXE deployment, and will
+configure all the iPXE chain needed after dhcp provided hosts with next-server
+ip address and filename to use.
 
 **Files location**
 """"""""""""""""""
@@ -31,9 +35,14 @@ The role take place just after the dhcp in the PXE deployment, and will configur
 
 This role will rely on multiple parts of the inventory, and is probably the most "invasive" role of the whole stack.
 
-* equipment_profile dictionarries are used for each equipment_profile group. All boot confiuration is made relying on it (operating system, cpu architecture, console, kernel parameters, etc.). It is recommanded to ensure coherency of the equipment_profile files.
-* authentication dictionarry is used to provide root password and default ssh authorized key.
-* hosts **network_interfaces** dedicated variables, to be able to force static ip at kernel boot.
+* equipment_profile dictionaries are used for each equipment_profile group. All
+  boot configuration is made relying on it (operating system, cpu architecture,
+  console, kernel parameters, etc.). It is recommanded to ensure coherency of
+  the equipment_profile files.
+* authentication dictionary is used to provide root password and default ssh
+  authorized key.
+* hosts **network_interfaces** dedicated variables, to be able to force static
+  ip address at kernel boot.
 
 **bootset usage**
 """""""""""""""""
@@ -147,6 +156,7 @@ To be done
 Changelog
 ^^^^^^^^^
 
+* 1.1.2: Add support of major distribution version. Bruno <devel@travouillon.fr>
 * 1.1.1: bootset.py refactoring. Adrien Ribeiro <adrien.ribeiro@atos.net>
 * 1.1.0: Rewamped the whole role. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.2: Add Ubuntu 18.04 compatibility. johnnykeats <johnny.keats@outlook.com>

--- a/roles/core/pxe_stack/templates/equipment_profile.ipxe.j2
+++ b/roles/core/pxe_stack/templates/equipment_profile.ipxe.j2
@@ -11,7 +11,7 @@ set eq-equipment-profile {{item | replace('equipment_','') | trim}}
 set eq-architecture {{hostvars[groups[item][0]]['equipment_profile']['hardware']['cpu']['architecture']}}
 set eq-distribution {{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']|lower}}
 set eq-distribution-major-version {{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution_major_version']}}
-set eq-distribution-version {{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution_version']}}
+set eq-distribution-version {{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution_version'] | default('${eq-distribution-major-version}')}}
 set eq-console {{hostvars[groups[item][0]]['equipment_profile']['console']}}
 set eq-kernel-parameters {{hostvars[groups[item][0]]['equipment_profile']['kernel_parameters']}}
 set eq-repositories-releasever {{hostvars[groups[item][0]]['equipment_profile']['operating_system']['repositories_releasever'] | default('${eq-distribution-major-version}')}}

--- a/roles/core/pxe_stack/vars/main.yml
+++ b/roles/core/pxe_stack/vars/main.yml
@@ -1,4 +1,4 @@
-role_version: 1.1.0
+role_version: 1.1.2
 
 supported_os:
   centos:


### PR DESCRIPTION
Make equipment_profile.operating_system.distribution_version optional.
If not defined, the pxe_stack role will default to the value of
distribution_major_version to set the images-root path.