### PR TITLE
feat: add optional param repositories_environment

### DIFF
--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/all_equipments/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/all_equipments/equipment_profile.yml
@@ -26,7 +26,9 @@ equipment_profile:
     # Define a minor distribution version to use for pxe_stack
     #distribution_version: 8.0
     # Overwrite the default $releasever on the target
-    #repositories_releasever: "8.0"
+    #repositories_releasever: 8.0
+    # Add the $environment in the repositories path (eg. production, staging)
+    #repositories_environment: production
 
   equipment_type: none  # If server, a pxe profile will be generated
 

--- a/resources/examples/simple_cluster/inventory/group_vars/all/all_equipments/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/all_equipments/equipment_profile.yml
@@ -26,7 +26,9 @@ equipment_profile:
     # Define a minor distribution version to use for pxe_stack
     #distribution_version: 8.0
     # Overwrite the default $releasever on the target
-    #repositories_releasever: "8.0"
+    #repositories_releasever: 8.0
+    # Add the $environment in the repositories path (eg. production, staging)
+    #repositories_environment: production
 
   equipment_type: none  # If server, a pxe profile will be generated
 

--- a/roles/core/pxe_stack/files/osdeploy/centos_7.ipxe
+++ b/roles/core/pxe_stack/files/osdeploy/centos_7.ipxe
@@ -12,8 +12,8 @@ echo | > Operating system target: ${eq-distribution} ${eq-distribution-version} 
 echo | > Console: ${eq-console}
 echo | > Additional kernel parameters: ${eq-kernel-parameters} ${dedicated-kernel-parameters}
 echo | > Deployment server: ${next-server}
-echo | > Target images: repositories/${eq-distribution}/${eq-distribution-version}/${eq-architecture}/
-echo | > Target repos: repositories/${eq-distribution}/${eq-repositories-releasever}/${eq-architecture}/
+echo | > Target images: repositories/${eq-repositories-environment}/${eq-distribution}/${eq-distribution-version}/${eq-architecture}/
+echo | > Target repos: repositories/${eq-repositories-environment}/${eq-distribution}/${eq-repositories-releasever}/${eq-architecture}/
 echo | > Target kickstart: ${eq-equipment-profile}.kickstart.cfg
 echo |
 echo | Loading linux ...

--- a/roles/core/pxe_stack/files/osdeploy/centos_8.ipxe
+++ b/roles/core/pxe_stack/files/osdeploy/centos_8.ipxe
@@ -12,8 +12,8 @@ echo | > Operating system target: ${eq-distribution} ${eq-distribution-version} 
 echo | > Console: ${eq-console}
 echo | > Additional kernel parameters: ${eq-kernel-parameters} ${dedicated-kernel-parameters}
 echo | > Deployment server: ${next-server}
-echo | > Target images: repositories/${eq-distribution}/${eq-distribution-version}/${eq-architecture}/
-echo | > Target repos: repositories/${eq-distribution}/${eq-repositories-releasever}/${eq-architecture}/
+echo | > Target images: repositories/${eq-repositories-environment}/${eq-distribution}/${eq-distribution-version}/${eq-architecture}/
+echo | > Target repos: repositories/${eq-repositories-environment}/${eq-distribution}/${eq-repositories-releasever}/${eq-architecture}/
 echo | > Target kickstart: ${eq-equipment-profile}.kickstart.cfg
 echo |
 echo | Loading linux ...

--- a/roles/core/pxe_stack/files/osdeploy/redhat_7.ipxe
+++ b/roles/core/pxe_stack/files/osdeploy/redhat_7.ipxe
@@ -12,8 +12,8 @@ echo | > Operating system target: ${eq-distribution} ${eq-distribution-version} 
 echo | > Console: ${eq-console}
 echo | > Additional kernel parameters: ${eq-kernel-parameters} ${dedicated-kernel-parameters}
 echo | > Deployment server: ${next-server}
-echo | > Target images: repositories/${eq-distribution}/${eq-distribution-version}/${eq-architecture}/
-echo | > Target repos: repositories/${eq-distribution}/${eq-repositories-releasever}/${eq-architecture}/
+echo | > Target images: repositories/${eq-repositories-environment}/${eq-distribution}/${eq-distribution-version}/${eq-architecture}/
+echo | > Target repos: repositories/${eq-repositories-environment}/${eq-distribution}/${eq-repositories-releasever}/${eq-architecture}/
 echo | > Target kickstart: ${eq-equipment-profile}.kickstart.cfg
 echo |
 echo | Loading linux ...

--- a/roles/core/pxe_stack/files/osdeploy/redhat_8.ipxe
+++ b/roles/core/pxe_stack/files/osdeploy/redhat_8.ipxe
@@ -12,8 +12,8 @@ echo | > Operating system target: ${eq-distribution} ${eq-distribution-version} 
 echo | > Console: ${eq-console}
 echo | > Additional kernel parameters: ${eq-kernel-parameters} ${dedicated-kernel-parameters}
 echo | > Deployment server: ${next-server}
-echo | > Target images: repositories/${eq-distribution}/${eq-distribution-version}/${eq-architecture}/
-echo | > Target repos: repositories/${eq-distribution}/${eq-repositories-releasever}/${eq-architecture}/
+echo | > Target images: repositories/${eq-repositories-environment}/${eq-distribution}/${eq-distribution-version}/${eq-architecture}/
+echo | > Target repos: repositories/${eq-repositories-environment}/${eq-distribution}/${eq-repositories-releasever}/${eq-architecture}/
 echo | > Target kickstart: ${eq-equipment-profile}.kickstart.cfg
 echo |
 echo | Loading linux ...

--- a/roles/core/pxe_stack/templates/equipment_profile.ipxe.j2
+++ b/roles/core/pxe_stack/templates/equipment_profile.ipxe.j2
@@ -15,10 +15,11 @@ set eq-distribution-version {{hostvars[groups[item][0]]['equipment_profile']['op
 set eq-console {{hostvars[groups[item][0]]['equipment_profile']['console']}}
 set eq-kernel-parameters {{hostvars[groups[item][0]]['equipment_profile']['kernel_parameters']}}
 set eq-repositories-releasever {{hostvars[groups[item][0]]['equipment_profile']['operating_system']['repositories_releasever'] | default('${eq-distribution-major-version}')}}
+set eq-repositories-environment {{hostvars[groups[item][0]]['equipment_profile']['operating_system']['repositories_environment'] | default('')}}
 
 # Dynamic variables
-set images-root http://${next-server}/repositories/${eq-distribution}/${eq-distribution-version}/${eq-architecture}/
-set repository-root http://${next-server}/repositories/${eq-distribution}/${eq-repositories-releasever}/${eq-architecture}/
+set images-root http://${next-server}/repositories/${eq-repositories-environment}/${eq-distribution}/${eq-distribution-version}/${eq-architecture}/
+set repository-root http://${next-server}/repositories/${eq-repositories-environment}/${eq-distribution}/${eq-repositories-releasever}/${eq-architecture}/
 set kickstart-path http://${next-server}/preboot_execution_environment/equipment_profiles//${eq-equipment-profile}.kickstart.cfg
 
 echo |

--- a/roles/core/repositories_client/tasks/centos_7.yml
+++ b/roles/core/repositories_client/tasks/centos_7.yml
@@ -15,7 +15,7 @@
 
 - name: Set baseurl prefix
   set_fact:
-    baseurl_prefix: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/{{ equipment_profile['operating_system']['distribution'] }}/$releasever/$basearch/"
+    baseurl_prefix: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/$environment/{{ equipment_profile['operating_system']['distribution'] }}/$releasever/$basearch/"
 
 - name: Force $releasever
   template:
@@ -33,6 +33,16 @@
     path: /etc/yum/vars/releasever
     state: absent
   when: equipment_profile.operating_system.repositories_releasever is not defined
+  tags:
+    - template
+
+- name: Set $environment
+  template:
+    src: environment.j2
+    dest: /etc/yum/vars/environment
+    owner: root
+    group: root
+    mode: 0644
   tags:
     - template
 

--- a/roles/core/repositories_client/tasks/centos_8.yml
+++ b/roles/core/repositories_client/tasks/centos_8.yml
@@ -18,7 +18,7 @@
 
 - name: Set baseurl prefix
   set_fact:
-    baseurl_prefix: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/{{ equipment_profile['operating_system']['distribution'] }}/$releasever/$basearch/"
+    baseurl_prefix: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/$environment/{{ equipment_profile['operating_system']['distribution'] }}/$releasever/$basearch/"
 
 - name: Force $releasever
   template:
@@ -36,6 +36,16 @@
     path: /etc/dnf/vars/releasever
     state: absent
   when: equipment_profile.operating_system.repositories_releasever is not defined
+  tags:
+    - template
+
+- name: Set $environment
+  template:
+    src: environment.j2
+    dest: /etc/yum/vars/environment
+    owner: root
+    group: root
+    mode: 0644
   tags:
     - template
 

--- a/roles/core/repositories_client/tasks/redhat_7.yml
+++ b/roles/core/repositories_client/tasks/redhat_7.yml
@@ -2,7 +2,7 @@
 
 - name: Set baseurl prefix
   set_fact:
-    baseurl_prefix: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/{{ equipment_profile['operating_system']['distribution'] }}/$releasever/$basearch/"
+    baseurl_prefix: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/$environment/{{ equipment_profile['operating_system']['distribution'] }}/$releasever/$basearch/"
 
 - name: Force $releasever
   template:
@@ -20,6 +20,16 @@
     path: /etc/yum/vars/releasever
     state: absent
   when: equipment_profile.operating_system.repositories_releasever is not defined
+  tags:
+    - template
+
+- name: Set $environment
+  template:
+    src: environment.j2
+    dest: /etc/yum/vars/environment
+    owner: root
+    group: root
+    mode: 0644
   tags:
     - template
 

--- a/roles/core/repositories_client/tasks/redhat_8.yml
+++ b/roles/core/repositories_client/tasks/redhat_8.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set baseurl prefix
   set_fact:
-    baseurl_prefix: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/{{ equipment_profile['operating_system']['distribution'] }}/$releasever/$basearch/"
+    baseurl_prefix: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/$environment/{{ equipment_profile['operating_system']['distribution'] }}/$releasever/$basearch/"
 
 - name: Force $releasever
   template:
@@ -19,6 +19,16 @@
     path: /etc/dnf/vars/releasever
     state: absent
   when: equipment_profile.operating_system.repositories_releasever is not defined
+  tags:
+    - template
+
+- name: Set $environment
+  template:
+    src: environment.j2
+    dest: /etc/yum/vars/environment
+    owner: root
+    group: root
+    mode: 0644
   tags:
     - template
 

--- a/roles/core/repositories_client/templates/environment.j2
+++ b/roles/core/repositories_client/templates/environment.j2
@@ -1,0 +1,1 @@
+{{ equipment_profile.operating_system.repositories_environment | default('') }}


### PR DESCRIPTION
For admins who need to manage several environments (prod/staging) for
their repositories, it is now possible to define the new parameter
equipment_profile.operating_system.repositories_environment in the
inventory.

The new url for boot images and packages repositories will be:

.. code-block:: bash

              Environment    Distribution    Version   Architecture    Repository
                    +                 +          +       +               +
                    |                 |          +--+    |               |
                    +--------------+  +--------+    |    |    +----------+
                                   |           |    |    |    |
                                   v           v    v    v    v
       /var/www/html/repositories/production/centos/7/x86_64/os/