### PR TITLE
feat: dns server slaves

### DIFF
--- a/.github/workflows/molecule-actions.yml
+++ b/.github/workflows/molecule-actions.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install 'molecule[docker]>3' ansible-lint flake8 jmespath netaddr
       - name: Run molecule test for ${{ matrix.role }}
         run: |
           cd roles/${{ matrix.role }} && molecule test

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/networks/ice1-1.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/networks/ice1-1.yml
@@ -10,7 +10,9 @@ networks:
     is_in_dns: true
     services_ip:
       pxe_ip: 10.11.0.1
-      dns_ip: 10.11.0.1
+      dns_ip:
+        - 10.11.0.1
+        - 10.11.0.2
       repository_ip: 10.11.0.1
       authentication_ip: 10.11.0.1
       time_ip: 10.11.0.1

--- a/resources/examples/simple_cluster/playbooks/management1.yml
+++ b/resources/examples/simple_cluster/playbooks/management1.yml
@@ -3,6 +3,8 @@
   hosts: "{{ target | default('management1') }}"
   roles:
 
+    - role: ansible
+      tags: ansible
     - role: set_hostname
       tags: set_hostname
     - role: nic

--- a/roles/advanced-core/advanced_dhcp_server/readme.rst
+++ b/roles/advanced-core/advanced_dhcp_server/readme.rst
@@ -63,6 +63,7 @@ If using match, because this features is using a specific 'hack' in the dhcp ser
 Changelog
 ^^^^^^^^^
 
+* 1.0.3: Added support of multiple DNS servers. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.2: Added Ubuntu 18.04 compatibility. johnnykeats <johnny.keats@outlook.com>
 * 1.0.1: Documentation. johnnykeats <johnny.keats@outlook.com>
 * 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.networks.conf.j2
+++ b/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.networks.conf.j2
@@ -1,3 +1,4 @@
+#jinja2: lstrip_blocks: True
 #### Blue Banquise file ####
 ## {{ansible_managed}}
 
@@ -20,33 +21,38 @@
 shared-network {{shared_network}} {
 {% for network in networks %}
 {% if (networks[network]['shared_network'] is defined and not none) and (networks[network]['shared_network'] == shared_network) and (networks[network]['is_in_dhcp'] == true) %}
+  {% set nameservers = networks[network]['services_ip']['dns_ip'] | ipaddr %}
 
 subnet {{networks[network]['subnet']}} netmask {{networks[network]['netmask']}} {
 
-{% if networks[network]['dhcp_unknown_range'] is defined and not none %}
+  {% if networks[network]['dhcp_unknown_range'] is defined and not none %}
   range {{networks[network]['dhcp_unknown_range']}};
-{% endif %}
+  {% endif %}
   option domain-name "{{domain_name}}";
-  option domain-name-servers {{networks[network]['services_ip']['dns_ip']}};
+  {% if nameservers is string %}
+  option domain-name-servers {{nameservers}};
+  {% else %}
+  option domain-name-servers {{nameservers | join(', ')}};
+  {% endif %}
   option broadcast-address {{networks[network]['broadcast']}};
   option ntp-servers {{networks[network]['services_ip']['time_ip']}};
-{% if networks[network]['gateway'] is defined and not none %}
+  {% if networks[network]['gateway'] is defined and not none %}
   option routers {{networks[network]['gateway']}};
-{% endif %}
+  {% endif %}
   default-lease-time {{dhcp_settings['default_lease_time']}};
   max-lease-time {{dhcp_settings['max_lease_time']}};
-{% if networks[network]['services_ip']['pxe_ip'] is defined and not none %}
-{% if (networks[network]['services_ip']['pxe_http_ip'] is defined and not none)
-    and (networks[network]['services_ip']['pxe_http_ip'] != networks[network]['services_ip']['pxe_ip']) %}
+  {% if networks[network]['services_ip']['pxe_ip'] is defined and not none %}
+    {% if (networks[network]['services_ip']['pxe_http_ip'] is defined and not none)
+      and (networks[network]['services_ip']['pxe_http_ip'] != networks[network]['services_ip']['pxe_ip']) %}
   if exists user-class and option user-class = "BlueBanquise" {
     next-server {{networks[network]['services_ip']['pxe_http_ip']}};
   } else {
     next-server {{networks[network]['services_ip']['pxe_ip']}};
   }
-{% else %}
+    {% else %}
   next-server {{networks[network]['services_ip']['pxe_ip']}};
-{% endif %}
-{% endif %}
+    {% endif %}
+  {% endif %}
 
   include "/etc/dhcp/dhcpd.{{network}}.conf";
 
@@ -61,31 +67,38 @@ subnet {{networks[network]['subnet']}} netmask {{networks[network]['netmask']}} 
 {% for network in networks %}
 {% if j2_current_iceberg_network in network %}
 {% if (networks[network]['shared_network'] is not defined or none) and (networks[network]['is_in_dhcp'] == true) %}
+  {% set nameservers = networks[network]['services_ip']['dns_ip'] | ipaddr %}
 
 subnet {{networks[network]['subnet']}} netmask {{networks[network]['netmask']}} {
 
-  {% if networks[network]['dhcp_unknown_range'] is defined and not none %}range {{networks[network]['dhcp_unknown_range']}};{% endif %}
-
+  {% if networks[network]['dhcp_unknown_range'] is defined and not none %}
+  range {{networks[network]['dhcp_unknown_range']}};
+  {% endif %}
   option domain-name "{{domain_name}}";
-  option domain-name-servers {{networks[network]['services_ip']['dns_ip']}};
+  {% if nameservers is string %}
+  option domain-name-servers {{nameservers}};
+  {% else %}
+  option domain-name-servers {{nameservers | join(', ')}};
+  {% endif %}
   option broadcast-address {{networks[network]['broadcast']}};
   option ntp-servers {{networks[network]['services_ip']['time_ip']}};
-  {% if networks[network]['gateway'] is defined and not none %}option routers {{networks[network]['gateway']}};{% endif %}
-
+  {% if networks[network]['gateway'] is defined and not none %}
+  option routers {{networks[network]['gateway']}};
+  {% endif %}
   default-lease-time {{dhcp_settings['default_lease_time']}};
   max-lease-time {{dhcp_settings['max_lease_time']}};
-{% if networks[network]['services_ip']['pxe_ip'] is defined and not none %}
-{% if (networks[network]['services_ip']['pxe_http_ip'] is defined and not none)
-    and (networks[network]['services_ip']['pxe_http_ip'] != networks[network]['services_ip']['pxe_ip']) %}
+  {% if networks[network]['services_ip']['pxe_ip'] is defined and not none %}
+    {% if (networks[network]['services_ip']['pxe_http_ip'] is defined and not none)
+      and (networks[network]['services_ip']['pxe_http_ip'] != networks[network]['services_ip']['pxe_ip']) %}
   if exists user-class and option user-class = "BlueBanquise" {
     next-server {{networks[network]['services_ip']['pxe_http_ip']}};
   } else {
     next-server {{networks[network]['services_ip']['pxe_ip']}};
   }
-{% else %}
+    {% else %}
   next-server {{networks[network]['services_ip']['pxe_ip']}};
-{% endif %}
-{% endif %}
+    {% endif %}
+  {% endif %}
 
   include "/etc/dhcp/dhcpd.{{network}}.conf";
 

--- a/roles/advanced-core/advanced_dhcp_server/vars/main.yml
+++ b/roles/advanced-core/advanced_dhcp_server/vars/main.yml
@@ -1,4 +1,5 @@
-role_version: 1.0.2
+---
+role_version: 1.0.3
 packages_to_install:
   ubuntu:
     _18:

--- a/roles/core/ansible/readme.rst
+++ b/roles/core/ansible/readme.rst
@@ -15,5 +15,6 @@ NA
 Changelog
 ^^^^^^^^^
 
+* 1.0.1: Add Ansible dependencies for additional filters. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>
  

--- a/roles/core/ansible/tasks/main.yml
+++ b/roles/core/ansible/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
-- name: Install Ansible
+- name: Install Ansible and dependencies for filters
   package:
-    name:
-      - ansible
+    name: "{{ packages_to_install[(ansible_facts.distribution | replace(' ','_'))]['_'+ansible_facts.distribution_major_version] }}"
     state: present
   tags:
     - package

--- a/roles/core/ansible/vars/main.yml
+++ b/roles/core/ansible/vars/main.yml
@@ -1,4 +1,6 @@
 ---
+role_version: 1.0.1
+
 packages_to_install:
   Ubuntu:
     _18:

--- a/roles/core/ansible/vars/main.yml
+++ b/roles/core/ansible/vars/main.yml
@@ -1,0 +1,25 @@
+---
+packages_to_install:
+  Ubuntu:
+    _18:
+      - ansible
+      - python-jmespath
+      - python-netaddr
+  CentOS:
+    _7:
+      - ansible          # available in EPEL 7
+      - python2-jmespath # available in EPEL 7
+      - python-netaddr
+    _8:
+      - ansible
+      - python3-jmespath
+      - python3-netaddr
+  RedHat:
+    _7:
+      - ansible          # available in RHEL 7 Server - Extras or EPEL 7
+      - python2-jmespath # available in RHEL 7 Server - Extras or EPEL 7
+      - python-netaddr
+    _8:
+      - ansible
+      - python3-jmespath
+      - python3-netaddr

--- a/roles/core/dhcp_server/readme.rst
+++ b/roles/core/dhcp_server/readme.rst
@@ -54,6 +54,7 @@ Consider increasing the default values once your network is production ready.
 Changelog
 ^^^^^^^^^
 
+* 1.0.4: Added support of multiple DNS servers. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.3: Simplify standard dhcp, create advanced dhcp for complex configurations. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.2: Added Ubuntu 18.04 compatibility. johnnykeats <johnny.keats@outlook.com>
 * 1.0.1: Documentation. johnnykeats <johnny.keats@outlook.com>

--- a/roles/core/dhcp_server/templates/dhcpd.networks.conf.j2
+++ b/roles/core/dhcp_server/templates/dhcpd.networks.conf.j2
@@ -1,5 +1,7 @@
+#jinja2: lstrip_blocks: True
 #### Blue Banquise file ####
 ## {{ansible_managed}}
+{% set nameservers = networks[j2_node_main_network]['services_ip']['dns_ip'] | ipaddr %}
 
 #### SUBNETS
 
@@ -9,17 +11,25 @@
 
 subnet {{networks[network]['subnet']}} netmask {{networks[network]['netmask']}} {
 
-  {% if networks[network]['dhcp_unknown_range'] is defined and not none %}range {{networks[network]['dhcp_unknown_range']}};{% endif %}
-
+{% if networks[network]['dhcp_unknown_range'] is defined and not none %}
+  range {{networks[network]['dhcp_unknown_range']}};
+{% endif %}
   option domain-name "{{domain_name}}";
-  option domain-name-servers {{networks[network]['services_ip']['dns_ip']}};
+{% if nameservers is string %}
+  option domain-name-servers {{nameservers}};
+{% else %}
+  option domain-name-servers {{nameservers | join(', ')}};
+{% endif %}
   option broadcast-address {{networks[network]['broadcast']}};
   option ntp-servers {{networks[network]['services_ip']['time_ip']}};
-  {% if networks[network]['gateway'] is defined and not none %}option routers {{networks[network]['gateway']}};{% endif %}
-
+{% if networks[network]['gateway'] is defined and not none %}
+  option routers {{networks[network]['gateway']}};
+{% endif %}
   default-lease-time {{dhcp_settings['default_lease_time']}};
   max-lease-time {{dhcp_settings['max_lease_time']}};
-  {% if networks[network]['services_ip']['pxe_ip'] is defined and not none %}next-server {{networks[network]['services_ip']['pxe_ip']}};{% endif %}
+{% if networks[network]['services_ip']['pxe_ip'] is defined and not none %}
+  next-server {{networks[network]['services_ip']['pxe_ip']}};
+{% endif %}
 
   include "/etc/dhcp/dhcpd.{{network}}.conf";
 

--- a/roles/core/dhcp_server/vars/main.yml
+++ b/roles/core/dhcp_server/vars/main.yml
@@ -1,4 +1,5 @@
-role_version: 1.0.3
+---
+role_version: 1.0.4
 
 packages_to_install:
   ubuntu:

--- a/roles/core/dns_client/readme.rst
+++ b/roles/core/dns_client/readme.rst
@@ -24,6 +24,7 @@ Note that this/these external(s) dns will be placed after the cluster internal d
 Changelog
 ^^^^^^^^^
 
+* 1.0.3: Added support of multiple DNS servers. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.2: Added variable for role version. johnnykeats <johnny.keats@outlook.com>
 * 1.0.1: Documentation. johnnykeats <johnny.keats@outlook.com>
 * 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/core/dns_client/templates/resolv.conf.j2
+++ b/roles/core/dns_client/templates/resolv.conf.j2
@@ -1,8 +1,16 @@
+#jinja2: lstrip_blocks: True
 #### Blue Banquise file ####
 ## {{ansible_managed}}
+{% set nameservers = networks[j2_node_main_network]['services_ip']['dns_ip'] | ipaddr %}
 
 search {{domain_name}}
-nameserver {{networks[j2_node_main_network]['services_ip']['dns_ip']}} 
+{% if nameservers is string %}
+nameserver {{nameservers}}
+{% else %}
+  {% for nameserver in nameservers %}
+nameserver {{nameserver}}
+  {% endfor %}
+{% endif %}
 {% if external_dns is defined and external_dns is not none %}
 {% if external_dns.dns_client is defined and external_dns.dns_client is not none and external_dns.dns_client %}
 {% for external_server in external_dns.dns_client %}

--- a/roles/core/dns_client/vars/main.yml
+++ b/roles/core/dns_client/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-role_version: 1.0.2
+role_version: 1.0.3

--- a/roles/core/dns_server/molecule/default/converge.yml
+++ b/roles/core/dns_server/molecule/default/converge.yml
@@ -3,14 +3,18 @@
   hosts: all
 
   vars:
-    j2_node_main_network_interface: en0
-    network_interfaces:
-      en0:
-        ip4: 127.0.0.1
-    j2_current_iceberg_network: ice-1
+    management_network_naming: "ice"
     external_dns: []
-    networks: []
-    domain_name: .localhost
+    networks:
+      ice1-1:
+        subnet: 10.10.0.0
+        prefix: 16
+        netmask: 255.255.0.0
+        broadcast: 10.10.255.255
+        is_in_dns: true
+        services_ip:
+          dns_ip: 10.10.0.1
+    domain_name: example.com
     start_services: false
     enable_services: false
 

--- a/roles/core/dns_server/molecule/default/molecule.yml
+++ b/roles/core/dns_server/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  - name: instance
+  - name: mgmt0
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
     command: "/lib/systemd/systemd"
     capabilities:
@@ -20,16 +20,15 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  inventory:
+    host_vars:
+      mgmt0:
+        j2_current_iceberg_network: ice1
+        j2_node_main_network: ice1-1
+        j2_node_main_network_interface: en0
+        network_interfaces:
+          en0:
+            ip4: 10.10.0.1
+            network: ice1-1
 verifier:
   name: ansible
-scenario:
-  name: default
-  test_sequence:
-    - lint
-    - destroy
-    # - dependency
-    - syntax
-    - create
-    - prepare
-    - converge
-    - verify

--- a/roles/core/dns_server/readme.rst
+++ b/roles/core/dns_server/readme.rst
@@ -44,6 +44,7 @@ It is possible to add here an external dns to bind to for this internal dns, as 
 Changelog
 ^^^^^^^^^
 
+* 1.1.0: Added DNS slaves support. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.2: Added Ubuntu 18.04 compatibility. johnnykeats <johnny.keats@outlook.com>
 * 1.0.1: Documentation. johnnykeats <johnny.keats@outlook.com>
 * 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/core/dns_server/tasks/main.yml
+++ b/roles/core/dns_server/tasks/main.yml
@@ -26,6 +26,31 @@
   tags:
     - package
 
+# Master DNS is the dns_ip of primary management network
+# (management_network_naming + '1-1')
+- name: Set master DNS server - Get DNS IP
+  set_fact:
+    dns_master: "{{ networks[management_network_naming+'1-1'].services_ip.dns_ip }}"
+  when:
+    - "dns_master is not defined"
+    - "networks[j2_node_main_network].services_ip.dns_ip is defined"
+
+- name: Assert dns_master is defined
+  assert:
+    that:
+      - dns_master is defined
+    fail_msg: "'dns_master' must be defined. Please ensure that either 'dns_master' or
+              networks[{{ management_network_naming }}1-1].services_ip.dns_ip is
+              defined and contains a valid IP address."
+
+# If dns_ip is a list, pick the first value as master DNS
+- name: Set master DNS server - Pick first element of dns_ip
+  set_fact:
+    dns_master: "{{ dns_master | first }}"
+  when:
+    - "dns_master is iterable"
+    - "dns_master is not string"
+
 - name: Create needed directory >> /var/named
   file:
     path: /var/named
@@ -43,25 +68,9 @@
   tags:
     - template
 
-- name: Template >> /var/named/forward
-  template:
-    src: forward.j2
-    dest: /var/named/forward
-    owner: root
-    group: root
-    mode: 0644
-  notify: Restart dns services
-  tags:
-    - template
-
-- name: Template >> /var/named/reverse
-  template:
-    src: reverse.j2
-    dest: /var/named/reverse
-    owner: root
-    group: root
-    mode: 0644
-  notify: Restart dns services
+- name: Configure Master DNS
+  include_tasks: master.yml
+  when: "dns_master in ansible_all_ipv4_addresses"
   tags:
     - template
 

--- a/roles/core/dns_server/tasks/main.yml
+++ b/roles/core/dns_server/tasks/main.yml
@@ -70,7 +70,7 @@
 
 - name: Configure Master DNS
   include_tasks: master.yml
-  when: "dns_master in ansible_all_ipv4_addresses"
+  when: "dns_master in (network_interfaces | json_query('*.ip4'))"
   tags:
     - template
 

--- a/roles/core/dns_server/tasks/master.yml
+++ b/roles/core/dns_server/tasks/master.yml
@@ -1,0 +1,62 @@
+---
+- name: Template >> Forward zone file on Master DNS
+  template:
+    src: forward.j2
+    dest: /var/named/forward
+    owner: root
+    group: root
+    mode: 0644
+  notify: Restart dns services
+  register: zoneconf
+  tags:
+    - template
+
+- name: Set SOA Serial for forward zone
+  set_fact:
+    serial: "{{ lookup('pipe', 'date +%s') }}"
+  when: zoneconf.changed  # noqa 503
+  tags:
+    - template
+
+- name: Template >> SOA for forward zone file /var/named/forward.soa
+  template:
+    src: forward.soa.j2
+    dest: /var/named/forward.soa
+    owner: root
+    group: root
+    mode: 0644
+  notify: Restart dns services
+  when: zoneconf.changed  # noqa 503
+  tags:
+    - template
+
+- name: Template >> Reverse zone file on Master DNS
+  template:
+    src: reverse.j2
+    dest: /var/named/reverse
+    owner: root
+    group: root
+    mode: 0644
+  notify: Restart dns services
+  register: zoneconf
+  tags:
+    - template
+
+- name: Set SOA Serial for reverse zone
+  set_fact:
+    serial: "{{ lookup('pipe', 'date +%s') }}"
+  when: zoneconf.changed  # noqa 503
+  tags:
+    - template
+
+- name: Template >> SOA for reverse zone file /var/named/reverse.soa
+  template:
+    src: reverse.soa.j2
+    dest: /var/named/reverse.soa
+    owner: root
+    group: root
+    mode: 0644
+  notify: Restart dns services
+  when: zoneconf.changed  # noqa 503
+  tags:
+    - template

--- a/roles/core/dns_server/templates/forward.j2
+++ b/roles/core/dns_server/templates/forward.j2
@@ -3,13 +3,7 @@
 
 $TTL 86400
 $ORIGIN {{domain_name}}.
-@ IN SOA  {{inventory_hostname}}.{{domain_name}}. root.{{domain_name}}. (
-  2011071001  ;Serial
-  3600        ;Refresh
-  1800        ;Retry
-  604800      ;Expire
-  86400       ;Minimum TTL
-)
+$INCLUDE "/var/named/forward.soa"
 @ IN NS {{inventory_hostname}}.{{domain_name}}.
 
 {% for host in groups['all'] %}

--- a/roles/core/dns_server/templates/forward.soa.j2
+++ b/roles/core/dns_server/templates/forward.soa.j2
@@ -1,0 +1,7 @@
+@ IN SOA  {{inventory_hostname}}.{{domain_name}}. root.{{domain_name}}. (
+  {{ serial }}  ;Serial
+  3600        ;Refresh
+  1800        ;Retry
+  604800      ;Expire
+  86400       ;Minimum TTL
+)

--- a/roles/core/dns_server/templates/named.conf.j2
+++ b/roles/core/dns_server/templates/named.conf.j2
@@ -2,6 +2,8 @@
 #### Blue Banquise file ####
 ## {{ansible_managed}}
 
+{% set inventory_all_ipv4_addresses = network_interfaces | json_query('*.ip4') %}
+
 options {
   listen-on port 53 {
     127.0.0.1;
@@ -11,10 +13,10 @@ options {
     {% if dns_slaves is defined %}
       {% set addresses = addresses|union(dns_slaves) %}
     {% endif %}
-    {% if addresses is string and addresses in ansible_all_ipv4_addresses %}
+    {% if addresses is string and addresses in inventory_all_ipv4_addresses %}
     {{ addresses }};
     {% else %}
-      {% for address in (addresses|intersect(ansible_all_ipv4_addresses)) %}
+      {% for address in (addresses|intersect(inventory_all_ipv4_addresses)) %}
     {{ address }};
       {% endfor %}
     {% endif %}
@@ -73,7 +75,7 @@ zone "." IN {
 };
 
 {# Is the host the master DNS? #}
-{% if dns_master in ansible_all_ipv4_addresses %}
+{% if dns_master in inventory_all_ipv4_addresses %}
 zone "{{ domain_name }}" IN {
   type master;
   file "forward";

--- a/roles/core/dns_server/templates/named.conf.j2
+++ b/roles/core/dns_server/templates/named.conf.j2
@@ -8,6 +8,9 @@ options {
 {% for network in (networks | select('match',(j2_current_iceberg_network+'-[0-9]+')) | list | unique | sort) %}
   {% if networks[network]['is_in_dns'] is defined and networks[network]['is_in_dns'] == true %}
     {% set addresses = networks[network]['services_ip']['dns_ip'] | ipaddr %}
+    {% if dns_slaves is defined %}
+      {% set addresses = addresses|union(dns_slaves) %}
+    {% endif %}
     {% if addresses is string and addresses in ansible_all_ipv4_addresses %}
     {{ addresses }};
     {% else %}
@@ -69,17 +72,43 @@ zone "." IN {
   file "named.ca";
 };
 
-zone"{{domain_name}}" IN {
-type master;
-file "forward";
-allow-update { none; };
+{# Is the host the master DNS? #}
+{% if dns_master in ansible_all_ipv4_addresses %}
+zone "{{ domain_name }}" IN {
+  type master;
+  file "forward";
+  allow-update { none; };
+  {% if dns_slaves is defined %}
+  allow-transfer { {{ dns_slaves | join('; ') }}; };
+  notify yes;
+  also-notify { {{ dns_slaves | join('; ') }}; };
+  {% endif %}
 };
 
-zone"in-addr.arpa" IN {
-type master;
-file "reverse";
-allow-update { none; };
+zone "in-addr.arpa" IN {
+  type master;
+  file "reverse";
+  allow-update { none; };
+  {% if dns_slaves is defined %}
+  allow-transfer { {{ dns_slaves | join('; ') }}; };
+  notify yes;
+  also-notify { {{ dns_slaves | join('; ') }}; };
+  {% endif %}
 };
+{% else %}
+{# slave of dns_master #}
+zone "{{ domain_name }}" IN {
+  type slave;
+  masters { {{ dns_master }}; };
+  file "slaves/forward";
+};
+
+zone "in-addr.arpa" IN {
+  type slave;
+  masters { {{ dns_master }}; };
+  file "slaves/reverse";
+};
+{% endif %}
 
 include "/etc/named.rfc1912.zones";
 include "/etc/named.root.key";

--- a/roles/core/dns_server/templates/named.conf.j2
+++ b/roles/core/dns_server/templates/named.conf.j2
@@ -1,3 +1,4 @@
+#jinja2: lstrip_blocks: True
 #### Blue Banquise file ####
 ## {{ansible_managed}}
 
@@ -5,9 +6,16 @@ options {
   listen-on port 53 {
     127.0.0.1;
 {% for network in (networks | select('match',(j2_current_iceberg_network+'-[0-9]+')) | list | unique | sort) %}
-{% if networks[network]['is_in_dns'] is defined and networks[network]['is_in_dns'] == true %}
-    {{networks[network]['services_ip']['dns_ip']}};
-{% endif %}
+  {% if networks[network]['is_in_dns'] is defined and networks[network]['is_in_dns'] == true %}
+    {% set addresses = networks[network]['services_ip']['dns_ip'] | ipaddr %}
+    {% if addresses is string and addresses in ansible_all_ipv4_addresses %}
+    {{ addresses }};
+    {% else %}
+      {% for address in (addresses|intersect(ansible_all_ipv4_addresses)) %}
+    {{ address }};
+      {% endfor %}
+    {% endif %}
+  {% endif %}
 {% endfor %}
   };
 

--- a/roles/core/dns_server/templates/reverse.j2
+++ b/roles/core/dns_server/templates/reverse.j2
@@ -3,13 +3,7 @@
 
 $TTL 86400
 $ORIGIN in-addr.arpa.
-@ IN SOA  {{inventory_hostname}}.{{domain_name}}. root.{{domain_name}}. (
-  2011071001  ;Serial
-  3600        ;Refresh
-  1800        ;Retry
-  604800      ;Expire
-  86400       ;Minimum TTL
-)
+$INCLUDE "/var/named/reverse.soa"
 @ IN NS {{inventory_hostname}}.{{domain_name}}.
 
 {% for host in groups['all'] %}

--- a/roles/core/dns_server/templates/reverse.soa.j2
+++ b/roles/core/dns_server/templates/reverse.soa.j2
@@ -1,0 +1,7 @@
+@ IN SOA  {{inventory_hostname}}.{{domain_name}}. root.{{domain_name}}. (
+  {{ serial }}  ;Serial
+  3600        ;Refresh
+  1800        ;Retry
+  604800      ;Expire
+  86400       ;Minimum TTL
+)

--- a/roles/core/dns_server/vars/main.yml
+++ b/roles/core/dns_server/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-role_version: 1.0.2
+role_version: 1.1.0


### PR DESCRIPTION
PR for #100 
May be easier to review per commit.

Commit 1:

    feat: configure several DNS servers in the clients
    
    Allow to configure a list of several name servers in the dns_ip
    parameter of a network:
    
      dns_ip:
        - 10.11.0.1
        - 10.11.0.2
    
    Update the dns_client role to create as much nameserver entries in
    /etc/resolv.conf.
    
    Update the dhcp_server and advanced_dhcp_server roles to add all the
    dns_ip entries to domain-name-servers.
    
    Enable jinja2's lstrip_blocks to indent the j2 templates without
    indenting the destination file.

Commit 2:

    feat: named listen-on local ipv4 address
    
    Do not listen on all the dns_ip IPv4 addresses but only on those
    already configured on the host.

Commit 3:

    feat: add support for slave DNS servers
    
    The master DNS is the first element of the dns_ip in the primary
    management network's configuration. I assume the primary management
    network is the network of the Ansible controller.
    
      networks:
        ice1-1:
          services_ip:
            dns_ip:
              - 10.10.0.1  # Master DNS server
              - 10.10.0.2
    
    The role dns_server will create the forward and reverse zones on the
    master DNS server with the new task file master.yml. For each zone, the
    role creates an SOA file that is included in the zone file. This allows
    to update the zone serial only when the zone file changed. The serial
    number is the Unix epoch (32-bits) at time of the zone change.
    
    To add slave DNS servers, one need to configure the dns_slaves parameter
    with a list of IP addresses in the primary management network. A good
    practice would be to add this in the general_settings/network.yml
    inventory file.
    
      dns_slaves:
        - 10.10.0.2
        - 10.10.0.3
