### PR TITLE
Fix: remove clustershell example groups

### DIFF
--- a/roles/addons/clustershell/tasks/main.yml
+++ b/roles/addons/clustershell/tasks/main.yml
@@ -3,10 +3,10 @@
     name: clustershell
     state: present
 
-- name: Template >> /etc/clustershell/groups.d/cluster.yaml
+- name: Template >> /etc/clustershell/groups.d/local.cfg
   template:
-    src: cluster.yaml.j2
-    dest: /etc/clustershell/groups.d/cluster.yaml
+    src: local.cfg.j2
+    dest: /etc/clustershell/groups.d/local.cfg
     owner: root
     group: root
     mode: 0644

--- a/roles/addons/clustershell/templates/local.cfg.j2
+++ b/roles/addons/clustershell/templates/local.cfg.j2
@@ -1,10 +1,9 @@
 #### Blue Banquise file ####
 ## {{ansible_managed}}
 
-ansible:
 {% for gr, gr_vars in groups.items() %}
 {% if (gr|string) != 'ungrouped' %}
-  {{gr}}: {% for node in gr_vars %}{% if loop.first %}{{node}}{% else %},{{node}}{% endif %}{% endfor %}
+{{gr}}: {% for node in gr_vars %}{% if loop.first %}{{node}}{% else %},{{node}}{% endif %}{% endfor %}
 
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Fix clustershell role, by using local.cfg directly instead of adding another file.