### PR TITLE
feat: add venv-molecule directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 pxe
+
+## VirtualEnv ##
+venv-molecule/


### PR DESCRIPTION
There is a proposal to create a virtual environment to develop and run
molecule tests in #165. There is no need to track the content of this
directory in git.