### PR TITLE
feat: add param dns_server_zone_files=auto|static

### DIFF
--- a/.github/workflows/molecule-actions-core-dns_server.yml
+++ b/.github/workflows/molecule-actions-core-dns_server.yml
@@ -1,0 +1,43 @@
+---
+name: core/dns_server unit testing
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'roles/core/dns_server/**'
+      - '.github/workflows/molecule-actions-core-dns_server.yml'
+  pull_request:
+    paths:
+      - 'roles/core/dns_server/**'
+      - '.github/workflows/molecule-actions-core-dns_server.yml'
+
+jobs:
+  molecule_test:
+    name: core/dns_server - ${{ matrix.distro }} - molecule test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - centos7
+          - centos8
+          - ubuntu1804
+          - ubuntu2004
+
+    env:
+      MOLECULE_DISTRO: ${{ matrix.distro }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup python environment
+        uses: actions/setup-python@v1
+      - name: Install packages
+        run: |
+          pip install 'molecule[docker]>3' ansible-lint flake8 jmespath netaddr
+      - name: Run molecule default scenario for core/dns_server
+        run: |
+          cd roles/core/dns_server && molecule test
+      - name: Run molecule static_zone_files scenario for core/dns_server
+        run: |
+          cd roles/core/dns_server && molecule test -s static_zone_files

--- a/.github/workflows/molecule-actions.yml
+++ b/.github/workflows/molecule-actions.yml
@@ -27,7 +27,6 @@ jobs:
           - core/conman
           - core/display_tuning
           - core/dns_client
-          - core/dns_server
           - core/log_client
           - core/log_server
           - core/repositories_client

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/network.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/network.yml
@@ -3,6 +3,13 @@
 ## DNS
 domain_name: tumulus.local
 
+# DNS zone files management
+#  - auto: the zone files are created from templates
+#  - static: the zone files 'forward' and 'reverse' are copied from
+#    roles/core/dns_server/files/{forward,reverse}. You have to create the
+#    files by yourself. See readme of role dns_server.
+#dns_server_zone_files: auto
+
 ## DHCP
 dhcp_settings:
   default_lease_time: 600 # Consider to increase once in production

--- a/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/network.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/network.yml
@@ -3,6 +3,13 @@
 ## DNS
 domain_name: tumulus.local
 
+# DNS zone files management
+#  - auto: the zone files are created from templates
+#  - static: the zone files 'forward' and 'reverse' are copied from
+#    roles/core/dns_server/files/{forward,reverse}. You have to create the
+#    files by yourself. See readme of role dns_server.
+#dns_server_zone_files: auto
+
 ## DHCP
 dhcp_settings:
   default_lease_time: 600 # Consider to increase once in production

--- a/roles/core/dns_server/molecule/static_zone_files/INSTALL.rst
+++ b/roles/core/dns_server/molecule/static_zone_files/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/roles/core/dns_server/molecule/static_zone_files/converge.yml
+++ b/roles/core/dns_server/molecule/static_zone_files/converge.yml
@@ -17,6 +17,7 @@
     domain_name: example.com
     start_services: true
     enable_services: true
+    dns_server_zone_files: static
 
   tasks:
     - name: "Include dns_server"

--- a/roles/core/dns_server/molecule/static_zone_files/files/forward
+++ b/roles/core/dns_server/molecule/static_zone_files/files/forward
@@ -1,0 +1,35 @@
+;Example forward file for molecule unit test static_zone_files
+
+$TTL 86400
+$ORIGIN example.com.
+@ IN SOA  management1.example.com. root.example.com. (
+  1589322572  ;Serial
+  3600        ;Refresh
+  1800        ;Retry
+  604800      ;Expire
+  86400       ;Minimum TTL
+)
+@                          IN NS management1.example.com.
+
+management1                IN A 10.10.0.1
+management1-ice1-1         IN A 10.10.0.1
+management1-interconnect-1 IN A 10.20.0.1
+bmanagement1               IN A 10.10.100.1
+bmanagement1-ice1-1        IN A 10.10.100.1
+login1                     IN A 10.10.2.1
+login1-ice1-1              IN A 10.10.2.1
+login1-interconnect-1      IN A 10.20.2.1
+blogin1                    IN A 10.10.102.1
+blogin1-ice1-1             IN A 10.10.102.1
+c001                       IN A 10.10.3.1
+c001-ice1-1                IN A 10.10.3.1
+c001-interconnect-1        IN A 10.20.3.1
+c002                       IN A 10.10.3.2
+c002-ice1-1                IN A 10.10.3.2
+c002-interconnect-1        IN A 10.20.3.2
+c003                       IN A 10.10.3.3
+c003-ice1-1                IN A 10.10.3.3
+c003-interconnect-1        IN A 10.20.3.3
+c004                       IN A 10.10.3.4
+c004-ice1-1                IN A 10.10.3.4
+c004-interconnect-1        IN A 10.20.3.4

--- a/roles/core/dns_server/molecule/static_zone_files/files/reverse
+++ b/roles/core/dns_server/molecule/static_zone_files/files/reverse
@@ -1,0 +1,35 @@
+;Example reverse file for molecule unit test static_zone_files
+
+$TTL 86400
+$ORIGIN in-addr.arpa.
+@ IN SOA  management1.example.com. root.example.com. (
+  1589322574  ;Serial
+  3600        ;Refresh
+  1800        ;Retry
+  604800      ;Expire
+  86400       ;Minimum TTL
+)
+@            IN NS management1.example.com.
+
+1.3.10.10    IN PTR c001.example.com.
+1.3.10.10    IN PTR c001-ice1-1.example.com.
+1.3.20.10    IN PTR c001-interconnect-1.example.com.
+2.3.10.10    IN PTR c002.example.com.
+2.3.10.10    IN PTR c002-ice1-1.example.com.
+2.3.20.10    IN PTR c002-interconnect-1.example.com.
+3.3.10.10    IN PTR c003.example.com.
+3.3.10.10    IN PTR c003-ice1-1.example.com.
+3.3.20.10    IN PTR c003-interconnect-1.example.com.
+4.3.10.10    IN PTR c004.example.com.
+4.3.10.10    IN PTR c004-ice1-1.example.com.
+4.3.20.10    IN PTR c004-interconnect-1.example.com.
+1.2.10.10    IN PTR login1.example.com.
+1.2.10.10    IN PTR login1-ice1-1.example.com.
+1.2.20.10    IN PTR login1-interconnect-1.example.com.
+1.102.10.10  IN PTR blogin1.example.com.
+1.102.10.10  IN PTR blogin1-ice1-1.example.com.
+1.0.10.10    IN PTR management1.example.com.
+1.0.10.10    IN PTR management1-ice1-1.example.com.
+1.0.20.10    IN PTR management1-interconnect-1.example.com.
+1.100.10.10  IN PTR bmanagement1.example.com.
+1.100.10.10  IN PTR bmanagement1-ice1-1.example.com.

--- a/roles/core/dns_server/molecule/static_zone_files/molecule.yml
+++ b/roles/core/dns_server/molecule/static_zone_files/molecule.yml
@@ -1,0 +1,34 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: mgmt0
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    command: "/lib/systemd/systemd"
+    capabilities:
+      - "SYS_ADMIN"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      mgmt0:
+        j2_current_iceberg_network: ice1
+        j2_node_main_network: ice1-1
+        j2_node_main_network_interface: en0
+        network_interfaces:
+          en0:
+            ip4: 10.10.0.1
+            network: ice1-1
+verifier:
+  name: ansible

--- a/roles/core/dns_server/molecule/static_zone_files/prepare.yml
+++ b/roles/core/dns_server/molecule/static_zone_files/prepare.yml
@@ -1,0 +1,8 @@
+---
+- name: Prepare
+  hosts: all
+
+  tasks:
+    - name: "update cache apt"
+      apt: update_cache=yes
+      when: ansible_facts.os_family == "Debian"

--- a/roles/core/dns_server/molecule/static_zone_files/verify.yml
+++ b/roles/core/dns_server/molecule/static_zone_files/verify.yml
@@ -1,0 +1,18 @@
+---
+- name: Verify
+  hosts: all
+
+  tasks:
+    - name: Check that files exists
+      stat:
+        path: "{{ item }}"
+      register: stat_results
+      with_items:
+        - /etc/named.conf
+        - /var/named/forward
+        - /var/named/reverse
+
+    - name: assert files exist
+      assert:
+        that: "{{ item }}.stat.exists"
+      loop: "{{ stat_results.results }}"

--- a/roles/core/dns_server/readme.rst
+++ b/roles/core/dns_server/readme.rst
@@ -4,12 +4,13 @@ DNS server
 Description
 ^^^^^^^^^^^
 
-This role provides a basic dns server based on bind.
+This role provides a basic DNS server based on bind.
 
 Instructions
 ^^^^^^^^^^^^
 
-This DNS role will automatically add all networks of the cluster, assuming their variable **is_in_dns** is set to true:
+By default, this DNS role will automatically add all networks of the cluster,
+assuming their variable **is_in_dns** is set to true:
 
 .. code-block:: yaml
 
@@ -26,14 +27,34 @@ This DNS role will automatically add all networks of the cluster, assuming their
 
 It will generate 3 files:
 
-* /etc/named.conf that contains main configuration, and that will try to bind to all networks defined on the host it is deployed on, using **services_ip.dns_ip** variable ip of the network.
+* /etc/named.conf that contains main configuration, and that will try to bind
+  to all networks defined on the host it is deployed on, using
+  **services_ip.dns_ip** variable ip of the network.
 * /var/named/forward that contains forward resolution of hosts
 * /var/named/reverse that contains reverse resolution of hosts
 
-External hosts defined in *group_vars/all/general_settings/external.yml* at variable **external_hosts** will be automatically added in the dns configuration.
+You can change this behaviour and use custom forward and reverse files by
+setting the parameter **dns_server_zone_files** to **static** in your
+inventory:
 
-To configure forwarding and intergrate this dns server into an existing IT configuration, use file *group_vars/all/general_settings/external.yml*.
-It is possible to add here an external dns to bind to for this internal dns, as a relay.
+.. code-block:: yaml
+
+  dns_server_zone_files: static
+
+With static, it is possible to install tailor made zone files in
+roles/core/dns_server/files/{forward,reverse}. The role will copy these files
+to the /var/named/ directory on the master DNS. This allows to add any record
+type (CNAME, SRV, TXT, etc.) or define your zone files with an external tool.
+FIXME DRAFT: need a documentation of the mandatory entries (hostname, hostname-net).
+
+External hosts defined in *group_vars/all/general_settings/external.yml* in
+variable **external_hosts** will be automatically added to the DNS
+configuration.
+
+To configure forwarding and intergrate this DNS server into an existing IT
+configuration, use file *group_vars/all/general_settings/external.yml*. It is
+possible to add here an external DNS to bind to for this internal DNS, as a
+relay.
 
 .. code-block:: yaml
 

--- a/roles/core/dns_server/tasks/main.yml
+++ b/roles/core/dns_server/tasks/main.yml
@@ -68,11 +68,28 @@
   tags:
     - template
 
-- name: Configure Master DNS
+- name: Generate Master DNS' zone files
   include_tasks: master.yml
-  when: "dns_master in (network_interfaces | json_query('*.ip4'))"
+  when:
+    - dns_master in (network_interfaces | json_query('*.ip4'))
+    - dns_server_zone_files is not defined or dns_server_zone_files != "static"
   tags:
     - template
+
+- name: Copy Master DNS' zone files
+  copy:
+    src: "{{ item }}"
+    dest: "/var/named/{{ item }}"
+    owner: root
+    group: root
+    mode: 0644
+  loop:
+    - forward
+    - reverse
+  notify: Restart dns services
+  when:
+    - dns_master in (network_interfaces | json_query('*.ip4'))
+    - dns_server_zone_files is defined and dns_server_zone_files == "static"
 
 - meta: flush_handlers
 


### PR DESCRIPTION
Introduce new global parameter `dns_server_zone_files`. It allows to
define custom zone files `forward` and `reverse` when set to static.

 - auto: the zone files are created from templates
 - static: the zone files 'forward' and 'reverse' are copied from
   roles/core/dns_server/files/{forward,reverse}. You have to create the

The role default to auto when the parameter is not set or different than
static.

ci: add a new molecule scenario to test dns_server_zone_files=static
ci: move core/dns_server unit tests to dedicated actions
ci: start the dns service in all scenario of the role
ci: add Ubuntu 18.04 and 20.04 to the matrix

See #220