### PR TITLE
Fix: log server seport deps

### DIFF
--- a/roles/core/log_server/molecule/default/verify.yml
+++ b/roles/core/log_server/molecule/default/verify.yml
@@ -2,10 +2,6 @@
 - name: Verify
   hosts: all
 
-  vars:
-    content_orig: "{{ lookup('file', '/etc/rsyslog.conf') }}"
-    expected_content: "{{ lookup('file', 'expected_rsyslog.conf') }}"
-
   tasks:
   - name: populate service facts
     service_facts:
@@ -15,17 +11,3 @@
       that:
         - ansible_facts.services['rsyslog.service'].status == 'enabled'
         - ansible_facts.services['rsyslog.service'].state == 'running'
-
-  - name: difference with expected content of rsyslog.conf
-    set_fact:
-      file_diff: "{{ expected_content .split('\n') | difference(content_orig.split('\n')) | list }}"
-  - name: debug
-    debug:
-      var: content_orig
-  - name: debug
-    debug:
-      var: file_diff
-
-  - name: assert rsyslog file has the right content
-    assert:
-      that: file_diff|length == 0

--- a/roles/core/log_server/vars/RedHat_7.yml
+++ b/roles/core/log_server/vars/RedHat_7.yml
@@ -1,0 +1,10 @@
+---
+log_server_packages_to_install:
+  - rsyslog
+  - logrotate
+  - xz
+  - libselinux-python
+  - policycoreutils-python
+log_server_services_to_start:
+  - rsyslog
+log_server_rsyslog_conf_path: /etc/rsyslog.conf

--- a/roles/core/log_server/vars/RedHat_8.yml
+++ b/roles/core/log_server/vars/RedHat_8.yml
@@ -1,0 +1,10 @@
+---
+log_server_packages_to_install:
+  - rsyslog
+  - logrotate
+  - xz
+  - python3-libselinux
+  - python3-policycoreutils
+log_server_services_to_start:
+  - rsyslog
+log_server_rsyslog_conf_path: /etc/rsyslog.conf


### PR DESCRIPTION
Use of seport in the role requires:
 - libselinux-python
 - policycoreutils-python

PR for EL-like only (SELinux support).

Also removed an ineffective unit test.