### PR TITLE
feat: merge equipment_profile with combine

### DIFF
--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_HP_rusted/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_HP_rusted/equipment_profile.yml
@@ -1,4 +1,4 @@
-equipment_profile:
+equipment_profile_override:
 
   access_control: true
   firewall: true

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_management/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_management/equipment_profile.yml
@@ -1,4 +1,4 @@
-equipment_profile:
+equipment_profile_override:
 
   access_control: false
   firewall: false

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_sandy_SMP/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_sandy_SMP/equipment_profile.yml
@@ -1,4 +1,4 @@
-equipment_profile:
+equipment_profile_override:
 
   access_control: false
   firewall: false

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_sandy_compute/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_sandy_compute/equipment_profile.yml
@@ -1,4 +1,4 @@
-equipment_profile:
+equipment_profile_override:
 
   access_control: false
   firewall: false

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_sandy_login/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_supermicro_sandy_login/equipment_profile.yml
@@ -1,4 +1,4 @@
-equipment_profile:
+equipment_profile_override:
 
   access_control: true
   firewall: true

--- a/resources/examples/simple_cluster/inventory/group_vars/equipment_typeC/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/equipment_typeC/equipment_profile.yml
@@ -1,4 +1,4 @@
-equipment_profile:
+equipment_profile_override:
 
 #  access_control: false # equivalent to selinux=0
   firewall: false

--- a/resources/examples/simple_cluster/inventory/group_vars/equipment_typeL/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/equipment_typeL/equipment_profile.yml
@@ -1,4 +1,4 @@
-equipment_profile:
+equipment_profile_override:
 
   access_control: true
   firewall: true

--- a/resources/examples/simple_cluster/inventory/group_vars/equipment_typeM/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/equipment_typeM/equipment_profile.yml
@@ -1,4 +1,4 @@
-equipment_profile:
+equipment_profile_override:
 
   access_control: true
   firewall: false

--- a/resources/examples/simple_cluster/playbooks/computes.yml
+++ b/resources/examples/simple_cluster/playbooks/computes.yml
@@ -3,6 +3,8 @@
   hosts: "{{ target }}"
   roles:
 
+    - role: common
+      tags: common
     - role: set_hostname
       tags: set_hostname
     - role: repositories_client

--- a/resources/examples/simple_cluster/playbooks/login1.yml
+++ b/resources/examples/simple_cluster/playbooks/login1.yml
@@ -3,6 +3,8 @@
   hosts: "{{ target | default('login1') }}"
   roles:
 
+    - role: common
+      tags: common
     - role: set_hostname
       tags: set_hostname
     - role: repositories_client

--- a/resources/examples/simple_cluster/playbooks/management1.yml
+++ b/resources/examples/simple_cluster/playbooks/management1.yml
@@ -3,6 +3,8 @@
   hosts: "{{ target | default('management1') }}"
   roles:
 
+    - role: common
+      tags: common
     - role: bluebanquise
       tags: bluebanquise
     - role: set_hostname

--- a/roles/core/common/tasks/main.yml
+++ b/roles/core/common/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Merge equipment profile
+  set_fact:
+    equipment_profile: "{{ equipment_profile | combine(equipment_profile_override, recursive=True) }}"


### PR DESCRIPTION
Because hash_behavior=merge will be deprecated with Ansible 2.10, move to the
combine filter to set the equipment_profile.

The default values are still defined in `equipment_profile`. To override any
default parameter for a specific equipment profile, define a new hash
`equipment_profile_override` with the parameter in the file
inventory/group_vars/equipment_*/equipment_profile.yml:

```
  equipment_profile_override:
    firewall: false
```

We need to call the combine filter explicitely, while hash_behavior was
transparent, thus the new role `common`.