### PR TITLE
fix: open services in firewall's public zone

### DIFF
--- a/roles/advanced-core/advanced_dhcp_server/tasks/main.yml
+++ b/roles/advanced-core/advanced_dhcp_server/tasks/main.yml
@@ -19,6 +19,20 @@
         - "vars/{{ ansible_facts.os_family }}.yml"
       skip: true
 
+- name: "Add services to firewall's {{ advanced_dhcp_server_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ advanced_dhcp_server_firewall_zone | default('public') }}"
+    service: "{{ item }}"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - equipment_profile['firewall'] | default(false) | bool
+  loop: "{{ advanced_dhcp_server_firewall_services_to_add }}"
+  tags:
+    - firewall
+
 - name: Package
   package:
     name: "{{ item }}"

--- a/roles/advanced-core/advanced_dhcp_server/vars/RedHat_7.yml
+++ b/roles/advanced-core/advanced_dhcp_server/vars/RedHat_7.yml
@@ -3,3 +3,5 @@ advanced_dhcp_server_packages_to_install:
   - dhcp
 advanced_dhcp_server_services_to_start:
   - dhcpd
+advanced_dhcp_server_firewall_services_to_add:
+  - dhcp

--- a/roles/advanced-core/advanced_dhcp_server/vars/RedHat_8.yml
+++ b/roles/advanced-core/advanced_dhcp_server/vars/RedHat_8.yml
@@ -3,3 +3,5 @@ advanced_dhcp_server_packages_to_install:
   - dhcp-server
 advanced_dhcp_server_services_to_start:
   - dhcpd
+advanced_dhcp_server_firewall_services_to_add:
+  - dhcp

--- a/roles/core/dhcp_server/tasks/main.yml
+++ b/roles/core/dhcp_server/tasks/main.yml
@@ -19,6 +19,20 @@
         - "vars/{{ ansible_facts.os_family }}.yml"
       skip: true
 
+- name: "Add services to firewall's {{ dhcp_server_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ dhcp_server_firewall_zone | default('public') }}"
+    service: "{{ item }}"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - equipment_profile['firewall'] | default(false) | bool
+  loop: "{{ dhcp_server_firewall_services_to_add }}"
+  tags:
+    - firewall
+
 - name: Install packages
   package:
     name: "{{ dhcp_server_packages_to_install }}"

--- a/roles/core/dhcp_server/vars/RedHat_7.yml
+++ b/roles/core/dhcp_server/vars/RedHat_7.yml
@@ -3,3 +3,5 @@ dhcp_server_packages_to_install:
   - dhcp
 dhcp_server_services_to_start:
   - dhcpd
+dhcp_server_firewall_services_to_add:
+  - dhcp

--- a/roles/core/dhcp_server/vars/RedHat_8.yml
+++ b/roles/core/dhcp_server/vars/RedHat_8.yml
@@ -3,3 +3,5 @@ dhcp_server_packages_to_install:
   - dhcp-server
 dhcp_server_services_to_start:
   - dhcpd
+dhcp_server_firewall_services_to_add:
+  - dhcp

--- a/roles/core/dns_server/tasks/main.yml
+++ b/roles/core/dns_server/tasks/main.yml
@@ -19,6 +19,20 @@
         - "vars/{{ ansible_facts.os_family }}.yml"
       skip: true
 
+- name: "Add services to firewall's {{ dns_server_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ dns_server_firewall_zone | default('public') }}"
+    service: "{{ item }}"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - equipment_profile['firewall'] | default(false) | bool
+  loop: "{{ dns_server_firewall_services_to_add }}"
+  tags:
+    - firewall
+
 - name: Install packages
   package:
     name: "{{ dns_server_packages_to_install }}"

--- a/roles/core/dns_server/vars/RedHat.yml
+++ b/roles/core/dns_server/vars/RedHat.yml
@@ -3,3 +3,5 @@ dns_server_packages_to_install:
   - bind
 dns_server_services_to_start:
   - named
+dns_server_firewall_services_to_add:
+  - dns

--- a/roles/core/log_server/tasks/main.yml
+++ b/roles/core/log_server/tasks/main.yml
@@ -19,6 +19,20 @@
         - "vars/{{ ansible_facts.os_family }}.yml"
       skip: true
 
+- name: "Add services to firewall's {{ log_server_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ log_server_firewall_zone | default('public') }}"
+    service: "{{ item }}"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - equipment_profile['firewall'] | default(false) | bool
+  loop: "{{ log_server_firewall_services_to_add }}"
+  tags:
+    - firewall
+
 - name: Install packages
   package:
     name: "{{ log_server_packages_to_install }}"

--- a/roles/core/log_server/vars/main.yml
+++ b/roles/core/log_server/vars/main.yml
@@ -7,4 +7,7 @@ log_server_packages_to_install:
   - xz
 log_server_services_to_start:
   - rsyslog
+log_server_firewall_services_to_add:
+  - syslog
+  - rsh # 514/tcp
 log_server_rsyslog_conf_path: /etc/rsyslog.conf

--- a/roles/core/nfs_server/tasks/main.yml
+++ b/roles/core/nfs_server/tasks/main.yml
@@ -19,6 +19,20 @@
         - "vars/{{ ansible_facts.os_family }}.yml"
       skip: true
 
+- name: "Add services to firewall's {{ nfs_server_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ nfs_server_firewall_zone | default('public') }}"
+    service: "{{ item }}"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - equipment_profile['firewall'] | default(false) | bool
+  loop: "{{ nfs_server_firewall_services_to_add }}"
+  tags:
+    - firewall
+
 - name: Install packages
   package:
     name: "{{ nfs_server_packages_to_install }}"

--- a/roles/core/nfs_server/vars/RedHat.yml
+++ b/roles/core/nfs_server/vars/RedHat.yml
@@ -4,3 +4,6 @@ nfs_server_packages_to_install:
 nfs_server_services_to_start:
   - nfs-server
   - rpcbind
+nfs_server_firewall_services_to_add:
+  - nfs
+  - rpc-bind

--- a/roles/core/pxe_stack/tasks/main.yml
+++ b/roles/core/pxe_stack/tasks/main.yml
@@ -19,6 +19,20 @@
         - "vars/{{ ansible_facts.os_family }}.yml"
       skip: true
 
+- name: "Add services to firewall's {{ pxe_stack_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ pxe_stack_firewall_zone | default('public') }}"
+    service: "{{ item }}"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - equipment_profile['firewall'] | default(false) | bool
+  loop: "{{ pxe_stack_firewall_services_to_add }}"
+  tags:
+    - firewall
+
 - name: Install minimum packages for PXE
   package:
     name: "{{ pxe_stack_packages_to_install }}"

--- a/roles/core/pxe_stack/vars/CentOS_8.yml
+++ b/roles/core/pxe_stack/vars/CentOS_8.yml
@@ -14,3 +14,6 @@ pxe_stack_packages_to_install:
 pxe_stack_services_to_start:
   - atftpd
   - httpd
+pxe_stack_firewall_services_to_add:
+  - http
+  - tftp

--- a/roles/core/pxe_stack/vars/RedHat_7.yml
+++ b/roles/core/pxe_stack/vars/RedHat_7.yml
@@ -14,3 +14,6 @@ pxe_stack_packages_to_install:
 pxe_stack_services_to_start:
   - atftpd
   - httpd
+pxe_stack_firewall_services_to_add:
+  - http
+  - tftp

--- a/roles/core/pxe_stack/vars/RedHat_8.yml
+++ b/roles/core/pxe_stack/vars/RedHat_8.yml
@@ -14,3 +14,6 @@ pxe_stack_packages_to_install:
 pxe_stack_services_to_start:
   - atftpd
   - httpd
+pxe_stack_firewall_services_to_add:
+  - http
+  - tftp

--- a/roles/core/repositories_server/tasks/main.yml
+++ b/roles/core/repositories_server/tasks/main.yml
@@ -19,6 +19,20 @@
         - "vars/{{ ansible_facts.os_family }}.yml"
       skip: true
 
+- name: "Add services to firewall's {{ repositories_server_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ repositories_server_firewall_zone | default('public') }}"
+    service: "{{ item }}"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - equipment_profile['firewall'] | default(false) | bool
+  loop: "{{ repositories_server_firewall_services_to_add }}"
+  tags:
+    - firewall
+
 - name: Install packages
   package:
     name: "{{ repositories_server_packages_to_install }}"

--- a/roles/core/repositories_server/vars/RedHat.yml
+++ b/roles/core/repositories_server/vars/RedHat.yml
@@ -3,3 +3,5 @@ repositories_server_packages_to_install:
   - httpd
 repositories_server_services_to_start:
   - httpd
+repositories_server_firewall_services_to_add:
+  - http

--- a/roles/core/time/tasks/main.yml
+++ b/roles/core/time/tasks/main.yml
@@ -19,6 +19,20 @@
         - "vars/{{ ansible_facts.os_family }}.yml"
       skip: true
 
+- name: "Add services to firewall's {{ time_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ time_firewall_zone | default('public') }}"
+    service: "{{ item }}"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - equipment_profile['firewall'] | default(false) | bool
+  loop: "{{ time_firewall_services_to_add }}"
+  tags:
+    - firewall
+
 - name: Install packages
   package:
     name: "{{ time_packages_to_install }}"

--- a/roles/core/time/vars/RedHat.yml
+++ b/roles/core/time/vars/RedHat.yml
@@ -3,4 +3,6 @@ time_packages_to_install:
   - chrony
 time_services_to_start:
   - chronyd
+time_firewall_services_to_add:
+  - ntp
 time_chrony_conf_path: /etc/chrony.conf


### PR DESCRIPTION
If equipment_profile.firewall is true, the roles will add the relevant services to the firewall's default zone. In RHEL/CentOS, the firewall defaults to public zone.

For EL-like only. Can be extended to OpenSuse/Ubuntu later.
This PR focus on core and advanced-core roles only.

List of services per role:
 - dhcp_server/advanced_dhcp_server:
   - dhcp
 - dns_server:
   - dns
 - log_server:
   - syslog
   - rsh (for syslog 514/tcp)
 - nfs_server:
   - nfs
   - rpc-bind
 - pxe_stack:
   - http
   - tftp
 - repositories_server:
   - http
 - time:
   - ntp

I don't consider `ssh_master` because:

1. The ssh service is already in the services of the default zone
2. The role does not configure the sshd service

For each role, one can override the default zone (public) by setting `${rolename}_firewall_zone`. For example, if one wants to add the services of pxe_stack to the internal zone, he must set the variable `pxe_stack_firewall_zone: internal`. Configuration of the firewall zones must be managed by the user, either interactively or with a custom role. This is for possible future usage (addon role) and can be removed at any time, thus I let it undocumented. If an addon role should be added later, we will have to document this.