### PR TITLE
ci: update platforms image for molecule tests

### DIFF
--- a/.github/workflows/molecule-actions-core-bluebanquise.yml
+++ b/.github/workflows/molecule-actions-core-bluebanquise.yml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - centos7
-          - centos8
+          - centos:7
+          - centos:8
 
     env:
       MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.github/workflows/molecule-actions-core-repositories_client.yml
+++ b/.github/workflows/molecule-actions-core-repositories_client.yml
@@ -1,0 +1,40 @@
+---
+name: core/repositories_client unit testing
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'roles/core/repositories_client/**'
+      - '.github/workflows/molecule-actions-core-repositories_client.yml'
+  pull_request:
+    paths:
+      - 'roles/core/repositories_client/**'
+      - '.github/workflows/molecule-actions-core-repositories_client.yml'
+
+jobs:
+  molecule_test:
+    name: ${{ matrix.distro }} - molecule test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - centos:7
+          - centos:8
+
+    env:
+      MOLECULE_DISTRO: ${{ matrix.distro }}
+    steps:
+      - name: Set INSTANCE_DISTRO variable
+        run: echo "::set-env name=INSTANCE_DISTRO::${MOLECULE_DISTRO/:/}"
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup python environment
+        uses: actions/setup-python@v1
+      - name: Install packages
+        run: |
+          pip install 'molecule[docker]>3' ansible-lint flake8
+      - name: Run molecule test for core/repositories_client
+        run: |
+          cd roles/core/repositories_client && molecule test

--- a/.github/workflows/molecule-actions-core-time.yml
+++ b/.github/workflows/molecule-actions-core-time.yml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - centos7
-          - centos8
+          - centos:7
+          - centos:8
 
     env:
       MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.github/workflows/molecule-actions.yml
+++ b/.github/workflows/molecule-actions.yml
@@ -30,7 +30,6 @@ jobs:
           - core/dns_server
           - core/log_client
           - core/log_server
-          - core/repositories_client
           - addons/clustershell
           - addons/users_basic
 

--- a/.github/workflows/molecule-actions.yml
+++ b/.github/workflows/molecule-actions.yml
@@ -21,8 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - centos7
-          - centos8
+          - centos:7
+          - centos:8
         role:
           - core/conman
           - core/display_tuning

--- a/roles/addons/clustershell/molecule/default/molecule.yml
+++ b/roles/addons/clustershell/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint:  |
   flake8
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"

--- a/roles/addons/clustershell/molecule/default/molecule.yml
+++ b/roles/addons/clustershell/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ lint:  |
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:

--- a/roles/addons/clustershell/molecule/default/prepare.yml
+++ b/roles/addons/clustershell/molecule/default/prepare.yml
@@ -1,8 +1,0 @@
----
-- hosts: all
-  name: prepare the environment
-
-  tasks:
-    - name: "update cache apt"
-      apt: update_cache=yes
-      when: ansible_facts.os_family == "Debian"

--- a/roles/addons/users_basic/molecule/default/molecule.yml
+++ b/roles/addons/users_basic/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint:  |
   flake8
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"

--- a/roles/addons/users_basic/molecule/default/molecule.yml
+++ b/roles/addons/users_basic/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ lint:  |
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:

--- a/roles/addons/users_basic/molecule/default/prepare.yml
+++ b/roles/addons/users_basic/molecule/default/prepare.yml
@@ -3,10 +3,6 @@
   name: prepare the environment
 
   tasks:
-    - name: "update cache apt"
-      apt: update_cache=yes
-      when: ansible_facts.os_family == "Debian"
-
     - name: "make sure openssh is installed"
       package:
         name: openssh

--- a/roles/core/bluebanquise/molecule/default/molecule.yml
+++ b/roles/core/bluebanquise/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: ansiblectrl
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"

--- a/roles/core/bluebanquise/molecule/default/molecule.yml
+++ b/roles/core/bluebanquise/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: ansiblectrl
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:

--- a/roles/core/bluebanquise/molecule/default/prepare.yml
+++ b/roles/core/bluebanquise/molecule/default/prepare.yml
@@ -1,8 +1,0 @@
----
-- name: Prepare
-  hosts: all
-
-  tasks:
-    - name: "update cache apt"
-      apt: update_cache=yes
-      when: ansible_facts.os_family == "Debian"

--- a/roles/core/conman/molecule/default/molecule.yml
+++ b/roles/core/conman/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ platforms:
     groups:
       - iceberg1
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:

--- a/roles/core/conman/molecule/default/molecule.yml
+++ b/roles/core/conman/molecule/default/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: instance
     groups:
       - iceberg1
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"

--- a/roles/core/display_tuning/molecule/default/molecule.yml
+++ b/roles/core/display_tuning/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint:  |
   flake8
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"

--- a/roles/core/display_tuning/molecule/default/molecule.yml
+++ b/roles/core/display_tuning/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ lint:  |
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:

--- a/roles/core/display_tuning/molecule/default/prepare.yml
+++ b/roles/core/display_tuning/molecule/default/prepare.yml
@@ -1,8 +1,0 @@
----
-- name: Prepare
-  hosts: all
-
-  tasks:
-    - name: "update cache apt"
-      apt: update_cache=yes
-      when: ansible_facts.os_family == "Debian"

--- a/roles/core/dns_client/molecule/default/molecule.yml
+++ b/roles/core/dns_client/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint:  |
   flake8
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"

--- a/roles/core/dns_client/molecule/default/molecule.yml
+++ b/roles/core/dns_client/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ lint:  |
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:

--- a/roles/core/dns_client/molecule/default/prepare.yml
+++ b/roles/core/dns_client/molecule/default/prepare.yml
@@ -7,7 +7,3 @@
       mount:
         path: /etc/resolv.conf
         state: unmounted
-
-    - name: "update cache apt"
-      apt: update_cache=yes
-      when: ansible_facts.os_family == "Debian"

--- a/roles/core/dns_server/molecule/default/molecule.yml
+++ b/roles/core/dns_server/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint: |
   flake8
 platforms:
   - name: mgmt0
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"

--- a/roles/core/dns_server/molecule/default/molecule.yml
+++ b/roles/core/dns_server/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ lint: |
 platforms:
   - name: mgmt0
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:

--- a/roles/core/dns_server/molecule/default/prepare.yml
+++ b/roles/core/dns_server/molecule/default/prepare.yml
@@ -1,8 +1,0 @@
----
-- name: Prepare
-  hosts: all
-
-  tasks:
-    - name: "update cache apt"
-      apt: update_cache=yes
-      when: ansible_facts.os_family == "Debian"

--- a/roles/core/log_client/molecule/default/molecule.yml
+++ b/roles/core/log_client/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint:  |
   flake8
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"

--- a/roles/core/log_client/molecule/default/molecule.yml
+++ b/roles/core/log_client/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ lint:  |
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:

--- a/roles/core/log_client/molecule/default/prepare.yml
+++ b/roles/core/log_client/molecule/default/prepare.yml
@@ -1,8 +1,0 @@
----
-- name: Prepare
-  hosts: all
-
-  tasks:
-    - name: "update cache apt"
-      apt: update_cache=yes
-      when: ansible_facts.os_family == "Debian"

--- a/roles/core/log_server/molecule/default/molecule.yml
+++ b/roles/core/log_server/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint:  |
   flake8
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"

--- a/roles/core/log_server/molecule/default/molecule.yml
+++ b/roles/core/log_server/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ lint:  |
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:

--- a/roles/core/log_server/molecule/default/prepare.yml
+++ b/roles/core/log_server/molecule/default/prepare.yml
@@ -1,8 +1,0 @@
----
-- name: Prepare
-  hosts: all
-
-  tasks:
-    - name: "update cache apt"
-      apt: update_cache=yes
-      when: ansible_facts.os_family == "Debian"

--- a/roles/core/repositories_client/molecule/default/molecule.yml
+++ b/roles/core/repositories_client/molecule/default/molecule.yml
@@ -4,7 +4,7 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: instance-${MOLECULE_DISTRO:-centos8}
+  - name: instance-${INSTANCE_DISTRO:-centos8}
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     override_command: false
     capabilities:

--- a/roles/core/repositories_client/molecule/default/molecule.yml
+++ b/roles/core/repositories_client/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: instance-${MOLECULE_DISTRO:-centos8}
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"

--- a/roles/core/repositories_client/molecule/default/molecule.yml
+++ b/roles/core/repositories_client/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: instance-${MOLECULE_DISTRO:-centos8}
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:

--- a/roles/core/time/molecule/default/molecule.yml
+++ b/roles/core/time/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ platforms:
     groups:
       - server
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:
@@ -24,7 +24,7 @@ platforms:
     groups:
       - server
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:
@@ -35,7 +35,7 @@ platforms:
     groups:
       - client
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:
@@ -46,7 +46,7 @@ platforms:
     groups:
       - client
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:
@@ -57,7 +57,7 @@ platforms:
     groups:
       - client
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:
@@ -68,7 +68,7 @@ platforms:
     groups:
       - client
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
-    command: "/lib/systemd/systemd"
+    override_command: false
     capabilities:
       - "SYS_ADMIN"
     volumes:

--- a/roles/core/time/molecule/default/molecule.yml
+++ b/roles/core/time/molecule/default/molecule.yml
@@ -12,7 +12,7 @@ platforms:
   - name: server-ext-pool
     groups:
       - server
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"
@@ -23,7 +23,7 @@ platforms:
   - name: server-ext-servers
     groups:
       - server
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"
@@ -34,7 +34,7 @@ platforms:
   - name: client-ext-pool
     groups:
       - client
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"
@@ -45,7 +45,7 @@ platforms:
   - name: client-ext-servers
     groups:
       - client
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"
@@ -56,7 +56,7 @@ platforms:
   - name: client-single-source
     groups:
       - client
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"
@@ -67,7 +67,7 @@ platforms:
   - name: client-multi-sources
     groups:
       - client
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
     command: "/lib/systemd/systemd"
     capabilities:
       - "SYS_ADMIN"

--- a/roles/core/time/molecule/default/prepare.yml
+++ b/roles/core/time/molecule/default/prepare.yml
@@ -1,8 +1,0 @@
----
-- name: Prepare
-  hosts: all
-
-  tasks:
-    - name: "update cache apt"
-      apt: update_cache=yes
-      when: ansible_facts.os_family == "Debian"


### PR DESCRIPTION
Use our own docker images for molecule tests.
The main purpose is to prepare the support of OpenSUSE Leap. It will also help to solve some drawbacks with previous images.