### PR TITLE
Feat: add profile_roles callback in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -81,6 +81,7 @@ stdout_callback = yaml
 
 # enable callback plugins, they can output to stdout but cannot be 'stdout' type.
 #callback_whitelist = timer, mail
+callback_whitelist = profile_roles
 
 # Determine whether includes in tasks and handlers are "static" by
 # default. As of 2.0, includes are dynamic by default. Setting these


### PR DESCRIPTION
Nice callback, allows to trace execution time.