### PR TITLE
fix: use relative paths in ansible.cfg

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -32,4 +32,4 @@ jobs:
         run: ansible-lint -v roles/{core,advanced-core}/* -x 204
 
       - name: Run linter on example playbooks
-        run: ansible-lint -v resources/examples/simple_cluster/playbooks/*.yml
+        run: ansible-lint -v --exclude . resources/examples/*/playbooks/*.yml

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,7 +11,7 @@
 
 # some basic default values...
 
-inventory      = /etc/bluebanquise/inventory
+inventory      = inventory
 #library        = /usr/share/my_modules/
 #module_utils   = /usr/share/my_module_utils/
 #remote_tmp     = ~/.ansible/tmp
@@ -65,7 +65,7 @@ forks          = 32
 # inject_facts_as_vars = True
 
 # additional paths to search for roles in, colon separated
-roles_path    = /etc/bluebanquise/roles/core:/etc/bluebanquise/roles/addons:/etc/bluebanquise/roles/customs:/etc/bluebanquise/roles/advanced-core
+roles_path    = roles/custom:roles/core:roles/addons:roles/advanced-core
 
 # uncomment this to disable SSH key host checking
 #host_key_checking = False


### PR DESCRIPTION
Use relative paths in ansible.cfg, as proposed in #182. 