### PR TITLE
fix: use --limit in bluebanquise-playbook

### DIFF
--- a/tools/bluebanquise-playbook
+++ b/tools/bluebanquise-playbook
@@ -50,9 +50,9 @@ fi
 
 playbook_yml="${ANSIBLE_CONFIG}/playbooks/${playbook}.yml"
 if [[ $(grep -c 'hosts:.*{{.*target.*}}' ${playbook_yml}) -ne 0 ]]; then
-    echo -e "\e[31mWARNING: Usage of {{ target }} in hosts is deprecated."\
+    echo -e "\e[31mERROR: Usage of {{ target }} in hosts is deprecated."\
          "Please update your playbook.\e[0m"
-    sleep 3
+    exit 1
 fi
 
 ansbook_cmd=$(which ansible-playbook)
@@ -68,8 +68,7 @@ if [[ $? -ne 0 ]]; then
 fi
 
 if [[ -n "$nodeset" ]]; then
-    nodeset="$(${nodeset_cmd} -e -S, ${nodeset})"
-    target="--limit ${nodeset} --extra-vars target=${nodeset}"
+    target="--limit $(${nodeset_cmd} -e -S, ${nodeset})"
 fi
 
 echo "Execute: $ansbook_cmd ${playbook_yml} ${target} ${PARAMS[@]}"

--- a/tools/bluebanquise-playbook
+++ b/tools/bluebanquise-playbook
@@ -48,6 +48,13 @@ elif [[ ! -f "${ANSIBLE_CONFIG}/playbooks/${playbook}.yml" ]]; then
     exit 1
 fi
 
+playbook_yml="${ANSIBLE_CONFIG}/playbooks/${playbook}.yml"
+if [[ $(grep -c 'hosts:.*{{.*target.*}}' ${playbook_yml}) -ne 0 ]]; then
+    echo -e "\e[31mWARNING: Usage of {{ target }} in hosts is deprecated."\
+         "Please update your playbook.\e[0m"
+    sleep 3
+fi
+
 ansbook_cmd=$(which ansible-playbook)
 if [[ $? -ne 0 ]]; then
     echo 'Error: Cannot find command `ansible-playbook`.'
@@ -61,8 +68,9 @@ if [[ $? -ne 0 ]]; then
 fi
 
 if [[ -n "$nodeset" ]]; then
-    target="--extra-vars target=$(${nodeset_cmd} -e -S, ${nodeset})"
+    nodeset="$(${nodeset_cmd} -e -S, ${nodeset})"
+    target="--limit ${nodeset} --extra-vars target=${nodeset}"
 fi
 
-echo "Execute: $ansbook_cmd ${ANSIBLE_CONFIG}/playbooks/${playbook}.yml ${target} ${PARAMS[@]}"
-$ansbook_cmd ${ANSIBLE_CONFIG}/playbooks/${playbook}.yml ${target} ${PARAMS[@]}
+echo "Execute: $ansbook_cmd ${playbook_yml} ${target} ${PARAMS[@]}"
+$ansbook_cmd ${playbook_yml} ${target} ${PARAMS[@]}


### PR DESCRIPTION
When a list of nodes is provided with -n, run ansible-playbook with the
parameter --limit.

Remove support of --extra-vars target=nodeset. If
`hosts: {{ target }}` is found in the playbook, print a deprecation
error and exit.

Related to changes in #252.