### PR TITLE
feat: deprecate external_repositories

### DIFF
--- a/roles/core/repositories_client/molecule/default/molecule.yml
+++ b/roles/core/repositories_client/molecule/default/molecule.yml
@@ -46,5 +46,7 @@ provisioner:
         repositories:
           - bluebanquise
           - os
+        external_repositories:
+          - fakerepo
 verifier:
   name: ansible

--- a/roles/core/repositories_client/readme.rst
+++ b/roles/core/repositories_client/readme.rst
@@ -69,12 +69,13 @@ any other repository.
 
 There is a use case of people running CentOS 7 with a local clone of the *base*
 repository but still using the online *updates* repository. You can keep this
-behaviour by adding this repo to the external_repositories parameter in your
-inventory. Please consider using the mirror closest to your location.
+behaviour by adding this repo to the repositories parameter in your inventory.
+Please consider using the mirror closest to your location.
 
 .. code-block:: yaml
 
-  external_repositories:
+  repositories:
+    ...
     - name: "CentOS-Updates"
       baseurl: "http://mirror.centos.org/centos/7/updates/x86_64/"
       gpgcheck: 1
@@ -92,12 +93,6 @@ Mandatory inventory vars:
 
 * repositories[item]
 
-Optional inventory vars:
-
-**hostvars[inventory_hostname]**
-
-* external_repositories[item]
-
 Output
 ^^^^^^
 
@@ -113,6 +108,7 @@ sources.list file.
 Changelog
 ^^^^^^^^^
 
+* 1.0.6: Deprecate external_repositories. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.5: Added support for excluding packages from CentOS and RHEL repositories. Neil Munday <neil@mundayweb.com>
 * 1.0.4: Clean. johnnykeats <johnny.keats@outlook.com>
 * 1.0.3: Add support of major release version. Bruno <devel@travouillon.fr>

--- a/roles/core/repositories_client/tasks/deprecation.yml
+++ b/roles/core/repositories_client/tasks/deprecation.yml
@@ -1,0 +1,10 @@
+---
+- name: fail ░ Deprecate external_repositories - Warning
+  fail:
+    msg: "Variable `external_repositories` is deprecated and will be
+ removed in a future release. Update your inventory to use `repositories`
+ instead."
+  when: external_repositories is defined
+  ignore_errors: yes
+  tags:
+    - internal

--- a/roles/core/repositories_client/tasks/main.yml
+++ b/roles/core/repositories_client/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: include_tasks ░ Deprecation messages
+  include_tasks: "deprecation.yml"
+  tags:
+    - internal
 
 - name: include_tasks ░ Use OS dedicated task
   include_tasks: "{{ (ansible_facts.distribution|lower|replace(' ','_')) }}_{{ ansible_facts.distribution_major_version }}.yml"

--- a/roles/core/repositories_client/vars/main.yml
+++ b/roles/core/repositories_client/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-repositories_client_role_version: 1.0.5
+repositories_client_role_version: 1.0.6
 
 ubuntu_versions:
   _18: bionic


### PR DESCRIPTION
This will print a `fail` message with `ignore_errors: yes` when `external_repositories` is defined in the inventory.

Fixes #268