### PR TITLE
fix: remove external_repositories from multi icebergs inventory

### DIFF
--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/external.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/external.yml
@@ -18,13 +18,3 @@ external_dns:
 # Hosts defined here will be automatically added into /etc/hosts
 external_hosts:
   sphenisc.com: 213.186.33.3
-
-# Uncomment this variable if you need additionnal repositories on your clients
-# Be aware that, at this level, theses repositories will be exported on all hosts without
-# any architecture or distribution check.
-
-#external_repositories:
-#  - name: epel
-#    baseurl: 'https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/'
-#    proxy: 'https://proxy:8080'
-


### PR DESCRIPTION
I thought it was removed in #252.