### PR TITLE
fix: make converter compatible with older PyYAML

### DIFF
--- a/tools/inventory-converter-1.3-network_interfaces.py
+++ b/tools/inventory-converter-1.3-network_interfaces.py
@@ -60,13 +60,13 @@ def main():
 
     with open(hostsfile, 'r') as fd:
         try:
-            inventory = yaml.load(fd, Loader=yaml.FullLoader)
+            inventory = yaml.load(fd, Loader=yaml.SafeLoader)
             new_inventory = search_network_interfaces(inventory)
         except yaml.YAMLError as exc:
             print(exc)
 
     with open(outfile, 'w') as fd:
-        fd.write(yaml.dump(new_inventory, Dumper=MyDumper))
+        fd.write(yaml.dump(new_inventory, Dumper=MyDumper, default_flow_style=False))
 
     print(f'''Next steps:
       $ diff -u {hostsfile} {outfile} | less


### PR DESCRIPTION
CentOS 8 ship with PyYAML 3.12 while I used some features introduced
with 5.1, which are incompatible. See yaml/pyyaml#265.

It appears I tested it in my virtualenv setup with latest PyYAML 5.3.1.... :-1: 