### PR TITLE
fix missing checks on j2 network vars

### DIFF
--- a/internal/group_vars/all/j2_variables/network.yml
+++ b/internal/group_vars/all/j2_variables/network.yml
@@ -7,10 +7,10 @@ j2_node_main_resolution_network: "{{ network_interfaces[0].network }}"
 
 # Main network. The network used by Ansible to deploy configuration (related to ssh).
 # Also the network used by the host to get services ip.
-j2_node_main_network: "{{ network_interfaces | selectattr('network','match','^'+j2_current_iceberg_network+'-[a-zA-Z0-9]+') | map(attribute='network') | list | first }}"
+j2_node_main_network: "{{ network_interfaces | selectattr('network','defined') | selectattr('network','match','^'+j2_current_iceberg_network+'-[a-zA-Z0-9]+') | map(attribute='network') | list | first }}"
 
 # Main network interface. Same as main network, but provides interface name instead of network.
-j2_node_main_network_interface: "{{ network_interfaces | selectattr('network','match','^'+j2_current_iceberg_network+'-[a-zA-Z0-9]+') | map(attribute='interface') | list | first }}"
+j2_node_main_network_interface: "{{ network_interfaces | selectattr('network','defined') | selectattr('network','match','^'+j2_current_iceberg_network+'-[a-zA-Z0-9]+') | map(attribute='interface') | list | first }}"
 
 # List of management networks.
 j2_management_networks: "{{ networks | select('match','^'+j2_current_iceberg_network+'-[a-zA-Z0-9]+') | list | unique | sort }}"

--- a/roles/core/ssh_master/templates/config.j2
+++ b/roles/core/ssh_master/templates/config.j2
@@ -1,7 +1,7 @@
 #jinja2: lstrip_blocks: "True"
 
 {% macro node_main_network(macro_network_interfaces,macro_current_iceberg_network) %}
-{{ macro_network_interfaces | selectattr('network','match','^'+macro_current_iceberg_network+'-[a-zA-Z0-9]+') | map(attribute='network') | list | first }}
+{{ macro_network_interfaces | selectattr('network','defined') | selectattr('network','match','^'+macro_current_iceberg_network+'-[a-zA-Z0-9]+') | map(attribute='network') | list | first }}
 {% endmacro %}
 
 {# Macro to avoid redundancy #}


### PR DESCRIPTION
Errors appear when a bond is required

Some roles fails using _j2_node_main_network_ and _j2_node_main_network_interface_ when the network is not defined for an interface. 

I'm using this template :

```
          network_interfaces:
            - interface: bond0
              type: bond
              vlan: false
              bond_options: "mode=4 xmit_hash_policy=layer3+4 miimon=100 lacp_rate=1"
              ip4: 10.11.0.1
              network: ice1-1
            - interface: ens5f0
              type: bond-slave
              master: bond0
            - interface: ens5f1
              type: bond-slave
              master: bond0
```