### PR TITLE
Oxedions/feat/scaling new nic

### DIFF
--- a/roles/advanced-core/direct_access/defaults/main.yml
+++ b/roles/advanced-core/direct_access/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+nodes_path: "/etc/bluebanquise/inventory/cluster/nodes"

--- a/roles/advanced-core/direct_access/tasks/main.yml
+++ b/roles/advanced-core/direct_access/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: "include vars █ Include vars from {{ nodes_path }}"
+  include_vars:
+    # Cannot use dir as dir do not merge files, only replace.
+    # Using file with with_filetree lookup instead.
+    file: "{{ nodes_path }}/{{ item.path }}"
+    name: direct_access
+  with_filetree: "{{ nodes_path }}"
+  when: item.state == 'file'
+

--- a/roles/core/hosts_file/readme.rst
+++ b/roles/core/hosts_file/readme.rst
@@ -75,6 +75,7 @@ Files generated:
 Changelog
 ^^^^^^^^^
 
+* 1.0.7: Add direct rendering capability. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.6: Update to new network_interfaces syntax. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.5: Clean. johnnykeats <johnny.keats@outlook.com>
 * 1.0.4: Rewrite whole macro, add BMC alias. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/core/hosts_file/tasks/main.yml
+++ b/roles/core/hosts_file/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "template █ Generate /etc/hosts"
+- name: "template █ Generate /etc/hosts {% if direct_access is defined %}with direct_access enabled{% endif %}"
   template:
     src: hosts.j2
     dest: /etc/hosts

--- a/roles/core/hosts_file/templates/hosts.j2
+++ b/roles/core/hosts_file/templates/hosts.j2
@@ -76,10 +76,41 @@
 
 ## Internal hosts
 
+{% if direct_access is not defined %}
+{# -- Standard method. Rely on hostvars. -- #}
+
 {% set current_iceberg = j2_current_iceberg %}
 {% for host in range %}
 {{ write_host(host,hostvars[host],current_iceberg) }}
 {% endfor %}
+
+{% else %}
+{# -- Direct access method. Rely on direct_access content. -- #}
+
+  {% for mg, mg_vars in direct_access.items() %}
+    {% for eqg, eqg_vars in mg_vars.children.items() %}
+      {% for host, host_vars in eqg_vars.hosts.items() %}
+        {% if host in range %}
+          {# Get host iceberg, from groups #}
+          {% set host_icb = (macro_groups.node_current_iceberg(host)|trim) %}
+          {# Check if user forced main network. #}
+          {% if host_vars.j2_node_main_network is defined %}
+            {% set host_node_main_network = host_vars.j2_node_main_network %}
+            {% set host_node_main_network_interface = (macro_network.node_main_network_interface(host_vars.network_interfaces,host_node_main_network) | trim) %}
+          {% elif host_vars.j2_node_main_network_interface is defined %}
+            {% set host_node_main_network_interface = host_vars.j2_node_main_network_interface %}
+          {% else %}
+            {% set host_icb_net = (management_networks_naming + (host_icb | replace(iceberg_naming,' ') | trim | string)) %}
+            {% set host_node_main_network = (macro_network.node_main_network(host_vars.network_interfaces,host_icb_net) | trim) %}
+            {% set host_node_main_network_interface = (macro_network.node_main_network_interface(host_vars.network_interfaces,host_node_main_network) | trim) %}
+          {% endif %}
+{{ write_host(host,host_vars,host_node_main_network_interface,host_icb) }}
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  {% endfor %}
+
+{% endif %}
 
 ## External hosts
 

--- a/roles/core/hosts_file/vars/main.yml
+++ b/roles/core/hosts_file/vars/main.yml
@@ -1,1 +1,1 @@
-hosts_file_role_version: 1.0.6
+hosts_file_role_version: 1.0.7


### PR DESCRIPTION
New direct access method.

Replace existing but badly designed accelerated mode.

Huge performance improvement. Could even be better, but at a cost of greater complexity.
I personally think this is a good balance here (complexity vs performances).

Target is to cover all ranged roles:

    hosts_file
    dhcp_server
    dns_server
    ssh_master
    pxe_stack

hosts_file being the priority, as this file is often deployed on a massive number of hosts.

direct_access role must be executed before other roles to activate it in templates.
nodes_path variable must be set for the direct_access role to work. By default, nodes_path is /etc/bluebanquise/inventory/cluster/nodes/.

Direct access method only allows standard mg_group + eq_group yml structure, other structures cannot be handled right now.