### PR TITLE
fix: define baseurl_prefix as single line value

### DIFF
--- a/roles/core/repositories_client/tasks/centos_7.yml
+++ b/roles/core/repositories_client/tasks/centos_7.yml
@@ -1,12 +1,12 @@
 ---
 - name: set_fact ░ Set static baseurl prefix
   set_fact:
-     baseurl_prefix: >-
-       "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/
-       {{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/
-       {{ equipment_profile['operating_system']['distribution'] }}/
-       {{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/
-       $basearch/"
+    baseurl_prefix:
+      "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/\
+      {{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/\
+      {{ equipment_profile['operating_system']['distribution'] }}/\
+      {{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/\
+      $basearch/"
 
 - name: ini_file █ Disable CentOS-Base distro repositories
   # In BlueBanquise, the CentOS 7 system repository is installed with the

--- a/roles/core/repositories_client/tasks/centos_8.yml
+++ b/roles/core/repositories_client/tasks/centos_8.yml
@@ -1,11 +1,11 @@
 ---
 - name: set_fact ░ Set static baseurl prefix
   set_fact:
-    baseurl_prefix: >-
-      "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/
-      {{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/
-      {{ equipment_profile['operating_system']['distribution'] }}/
-      {{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/
+    baseurl_prefix:
+      "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/\
+      {{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/\
+      {{ equipment_profile['operating_system']['distribution'] }}/\
+      {{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/\
       $basearch/"
 
 - name: ini_file █ Disable CentOS Extras repository

--- a/roles/core/repositories_client/tasks/redhat_7.yml
+++ b/roles/core/repositories_client/tasks/redhat_7.yml
@@ -1,11 +1,11 @@
 ---
 - name: set_fact ░ Set static baseurl prefix
   set_fact:
-    baseurl_prefix: >-
-      "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/
-      {{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/
-      {{ equipment_profile['operating_system']['distribution'] }}/
-      {{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/
+    baseurl_prefix:
+      "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/\
+      {{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/\
+      {{ equipment_profile['operating_system']['distribution'] }}/\
+      {{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/\
       $basearch/"
 
 - name: yum_repository █ Setting repositories

--- a/roles/core/repositories_client/tasks/redhat_8.yml
+++ b/roles/core/repositories_client/tasks/redhat_8.yml
@@ -1,11 +1,11 @@
 ---
 - name: set_fact ░ Set static baseurl prefix
   set_fact:
-    baseurl_prefix: >-
-      "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/
-      {{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/
-      {{ equipment_profile['operating_system']['distribution'] }}/
-      {{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/
+    baseurl_prefix:
+      "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/\
+      {{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/\
+      {{ equipment_profile['operating_system']['distribution'] }}/\
+      {{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/\
       $basearch/"
 
 - name: yum_repository █ Setting repositories


### PR DESCRIPTION
baseurl_prefix fact is defined with multi-line format for readability,
but the value must remain single line (no \n, no spaces).

Fixes #292.