### PR TITLE
ci: trigger Test RPM build for pull request

### DIFF
--- a/.github/workflows/rpmbuild-action.yml
+++ b/.github/workflows/rpmbuild-action.yml
@@ -1,10 +1,7 @@
 name: Test RPM build
-on: push
-  # push:
-  #   branches:
-  #     - master
-  #       tags:
-  #         - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+on:
+  push:
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
We need to trigger this for PR as well. Otherwise some changes can break the rpm build and we cannot see this before merge to master. (https://github.com/bluebanquise/bluebanquise/runs/902731210)