### PR TITLE
Call imgstat in ipxe files to get image report

### DIFF
--- a/roles/addons/diskless/files/disklessset.py
+++ b/roles/addons/diskless/files/disklessset.py
@@ -87,6 +87,10 @@ echo | Loading initial ramdisk ...
 initrd http://${{next-server}}/preboot_execution_environment/diskless/kernels/${{image-initramfs}}
 
 echo | ALL DONE! We are ready.
+echo | Downloaded images report:
+
+imgstat
+
 echo | Booting in 4s ...
 echo |
 echo +----------------------------------------------------+
@@ -123,6 +127,10 @@ echo | Loading initial ramdisk ...
 initrd http://${{next-server}}/preboot_execution_environment/diskless/kernels/${{image-initramfs}}
 
 echo | ALL DONE! We are ready.
+echo | Downloaded images report:
+
+imgstat
+
 echo | Booting in 4s ...
 echo |
 echo +----------------------------------------------------+
@@ -158,6 +166,10 @@ echo | Loading initial ramdisk ...
 initrd http://${{next-server}}/preboot_execution_environment/diskless/kernels/${{image-initramfs}}
 
 echo | ALL DONE! We are ready.
+echo | Downloaded images report:
+
+imgstat
+
 echo | Booting in 4s ...
 echo |
 echo +----------------------------------------------------+

--- a/roles/core/pxe_stack/files/osdeploy/centos_7.ipxe
+++ b/roles/core/pxe_stack/files/osdeploy/centos_7.ipxe
@@ -25,6 +25,10 @@ echo | Loading initial ramdisk ...
 initrd ${images-root}/os/images/pxeboot/initrd.img
 
 echo | ALL DONE! We are ready.
+echo | Downloaded images report:
+
+imgstat
+
 echo | Booting in 4s ...
 echo |
 echo +----------------------------------------------------+

--- a/roles/core/pxe_stack/files/osdeploy/centos_8.ipxe
+++ b/roles/core/pxe_stack/files/osdeploy/centos_8.ipxe
@@ -25,6 +25,10 @@ echo | Loading initial ramdisk ...
 initrd ${images-root}/os/images/pxeboot/initrd.img
 
 echo | ALL DONE! We are ready.
+echo | Downloaded images report:
+
+imgstat
+
 echo | Booting in 4s ...
 echo |
 echo +----------------------------------------------------+

--- a/roles/core/pxe_stack/files/osdeploy/redhat_7.ipxe
+++ b/roles/core/pxe_stack/files/osdeploy/redhat_7.ipxe
@@ -25,6 +25,10 @@ echo | Loading initial ramdisk ...
 initrd ${images-root}/os/images/pxeboot/initrd.img
 
 echo | ALL DONE! We are ready.
+echo | Downloaded images report:
+
+imgstat
+
 echo | Booting in 4s ...
 echo |
 echo +----------------------------------------------------+

--- a/roles/core/pxe_stack/files/osdeploy/redhat_8.ipxe
+++ b/roles/core/pxe_stack/files/osdeploy/redhat_8.ipxe
@@ -25,6 +25,10 @@ echo | Loading initial ramdisk ...
 initrd ${images-root}/os/images/pxeboot/initrd.img
 
 echo | ALL DONE! We are ready.
+echo | Downloaded images report:
+
+imgstat
+
 echo | Booting in 4s ...
 echo |
 echo +----------------------------------------------------+


### PR DESCRIPTION
Add imgstat to see useful data before booting.

See https://ipxe.org/cmd/imgstat

I will update the other files if others are ok with this small add.