### PR TITLE
fix: remove equipment_profile key from inventory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,15 +141,15 @@ can be defined in the role vars. Example: packages names, services names, paths,
 in dedicated files or if needed in a new one. When possible, variables should be optional.
 In any cases, they must be documented in the role readme (and if needed provided commented in the example inventories).
 
-4. All variables related to an equipment_profile should go in group_vars/all/all_equipment/ (global) or in group_vars/equipment_X/ with X the equipment profile name (dedicated).
+4. All variables related to an equipment_profile should go in group_vars/all/all_equipment/ (global) or in group_vars/equipment_X/ with X the equipment profile name (dedicated). These variables must be prefixed by **ep_**.
 
 5. All variables containing jinja2 code must be prefix with *j2_* and stored in group_vars/all/j2_variables/.
 j2_ variables are core of the stack, and should be manipulated with care.
 These are intended to be precedence by user only. If needed, theses variables can be fixed.
 
 6. Also, consider that some variables are specific in BlueBanquise,
-and do not fully follow the standard rules of Ansible: *Equipment_profile* and *Authentication* dictionaries are good example.
-As stated in 4, these dictionaries **must** be set in group_vars/equipment_X/ folders or in group_vars/all/all_equipment/.
+and do not fully follow the standard rules of Ansible.
+As stated in 4, these variables **must** be set in group_vars/equipment_X/ folders or in group_vars/all/all_equipment/.
 Any other usage (for example at host_vars level or extra_vars level) will result in a unpredictable situation, as the stack use a random host of these groups to gather equipment_profile data.
 
 ### Miscellaneous

--- a/resources/documentation/configure_bluebanquise.rst
+++ b/resources/documentation/configure_bluebanquise.rst
@@ -321,9 +321,7 @@ and check access_control variable. It is set to true:
 
 .. code-block:: yaml
 
-  equipment_profile:
-    ...
-    access_control: true
+  ep_access_control: true
 
 Ok, but so all nodes will get this value. Let's check computes nodes, that are
 in equipment_typeC group. Let's check c001:

--- a/resources/documentation/vocabulary.rst
+++ b/resources/documentation/vocabulary.rst
@@ -342,8 +342,8 @@ In **BlueBanquise**, nodes are nearly always part of a group starting with
 prefix **equipment_**. These groups are called *equipment profiles*.
 
 They are used to provide to hosts of this group the **equipment_profile**
-dictionary (this dictionary defines hosts operating system parameters, kernel
-parameters, partitioning, etc.), and other variables if needed like dedicated
+parameters (this includes hosts operating system parameters, kernel parameters,
+partitioning, etc.), and other variables if needed like dedicated
 authentication parameters.
 
 These are key groups of the stack.

--- a/resources/examples/equipment_profils/nvidia.yml
+++ b/resources/examples/equipment_profils/nvidia.yml
@@ -1,3 +1,3 @@
-equipment_profile:
-  # Blacklist nouveau driver
-  kernel_parameters: modprobe.blacklist=nouveau nouveau.modeset=0 rd.driver.blacklist=nouveau
+---
+# Blacklist nouveau driver
+ep_kernel_parameters: modprobe.blacklist=nouveau nouveau.modeset=0 rd.driver.blacklist=nouveau

--- a/resources/examples/equipment_profils/opensuse_leap_15.yml
+++ b/resources/examples/equipment_profils/opensuse_leap_15.yml
@@ -1,18 +1,18 @@
-equipment_profile:
+---
 
-  partitioning: |
-    <partitioning config:type="list">
-      <drive>
-        <initialize config:type="boolean">true</initialize>
-        <device>/dev/sda</device>
-        <use>all</use>
-      </drive>
-    </partitioning>
+ep_partitioning: |
+  <partitioning config:type="list">
+    <drive>
+      <initialize config:type="boolean">true</initialize>
+      <device>/dev/sda</device>
+      <use>all</use>
+    </drive>
+  </partitioning>
 
-  operating_system:
-    distribution: opensuse_leap
-    distribution_major_version: 15
-    distribution_version: 15.1
+ep_operating_system:
+  distribution: opensuse_leap
+  distribution_major_version: 15
+  distribution_version: 15.1
 
-  equipment_type: server
+ep_equipment_type: server
 

--- a/resources/examples/equipment_profils/ubuntu_18.yml
+++ b/resources/examples/equipment_profils/ubuntu_18.yml
@@ -1,15 +1,15 @@
-equipment_profile:
+---
 
-  partitioning: |
-    d-i partman-auto/disk string /dev/sda
-    d-i partman-auto/method string regular
-    d-i partman-auto/choose_recipe select atomic
-    d-i partman-auto/init_automatically_partition select Guided - use entire disk
+ep_partitioning: |
+  d-i partman-auto/disk string /dev/sda
+  d-i partman-auto/method string regular
+  d-i partman-auto/choose_recipe select atomic
+  d-i partman-auto/init_automatically_partition select Guided - use entire disk
 
-  operating_system:
-    distribution: ubuntu
-    distribution_major_version: 18
-    distribution_version: 18.04
+ep_operating_system:
+  distribution: ubuntu
+  distribution_major_version: 18
+  distribution_version: 18.04
 
-  equipment_type: server
+ep_equipment_type: server
 

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/equipment_all/authentication.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/equipment_all/authentication.yml
@@ -1,8 +1,8 @@
-authentication:
-  # Root password to be used on deployed hosts
-  root_password_sha512: $6$M3crarMVoUV3rALd$ZTre2CIyss7zOb4lkLoG23As9OAkYPw2BM88Y1F43n8CCyV5XWwAYEwBOrS8bcCBIMjIPdJG.ndOfzWyAVR4j0 # This password is 'root', change it!
+---
+# Root password to be used on deployed hosts
+authentication_root_password_sha512: $6$M3crarMVoUV3rALd$ZTre2CIyss7zOb4lkLoG23As9OAkYPw2BM88Y1F43n8CCyV5XWwAYEwBOrS8bcCBIMjIPdJG.ndOfzWyAVR4j0 # This password is 'root', change it!
 
-  # SSH public keys to be added as authorized keys on deployed/managed hosts
-  ssh_keys:
-    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDodjKUXHm1K7HkQ8rgyXDfOAW9wvWHz24+YpkNGO0wI/jS0E44F4pdfNSqUWfLfBwwyiJ/+iLQAcJZjrQ1CnECNtImpHNRuMVH6shXX99oYRDOfJ8/MV89zrAe/KDUR677/j1dHYIS1fGzOzsxey00n+2c4LqxiFvwEIOGkB6W96aIQTx+V7eTxMegYrNttlh9eSR8yr8n4+0qk29wVVvtMysEUIt1z12dtqOr7lBuXhOy9EIUz+EZpPyXFrJiNBaKFpZBJXjzzRwR0uplyH5qf3tb3vgIxgHDPKiYRIOf3Caa9XAgmE1BU+R36wvLoS2z58ELQekJeO5z7TpsxXeB root@localhost.localdomain
+# SSH public keys to be added as authorized keys on deployed/managed hosts
+authentication_ssh_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDodjKUXHm1K7HkQ8rgyXDfOAW9wvWHz24+YpkNGO0wI/jS0E44F4pdfNSqUWfLfBwwyiJ/+iLQAcJZjrQ1CnECNtImpHNRuMVH6shXX99oYRDOfJ8/MV89zrAe/KDUR677/j1dHYIS1fGzOzsxey00n+2c4LqxiFvwEIOGkB6W96aIQTx+V7eTxMegYrNttlh9eSR8yr8n4+0qk29wVVvtMysEUIt1z12dtqOr7lBuXhOy9EIUz+EZpPyXFrJiNBaKFpZBJXjzzRwR0uplyH5qf3tb3vgIxgHDPKiYRIOf3Caa9XAgmE1BU+R36wvLoS2z58ELQekJeO5z7TpsxXeB root@localhost.localdomain
 

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/equipment_all/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/equipment_all/equipment_profile.yml
@@ -1,51 +1,51 @@
-equipment_profile:
+---
 
-  # iPXE network driver
-  # default should be good for most of NIC, but some need SNP. Refer to http://ipxe.org/appnote/buildtargets for more information.
-  ipxe_driver: default # default or snp or snponly
-  ipxe_platform: pcbios # can be pcbios (for legacy/bios) or efi
-  ipxe_embed: standard # can be standard or dhcpretry
+# iPXE network driver
+# default should be good for most of NIC, but some need SNP. Refer to http://ipxe.org/appnote/buildtargets for more information.
+ep_ipxe_driver: default # default or snp or snponly
+ep_ipxe_platform: pcbios # can be pcbios (for legacy/bios) or efi
+ep_ipxe_embed: standard # can be standard or dhcpretry
 
-  # When installing in EFI, grub2 break the boot order and set next boot to disk (seriously, why??!)
-  # In most case, you prefer system to continue to boot on PXE, and so the stack can restore first boot device after grub2 installation
-  preserve_efi_first_boot_device: true # true or false
+# When installing in EFI, grub2 break the boot order and set next boot to disk (seriously, why??!)
+# In most case, you prefer system to continue to boot on PXE, and so the stack can restore first boot device after grub2 installation
+ep_preserve_efi_first_boot_device: true # true or false
 
-  console:
-  kernel_parameters:
+ep_console:
+ep_kernel_parameters:
 
-  access_control: enforcing # Selinux, AppArmor, etc. Selinux: enforcing, permissive, disabled
-  firewall: true # Enable or disable native firewall
+ep_access_control: enforcing # Selinux, AppArmor, etc. Selinux: enforcing, permissive, disabled
+ep_firewall: true # Enable or disable native firewall
 
-  partitioning: | # Please provide native distribution partitioning. This example is for Centos/RedHat systems.
-    clearpart --all --initlabel
-    autopart --type=plain --fstype=ext4 --nohome
+ep_partitioning: | # Please provide native distribution partitioning. This example is for Centos/RedHat systems.
+  clearpart --all --initlabel
+  autopart --type=plain --fstype=ext4 --nohome
 
-  autoinstall_pre_script: # Add optional pre script in auto installer file (kickstart, preseed, autoyast)
-  autoinstall_post_script: # Add optional post script in auto installer file (kickstart, preseed, autoyast)
+ep_autoinstall_pre_script: # Add optional pre script in auto installer file (kickstart, preseed, autoyast)
+ep_autoinstall_post_script: # Add optional post script in auto installer file (kickstart, preseed, autoyast)
 
-  operating_system:
-    distribution: centos # centos, redhat, debian, ubuntu, opensuse, etc.
-    distribution_major_version: 8
-    # Optional: define a minor distribution version to force (repositories/PXE)
-    #distribution_version: 8.0
-    # Optional: add an environment in the repositories path (eg. production, staging) (repositories/PXE)
-    #repositories_environment: production
+ep_operating_system:
+  distribution: centos # centos, redhat, debian, ubuntu, opensuse, etc.
+  distribution_major_version: 8
+  # Optional: define a minor distribution version to force (repositories/PXE)
+  #distribution_version: 8.0
+  # Optional: add an environment in the repositories path (eg. production, staging) (repositories/PXE)
+  #repositories_environment: production
 
-  equipment_type: none  # If server, a pxe profile will be generated
+ep_equipment_type: none  # If server, a pxe profile will be generated
 
-  configuration:
-    keyboard_layout: us # us, fr, etc.
-    system_language: en_US.UTF-8 # You should not update this if you want to google issues...
+ep_configuration:
+  keyboard_layout: us # us, fr, etc.
+  system_language: en_US.UTF-8 # You should not update this if you want to google issues...
 
-  hardware:
-    cpu:
-      architecture: x86_64 # Can be x86_64 or arm64
-      cores: 1             # Mainly for slurm, but optional. You can define here detailed information on the CPUs.
-      cores_per_socket: 1
-      sockets: 1
-      threads_per_core: 1
-    gpu:
+ep_hardware:
+  cpu:
+    architecture: x86_64 # Can be x86_64 or arm64
+    cores: 1             # Mainly for slurm, but optional. You can define here detailed information on the CPUs.
+    cores_per_socket: 1
+    sockets: 1
+    threads_per_core: 1
+  gpu:
 
-  equipment_authentication: # login/password for BMC, storage bay controller, switch, etc.
-    user: ADMIN
-    password: ADMIN
+ep_equipment_authentication: # login/password for BMC, storage bay controller, switch, etc.
+  user: ADMIN
+  password: ADMIN

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_typeC/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_typeC/equipment_profile.yml
@@ -1,42 +1,42 @@
-equipment_profile:
+---
 
-  ipxe_driver: default
-  ipxe_platform: pcbios
-  ipxe_embed: standard
-  preserve_efi_first_boot_device: true
+ep_ipxe_driver: default
+ep_ipxe_platform: pcbios
+ep_ipxe_embed: standard
+ep_preserve_efi_first_boot_device: true
 
-  console: console=tty0 console=ttyS1,115200n8
-  kernel_parameters: nomodeset
+ep_console: console=tty0 console=ttyS1,115200n8
+ep_kernel_parameters: nomodeset
 
-  access_control: disabled
-  firewall: false
+ep_access_control: disabled
+ep_firewall: false
 
-  partitioning: |
-    clearpart --all --initlabel
-    autopart --type=plain --fstype=ext4 --nohome
+ep_partitioning: |
+  clearpart --all --initlabel
+  autopart --type=plain --fstype=ext4 --nohome
 
-  autoinstall_pre_script:
-  autoinstall_post_script:
+ep_autoinstall_pre_script:
+ep_autoinstall_post_script:
 
-  operating_system:
-    distribution: centos
-    distribution_major_version: 8
+ep_operating_system:
+  distribution: centos
+  distribution_major_version: 8
 
-  equipment_type: server
+ep_equipment_type: server
 
-  configuration:
-    keyboard_layout: us
-    system_language: en_US.UTF-8
+ep_configuration:
+  keyboard_layout: us
+  system_language: en_US.UTF-8
 
-  hardware:
-    cpu:
-      architecture: x86_64
-      cores: 24
-      cores_per_socket: 12
-      sockets: 2
-      threads_per_core: 1
-    gpu:
+ep_hardware:
+  cpu:
+    architecture: x86_64
+    cores: 24
+    cores_per_socket: 12
+    sockets: 2
+    threads_per_core: 1
+  gpu:
 
-  equipment_authentication:
-    user: ADMIN
-    password: ADMIN
+ep_equipment_authentication:
+  user: ADMIN
+  password: ADMIN

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_typeL/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_typeL/equipment_profile.yml
@@ -1,42 +1,42 @@
-equipment_profile:
+---
 
-  ipxe_driver: default
-  ipxe_platform: pcbios
-  ipxe_embed: standard
-  preserve_efi_first_boot_device: true
+ep_ipxe_driver: default
+ep_ipxe_platform: pcbios
+ep_ipxe_embed: standard
+ep_preserve_efi_first_boot_device: true
 
-  console: console=tty0 console=ttyS1,115200n8
-  kernel_parameters:
+ep_console: console=tty0 console=ttyS1,115200n8
+ep_kernel_parameters:
 
-  access_control: enforcing
-  firewall: true
+ep_access_control: enforcing
+ep_firewall: true
 
-  partitioning: |
-    clearpart --all --initlabel
-    autopart --type=plain --fstype=ext4 --nohome
+ep_partitioning: |
+  clearpart --all --initlabel
+  autopart --type=plain --fstype=ext4 --nohome
 
-  autoinstall_pre_script:
-  autoinstall_post_script:
+ep_autoinstall_pre_script:
+ep_autoinstall_post_script:
 
-  operating_system:
-    distribution: centos
-    distribution_major_version: 8
+ep_operating_system:
+  distribution: centos
+  distribution_major_version: 8
 
-  equipment_type: server
+ep_equipment_type: server
 
-  configuration:
-    keyboard_layout: us
-    system_language: en_US.UTF-8
+ep_configuration:
+  keyboard_layout: us
+  system_language: en_US.UTF-8
 
-  hardware:
-    cpu:
-      architecture: x86_64
-      cores: 24
-      cores_per_socket: 12
-      sockets: 2
-      threads_per_core: 1
-    gpu:
+ep_hardware:
+  cpu:
+    architecture: x86_64
+    cores: 24
+    cores_per_socket: 12
+    sockets: 2
+    threads_per_core: 1
+  gpu:
 
-  equipment_authentication:
-    user: ADMIN
-    password: ADMIN
+ep_equipment_authentication:
+  user: ADMIN
+  password: ADMIN

--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_typeM/equipment_profile.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/equipment_typeM/equipment_profile.yml
@@ -1,44 +1,44 @@
-equipment_profile:
+---
 
-  ipxe_driver: default
-  ipxe_platform: pcbios
-  ipxe_embed: standard
-  preserve_efi_first_boot_device: true
+ep_ipxe_driver: default
+ep_ipxe_platform: pcbios
+ep_ipxe_embed: standard
+ep_preserve_efi_first_boot_device: true
 
-  console: console=tty0 console=ttyS1,115200n8
-  kernel_parameters:
+ep_console: console=tty0 console=ttyS1,115200n8
+ep_kernel_parameters:
 
-  access_control: enforcing
-  firewall: true
+ep_access_control: enforcing
+ep_firewall: true
 
-  partitioning: |
-    clearpart --all --initlabel
-    part /boot --fstype=ext4 --size=1024
-    part / --fstype=ext4 --size=60000
-    part /home --fstype=ext4 --size=4096 --grow
+ep_partitioning: |
+  clearpart --all --initlabel
+  part /boot --fstype=ext4 --size=1024
+  part / --fstype=ext4 --size=60000
+  part /home --fstype=ext4 --size=4096 --grow
 
-  autoinstall_pre_script:
-  autoinstall_post_script:
+ep_autoinstall_pre_script:
+ep_autoinstall_post_script:
 
-  operating_system:
-    distribution: centos
-    distribution_major_version: 8
+ep_operating_system:
+  distribution: centos
+  distribution_major_version: 8
 
-  equipment_type: server
+ep_equipment_type: server
 
-  configuration:
-    keyboard_layout: us
-    system_language: en_US.UTF-8
+ep_configuration:
+  keyboard_layout: us
+  system_language: en_US.UTF-8
 
-  hardware:
-    cpu:
-      architecture: x86_64
-      cores: 8
-      cores_per_socket: 4
-      sockets: 1
-      threads_per_core: 2
-    gpu:
+ep_hardware:
+  cpu:
+    architecture: x86_64
+    cores: 8
+    cores_per_socket: 4
+    sockets: 1
+    threads_per_core: 2
+  gpu:
 
-  equipment_authentication:
-    user: ADMIN
-    password: ADMIN
+ep_equipment_authentication:
+  user: ADMIN
+  password: ADMIN

--- a/resources/examples/simple_cluster/inventory/group_vars/all/equipment_all/authentication.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/equipment_all/authentication.yml
@@ -1,7 +1,7 @@
-authentication:
-  # Root password to be used on deployed hosts
-  root_password_sha512: $6$M3crarMVoUV3rALd$ZTre2CIyss7zOb4lkLoG23As9OAkYPw2BM88Y1F43n8CCyV5XWwAYEwBOrS8bcCBIMjIPdJG.ndOfzWyAVR4j0 # This password is 'root', change it!
+---
+# Root password to be used on deployed hosts
+authentication_root_password_sha512: $6$M3crarMVoUV3rALd$ZTre2CIyss7zOb4lkLoG23As9OAkYPw2BM88Y1F43n8CCyV5XWwAYEwBOrS8bcCBIMjIPdJG.ndOfzWyAVR4j0 # This password is 'root', change it!
 
-  # SSH public keys to be added as authorized keys on deployed/managed hosts
-  ssh_keys:
-    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDodjKUXHm1K7HkQ8rgyXDfOAW9wvWHz24+YpkNGO0wI/jS0E44F4pdfNSqUWfLfBwwyiJ/+iLQAcJZjrQ1CnECNtImpHNRuMVH6shXX99oYRDOfJ8/MV89zrAe/KDUR677/j1dHYIS1fGzOzsxey00n+2c4LqxiFvwEIOGkB6W96aIQTx+V7eTxMegYrNttlh9eSR8yr8n4+0qk29wVVvtMysEUIt1z12dtqOr7lBuXhOy9EIUz+EZpPyXFrJiNBaKFpZBJXjzzRwR0uplyH5qf3tb3vgIxgHDPKiYRIOf3Caa9XAgmE1BU+R36wvLoS2z58ELQekJeO5z7TpsxXeB root@localhost.localdomain
+# SSH public keys to be added as authorized keys on deployed/managed hosts
+authentication_ssh_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDodjKUXHm1K7HkQ8rgyXDfOAW9wvWHz24+YpkNGO0wI/jS0E44F4pdfNSqUWfLfBwwyiJ/+iLQAcJZjrQ1CnECNtImpHNRuMVH6shXX99oYRDOfJ8/MV89zrAe/KDUR677/j1dHYIS1fGzOzsxey00n+2c4LqxiFvwEIOGkB6W96aIQTx+V7eTxMegYrNttlh9eSR8yr8n4+0qk29wVVvtMysEUIt1z12dtqOr7lBuXhOy9EIUz+EZpPyXFrJiNBaKFpZBJXjzzRwR0uplyH5qf3tb3vgIxgHDPKiYRIOf3Caa9XAgmE1BU+R36wvLoS2z58ELQekJeO5z7TpsxXeB root@localhost.localdomain

--- a/resources/examples/simple_cluster/inventory/group_vars/all/equipment_all/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/equipment_all/equipment_profile.yml
@@ -1,51 +1,51 @@
-equipment_profile:
+---
 
-  # iPXE network driver
-  # default should be good for most of NIC, but some need SNP. Refer to http://ipxe.org/appnote/buildtargets for more information.
-  ipxe_driver: default # default or snp or snponly
-  ipxe_platform: pcbios # can be pcbios (for legacy/bios) or efi
-  ipxe_embed: standard # can be standard or dhcpretry
+# iPXE network driver
+# default should be good for most of NIC, but some need SNP. Refer to http://ipxe.org/appnote/buildtargets for more information.
+ep_ipxe_driver: default # default or snp or snponly
+ep_ipxe_platform: pcbios # can be pcbios (for legacy/bios) or efi
+ep_ipxe_embed: standard # can be standard or dhcpretry
 
-  # When installing in EFI, grub2 break the boot order and set next boot to disk (seriously, why??!)
-  # In most case, you prefer system to continue to boot on PXE, and so the stack can restore first boot device after grub2 installation
-  preserve_efi_first_boot_device: true # true or false
+# When installing in EFI, grub2 break the boot order and set next boot to disk (seriously, why??!)
+# In most case, you prefer system to continue to boot on PXE, and so the stack can restore first boot device after grub2 installation
+ep_preserve_efi_first_boot_device: true # true or false
 
-  console:
-  kernel_parameters:
+ep_console:
+ep_kernel_parameters:
 
-  access_control: enforcing # Selinux, AppArmor, etc. Selinux: enforcing, permissive, disabled
-  firewall: false # Enable or disable native firewall
+ep_access_control: enforcing # Selinux, AppArmor, etc. Selinux: enforcing, permissive, disabled
+ep_firewall: false # Enable or disable native firewall
 
-  partitioning: | # Please provide native distribution partitioning. This example is for Centos/RedHat systems.
-    clearpart --all --initlabel
-    autopart --type=plain --fstype=ext4 --nohome
+ep_partitioning: | # Please provide native distribution partitioning. This example is for Centos/RedHat systems.
+  clearpart --all --initlabel
+  autopart --type=plain --fstype=ext4 --nohome
 
-  autoinstall_pre_script: # Add optional pre script in auto installer file (kickstart, preseed, autoyast)
-  autoinstall_post_script: # Add optional post script in auto installer file (kickstart, preseed, autoyast)
+ep_autoinstall_pre_script: # Add optional pre script in auto installer file (kickstart, preseed, autoyast)
+ep_autoinstall_post_script: # Add optional post script in auto installer file (kickstart, preseed, autoyast)
 
-  operating_system:
-    distribution: centos # centos, redhat, debian, ubuntu, opensuse, etc.
-    distribution_major_version: 8
-    # Optional: define a minor distribution version to force (repositories/PXE)
-    #distribution_version: 8.0
-    # Optional: add an environment in the repositories path (eg. production, staging) (repositories/PXE)
-    #repositories_environment: production
+ep_operating_system:
+  distribution: centos # centos, redhat, debian, ubuntu, opensuse, etc.
+  distribution_major_version: 8
+  # Optional: define a minor distribution version to force (repositories/PXE)
+  #distribution_version: 8.0
+  # Optional: add an environment in the repositories path (eg. production, staging) (repositories/PXE)
+  #repositories_environment: production
 
-  equipment_type: none  # If server, a pxe profile will be generated
+ep_equipment_type: none  # If server, a pxe profile will be generated
 
-  configuration:
-    keyboard_layout: us # us, fr, etc.
-    system_language: en_US.UTF-8 # You should not update this if you want to google issues...
+ep_configuration:
+  keyboard_layout: us # us, fr, etc.
+  system_language: en_US.UTF-8 # You should not update this if you want to google issues...
 
-  hardware:
-    cpu:
-      architecture: x86_64 # Can be x86_64 or arm64
-      cores: 1             # Mainly for slurm, but optional. You can define here detailed information on the CPUs.
-      cores_per_socket: 1
-      sockets: 1
-      threads_per_core: 1
-    gpu:
+ep_hardware:
+  cpu:
+    architecture: x86_64 # Can be x86_64 or arm64
+    cores: 1             # Mainly for slurm, but optional. You can define here detailed information on the CPUs.
+    cores_per_socket: 1
+    sockets: 1
+    threads_per_core: 1
+  gpu:
 
-  equipment_authentication: # login/password for BMC, storage bay controller, switch, etc.
-    user: ADMIN
-    password: ADMIN
+ep_equipment_authentication: # login/password for BMC, storage bay controller, switch, etc.
+  user: ADMIN
+  password: ADMIN

--- a/resources/examples/simple_cluster/inventory/group_vars/equipment_typeC/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/equipment_typeC/equipment_profile.yml
@@ -1,42 +1,42 @@
-equipment_profile:
+---
 
-  ipxe_driver: default
-  ipxe_platform: pcbios
-  ipxe_embed: standard
-  preserve_efi_first_boot_device: true
+ep_ipxe_driver: default
+ep_ipxe_platform: pcbios
+ep_ipxe_embed: standard
+ep_preserve_efi_first_boot_device: true
 
-  console: console=tty0 console=ttyS1,115200n8
-  kernel_parameters: nomodeset
+ep_console: console=tty0 console=ttyS1,115200n8
+ep_kernel_parameters: nomodeset
 
-  access_control: false
-  firewall: false
+ep_access_control: false
+ep_firewall: false
 
-  partitioning: |
-    clearpart --all --initlabel
-    autopart --type=plain --fstype=ext4 --nohome
+ep_partitioning: |
+  clearpart --all --initlabel
+  autopart --type=plain --fstype=ext4 --nohome
 
-  autoinstall_pre_script:
-  autoinstall_post_script:
+ep_autoinstall_pre_script:
+ep_autoinstall_post_script:
 
-  operating_system:
-    distribution: centos
-    distribution_major_version: 8
+ep_operating_system:
+  distribution: centos
+  distribution_major_version: 8
 
-  equipment_type: server
+ep_equipment_type: server
 
-  configuration:
-    keyboard_layout: us
-    system_language: en_US.UTF-8
+ep_configuration:
+  keyboard_layout: us
+  system_language: en_US.UTF-8
 
-  hardware:
-    cpu:
-      architecture: x86_64
-      cores: 24
-      cores_per_socket: 12
-      sockets: 2
-      threads_per_core: 1
-    gpu:
+ep_hardware:
+  cpu:
+    architecture: x86_64
+    cores: 24
+    cores_per_socket: 12
+    sockets: 2
+    threads_per_core: 1
+  gpu:
 
-  equipment_authentication:
-    user: ADMIN
-    password: ADMIN
+ep_equipment_authentication:
+  user: ADMIN
+  password: ADMIN

--- a/resources/examples/simple_cluster/inventory/group_vars/equipment_typeG/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/equipment_typeG/equipment_profile.yml
@@ -1,42 +1,42 @@
-equipment_profile:
+---
 
-  ipxe_driver: default
-  ipxe_platform: pcbios
-  ipxe_embed: standard
-  preserve_efi_first_boot_device: true
+ep_ipxe_driver: default
+ep_ipxe_platform: pcbios
+ep_ipxe_embed: standard
+ep_preserve_efi_first_boot_device: true
 
-  console: console=tty0 console=ttyS1,115200n8
-  kernel_parameters: nomodeset
+ep_console: console=tty0 console=ttyS1,115200n8
+ep_kernel_parameters: nomodeset
 
-  access_control: false
-  firewall: false
+ep_access_control: false
+ep_firewall: false
 
-  partitioning: |
-    clearpart --all --initlabel
-    autopart --type=plain --fstype=ext4 --nohome
+ep_partitioning: |
+  clearpart --all --initlabel
+  autopart --type=plain --fstype=ext4 --nohome
 
-  autoinstall_pre_script:
-  autoinstall_post_script:
+ep_autoinstall_pre_script:
+ep_autoinstall_post_script:
 
-  operating_system:
-    distribution: centos
-    distribution_major_version: 8
+ep_operating_system:
+  distribution: centos
+  distribution_major_version: 8
 
-  equipment_type: server
+ep_equipment_type: server
 
-  configuration:
-    keyboard_layout: us
-    system_language: en_US.UTF-8
+ep_configuration:
+  keyboard_layout: us
+  system_language: en_US.UTF-8
 
-  hardware:
-    cpu:
-      architecture: x86_64
-      cores: 24
-      cores_per_socket: 12
-      sockets: 2
-      threads_per_core: 1
-    gpu:
+ep_hardware:
+  cpu:
+    architecture: x86_64
+    cores: 24
+    cores_per_socket: 12
+    sockets: 2
+    threads_per_core: 1
+  gpu:
 
-  equipment_authentication:
-    user: ADMIN
-    password: ADMIN
+ep_equipment_authentication:
+  user: ADMIN
+  password: ADMIN

--- a/resources/examples/simple_cluster/inventory/group_vars/equipment_typeL/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/equipment_typeL/equipment_profile.yml
@@ -1,42 +1,42 @@
-equipment_profile:
+---
 
-  ipxe_driver: default
-  ipxe_platform: pcbios
-  ipxe_embed: standard
-  preserve_efi_first_boot_device: true
+ep_ipxe_driver: default
+ep_ipxe_platform: pcbios
+ep_ipxe_embed: standard
+ep_preserve_efi_first_boot_device: true
 
-  console: console=tty0 console=ttyS1,115200n8
-  kernel_parameters:
+ep_console: console=tty0 console=ttyS1,115200n8
+ep_kernel_parameters:
 
-  access_control: true
-  firewall: true
+ep_access_control: true
+ep_firewall: true
 
-  partitioning: |
-    clearpart --all --initlabel
-    autopart --type=plain --fstype=ext4 --nohome
+ep_partitioning: |
+  clearpart --all --initlabel
+  autopart --type=plain --fstype=ext4 --nohome
 
-  autoinstall_pre_script:
-  autoinstall_post_script:
+ep_autoinstall_pre_script:
+ep_autoinstall_post_script:
 
-  operating_system:
-    distribution: centos
-    distribution_major_version: 8
+ep_operating_system:
+  distribution: centos
+  distribution_major_version: 8
 
-  equipment_type: server
+ep_equipment_type: server
 
-  configuration:
-    keyboard_layout: us
-    system_language: en_US.UTF-8
+ep_configuration:
+  keyboard_layout: us
+  system_language: en_US.UTF-8
 
-  hardware:
-    cpu:
-      architecture: x86_64
-      cores: 24
-      cores_per_socket: 12
-      sockets: 2
-      threads_per_core: 1
-    gpu:
+ep_hardware:
+  cpu:
+    architecture: x86_64
+    cores: 24
+    cores_per_socket: 12
+    sockets: 2
+    threads_per_core: 1
+  gpu:
 
-  equipment_authentication:
-    user: ADMIN
-    password: ADMIN
+ep_equipment_authentication:
+  user: ADMIN
+  password: ADMIN

--- a/resources/examples/simple_cluster/inventory/group_vars/equipment_typeM/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/equipment_typeM/equipment_profile.yml
@@ -1,44 +1,44 @@
-equipment_profile:
+---
 
-  ipxe_driver: default
-  ipxe_platform: pcbios
-  ipxe_embed: standard
-  preserve_efi_first_boot_device: true
+ep_ipxe_driver: default
+ep_ipxe_platform: pcbios
+ep_ipxe_embed: standard
+ep_preserve_efi_first_boot_device: true
 
-  console: console=tty0 console=ttyS1,115200n8
-  kernel_parameters:
+ep_console: console=tty0 console=ttyS1,115200n8
+ep_kernel_parameters:
 
-  access_control: true
-  firewall: true
+ep_access_control: true
+ep_firewall: true
 
-  partitioning: |
-    clearpart --all --initlabel
-    part /boot --fstype=ext4 --size=1024
-    part / --fstype=ext4 --size=60000
-    part /home --fstype=ext4 --size=4096 --grow
+ep_partitioning: |
+  clearpart --all --initlabel
+  part /boot --fstype=ext4 --size=1024
+  part / --fstype=ext4 --size=60000
+  part /home --fstype=ext4 --size=4096 --grow
 
-  autoinstall_pre_script:
-  autoinstall_post_script:
+ep_autoinstall_pre_script:
+ep_autoinstall_post_script:
 
-  operating_system:
-    distribution: centos
-    distribution_major_version: 8
+ep_operating_system:
+  distribution: centos
+  distribution_major_version: 8
 
-  equipment_type: server
+ep_equipment_type: server
 
-  configuration:
-    keyboard_layout: us
-    system_language: en_US.UTF-8
+ep_configuration:
+  keyboard_layout: us
+  system_language: en_US.UTF-8
 
-  hardware:
-    cpu:
-      architecture: x86_64
-      cores: 8
-      cores_per_socket: 4
-      sockets: 1
-      threads_per_core: 2
-    gpu:
+ep_hardware:
+  cpu:
+    architecture: x86_64
+    cores: 8
+    cores_per_socket: 4
+    sockets: 1
+    threads_per_core: 2
+  gpu:
 
-  equipment_authentication:
-    user: ADMIN
-    password: ADMIN
+ep_equipment_authentication:
+  user: ADMIN
+  password: ADMIN

--- a/resources/examples/simple_cluster/inventory/group_vars/equipment_typeS/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/equipment_typeS/equipment_profile.yml
@@ -1,44 +1,44 @@
-equipment_profile:
+---
 
-  ipxe_driver: default
-  ipxe_platform: pcbios
-  ipxe_embed: standard
-  preserve_efi_first_boot_device: true
+ep_ipxe_driver: default
+ep_ipxe_platform: pcbios
+ep_ipxe_embed: standard
+ep_preserve_efi_first_boot_device: true
 
-  console: console=tty0 console=ttyS1,115200n8
-  kernel_parameters:
+ep_console: console=tty0 console=ttyS1,115200n8
+ep_kernel_parameters:
 
-  access_control: true
-  firewall: true
+ep_access_control: true
+ep_firewall: true
 
-  partitioning: |
-    clearpart --all --initlabel
-    part /boot --fstype=ext4 --size=1024
-    part / --fstype=ext4 --size=60000
-    part /home --fstype=ext4 --size=4096 --grow
+ep_partitioning: |
+  clearpart --all --initlabel
+  part /boot --fstype=ext4 --size=1024
+  part / --fstype=ext4 --size=60000
+  part /home --fstype=ext4 --size=4096 --grow
 
-  autoinstall_pre_script:
-  autoinstall_post_script:
+ep_autoinstall_pre_script:
+ep_autoinstall_post_script:
 
-  operating_system:
-    distribution: centos
-    distribution_major_version: 8
+ep_operating_system:
+  distribution: centos
+  distribution_major_version: 8
 
-  equipment_type: server
+ep_equipment_type: server
 
-  configuration:
-    keyboard_layout: us
-    system_language: en_US.UTF-8
+ep_configuration:
+  keyboard_layout: us
+  system_language: en_US.UTF-8
 
-  hardware:
-    cpu:
-      architecture: x86_64
-      cores: 8
-      cores_per_socket: 4
-      sockets: 1
-      threads_per_core: 2
-    gpu:
+ep_hardware:
+  cpu:
+    architecture: x86_64
+    cores: 8
+    cores_per_socket: 4
+    sockets: 1
+    threads_per_core: 2
+  gpu:
 
-  equipment_authentication:
-    user: ADMIN
-    password: ADMIN
+ep_equipment_authentication:
+  user: ADMIN
+  password: ADMIN

--- a/roles/addons/powerman/readme.rst
+++ b/roles/addons/powerman/readme.rst
@@ -28,9 +28,8 @@ Mandatory inventory vars:
 
 **hostvars[hosts]**
 
-* equipment_profile
-   * .equipment_authentication.user
-   * .equipment_authentication.password
+* ep_equipment_authentication.user
+* ep_equipment_authentication.password
 * bmc
    * .name
    * .ip4

--- a/roles/addons/powerman/templates/powerman.conf.j2
+++ b/roles/addons/powerman/templates/powerman.conf.j2
@@ -26,7 +26,7 @@ include "/etc/powerman/ipmipower.dev"
     {% endif %}
   {% endfor %}
   {% if hosts | length > 0 %}
-device "{{ equipment }}" "ipmipower" "/usr/sbin/ipmipower --wait-until-on --wait-until-off -h {{ bmcs|join(',') }} -u {{ hostvars[hosts[0]]['equipment_profile']['equipment_authentication']['user'] }} -p {{ hostvars[hosts[0]]['equipment_profile']['equipment_authentication']['password'] }} |&"
+device "{{ equipment }}" "ipmipower" "/usr/sbin/ipmipower --wait-until-on --wait-until-off -h {{ bmcs|join(',') }} -u {{ hostvars[hosts[0]]['ep_equipment_authentication']['user'] }} -p {{ hostvars[hosts[0]]['ep_equipment_authentication']['password'] }} |&"
 node "{{ hosts|join(',') }}" "{{ equipment }}" "{{ bmcs|join(',') }}"
   {% endif %}
 {% endfor %}

--- a/roles/addons/prometheus_server/templates/ipmi_config.yml.j2
+++ b/roles/addons/prometheus_server/templates/ipmi_config.yml.j2
@@ -6,8 +6,8 @@ modules:
 {% if hostvars[groups[equipment][0]]['monitoring'] is defined and hostvars[groups[equipment][0]]['monitoring'] is not none and hostvars[groups[equipment][0]]['monitoring']['exporters'] is defined and hostvars[groups[equipment][0]]['monitoring']['exporters'] is not none and hostvars[groups[equipment][0]]['monitoring']['exporters'] is iterable and "ipmi_exporter" in hostvars[groups[equipment][0]]['monitoring']['exporters'] %}
 
   {{equipment}}:
-    user: {{hostvars[groups[equipment][0]]['equipment_profile']['equipment_authentication']['user']}}
-    pass: {{hostvars[groups[equipment][0]]['equipment_profile']['equipment_authentication']['password']}}
+    user: {{hostvars[groups[equipment][0]]['ep_equipment_authentication']['user']}}
+    pass: {{hostvars[groups[equipment][0]]['ep_equipment_authentication']['password']}}
     driver: "LAN_2_0"
     privilege: "user"
     timeout: 10000

--- a/roles/addons/report/templates/equipment_profiles.html.j2
+++ b/roles/addons/report/templates/equipment_profiles.html.j2
@@ -7,42 +7,42 @@
 
   <li class="rotate">PXE:</li>
   <ul class="lvl2">
-    <li>iPXE driver:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['ipxe_driver']}}</span></li>
-    <li>iPXE platform:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['ipxe_platform']}}</span></li>
-    <li>iPXE embed script:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['ipxe_embed']}}</span></li>
-    <li>Preserve EFI first boot device during OS deployment:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['preserve_efi_first_boot_device']}}</span></li>
+    <li>iPXE driver:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_ipxe_driver']}}</span></li>
+    <li>iPXE platform:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_ipxe_platform']}}</span></li>
+    <li>iPXE embed script:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_ipxe_embed']}}</span></li>
+    <li>Preserve EFI first boot device during OS deployment:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_preserve_efi_first_boot_device']}}</span></li>
   </ul>
 
   <li class="rotate">Security:</li>
   <ul class="lvl2">
-    <li>Access Control:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['access_control']}}</span></li>
-    <li>Firewall:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['firewall']}}</span></li>
+    <li>Access Control:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_access_control']}}</span></li>
+    <li>Firewall:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_firewall']}}</span></li>
   </ul>
 
   <li class="rotate">Operating system configuration:</li>
   <ul class="lvl2">
-    <li>Distribution:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['operating_system']['distribution']}}</span></li>
-    <li>Distribution major version:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['operating_system']['distribution_major_version']}}</span></li>
-    <li>Distribution version:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['operating_system']['distribution_version']}}</span></li>
-    <li>Partitioning:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['partitioning']}}</span></li>
-    <li>System language:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['configuration']['system_language']}}</span></li>
-    <li>Keyboard Layout:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['configuration']['keyboard_layout']}}</span></li>
+    <li>Distribution:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_operating_system']['distribution']}}</span></li>
+    <li>Distribution major version:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_operating_system']['distribution_major_version']}}</span></li>
+    <li>Distribution version:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_operating_system']['distribution_version']}}</span></li>
+    <li>Partitioning:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_partitioning']}}</span></li>
+    <li>System language:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_configuration']['system_language']}}</span></li>
+    <li>Keyboard Layout:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_configuration']['keyboard_layout']}}</span></li>
   </ul>
 
   <li class="rotate">Hardware:</li>
   <ul class="lvl2">
-    <li>CPU architecture:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['hardware']['cpu']['architecture']}}</span></li>
-    <li>CPU count:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['hardware']['cpu']['sockets']}} Sockets, {{hostvars[groups[equipment][0]]['equipment_profile']['hardware']['cpu']['cores_per_socket']}} Cores per socket, {{hostvars[groups[equipment][0]]['equipment_profile']['hardware']['cpu']['threads_per_core']}} Threads per core, for a total of {{hostvars[groups[equipment][0]]['equipment_profile']['hardware']['cpu']['cores']}} Cores</span></li>
+    <li>CPU architecture:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_hardware']['cpu']['architecture']}}</span></li>
+    <li>CPU count:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_hardware']['cpu']['sockets']}} Sockets, {{hostvars[groups[equipment][0]]['ep_hardware']['cpu']['cores_per_socket']}} Cores per socket, {{hostvars[groups[equipment][0]]['ep_hardware']['cpu']['threads_per_core']}} Threads per core, for a total of {{hostvars[groups[equipment][0]]['ep_hardware']['cpu']['cores']}} Cores</span></li>
   </ul>
 
   <li class="rotate">Equipment authentication:</li>
   <ul class="lvl2">
-    <li>Hardware user:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['equipment_authentication']['user']}}</span></li>
-    <li>Hardware password:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['equipment_profile']['equipment_authentication']['password']}}</span></li>
-    <li>OS root hash:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['authentication']['root_password_sha512']}}</span></li>
+    <li>Hardware user:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_equipment_authentication']['user']}}</span></li>
+    <li>Hardware password:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_equipment_authentication']['password']}}</span></li>
+    <li>OS root hash:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['authentication_root_password_sha512']}}</span></li>
     <li class="rotate">SSH public keys:</li>
     <ul class="lvl3">
-    {% for sshkey in hostvars[groups[equipment][0]]['authentication']['ssh_keys'] %}
+    {% for sshkey in hostvars[groups[equipment][0]]['authentication_ssh_keys'] %}
        <li><span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;">{{sshkey}}</span></li>
     {% endfor %}
     </ul>

--- a/roles/addons/root_password/molecule/default/molecule.yml
+++ b/roles/addons/root_password/molecule/default/molecule.yml
@@ -17,9 +17,8 @@ provisioner:
   inventory:
     host_vars:
       instance:
-        authentication:
-          # password: root
-          # FIXME: https://github.com/ansible-community/molecule/issues/993
-          root_password_sha512: "{{ lookup('file', 'password_hash') }}"
+        # password: root
+        # FIXME: https://github.com/ansible-community/molecule/issues/993
+        authentication_root_password_sha512: "{{ lookup('file', 'password_hash') }}"
 verifier:
   name: ansible

--- a/roles/addons/root_password/readme.rst
+++ b/roles/addons/root_password/readme.rst
@@ -13,8 +13,7 @@ The root password must be defined in the inventory:
 
 .. code-block:: yaml
 
-  authentication:
-    root_password_sha512: $6$M3crarMVoUV3rALd$ZTre2CIyss7zOb4lkLoG23As9OAkYPw2BM88Y1F43n8CCyV5XWwAYEwBOrS8bcCBIMjIPdJG.ndOfzWyAVR4j0
+  authentication_root_password_sha512: $6$M3crarMVoUV3rALd$ZTre2CIyss7zOb4lkLoG23As9OAkYPw2BM88Y1F43n8CCyV5XWwAYEwBOrS8bcCBIMjIPdJG.ndOfzWyAVR4j0
 
 To generate an sha512 password, use the following command (python >3.3):
 
@@ -29,7 +28,7 @@ Mandatory inventory vars:
 
 **hostvars[inventory_hostname]**
 
-* authentication.root_password_sha512
+* authentication_root_password_sha512
 
 Changelog
 ^^^^^^^^^

--- a/roles/addons/root_password/tasks/main.yml
+++ b/roles/addons/root_password/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: user █ Set root password
   user:
     name: root
-    password: "{{ authentication.root_password_sha512 }}"
+    password: "{{ authentication_root_password_sha512 }}"

--- a/roles/addons/slurm/templates/slurm.conf.j2
+++ b/roles/addons/slurm/templates/slurm.conf.j2
@@ -46,7 +46,7 @@ SelectType=select/cons_res
 {% for equipment_group in slurm['nodes_equipment_groups'] %}
 {% if groups[equipment_group] is defined and not none %}
 {% for node in groups[equipment_group] %}
-NodeName={{node}} Procs={{hostvars[node]['equipment_profile']['hardware']['cpu']['cores']}} State=UNKNOWN
+NodeName={{node}} Procs={{hostvars[node]['ep_hardware']['cpu']['cores']}} State=UNKNOWN
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/roles/advanced-core/advanced_dhcp_server/tasks/main.yml
+++ b/roles/advanced-core/advanced_dhcp_server/tasks/main.yml
@@ -28,7 +28,7 @@
     state: enabled
   when:
     - ansible_facts.os_family == "RedHat"
-    - equipment_profile['firewall'] | default(false) | bool
+    - ep_firewall | default(false) | bool
   loop: "{{ advanced_dhcp_server_firewall_services_to_add }}"
   tags:
     - firewall

--- a/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
+++ b/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
@@ -16,24 +16,24 @@
 {% for host in range %}
   {% if hostvars[host]['network_interfaces'] is defined and hostvars[host]['network_interfaces'] is iterable %}
     {#- Define iPXE rom to use #}
-    {% if hostvars[host]['equipment_profile']['ipxe_driver'] == 'snponly' %} {# Select driver first #}
+    {% if hostvars[host]['ep_ipxe_driver'] == 'snponly' %} {# Select driver first #}
       {% set ipxe_driver = 'snponly_' %}
-    {% elif hostvars[host]['equipment_profile']['ipxe_driver'] == 'snp' %}
+    {% elif hostvars[host]['ep_ipxe_driver'] == 'snp' %}
       {% set ipxe_driver = 'snp_' %}
     {% else %}{# Assume everything else is default driver #}
       {% set ipxe_driver = '' %}
     {% endif %}
-    {% if hostvars[host]['equipment_profile']['hardware']['cpu']['architecture'] == 'arm64' %} {# Now select architecture #}
+    {% if hostvars[host]['ep_hardware']['cpu']['architecture'] == 'arm64' %} {# Now select architecture #}
       {% set ipxe_architecture = 'arm64' %}
     {% else %}{# Assume everything else is x86_64 #}
       {% set ipxe_architecture = 'x86_64' %}
     {% endif %}
-    {% if hostvars[host]['equipment_profile']['ipxe_embed'] == 'dhcpretry' %} {# Now select embed script #}
+    {% if hostvars[host]['ep_ipxe_embed'] == 'dhcpretry' %} {# Now select embed script #}
       {% set ipxe_embed = 'dhcpretry' %}
     {% else %}
       {% set ipxe_embed = 'standard' %}
     {% endif %}
-    {% if hostvars[host]['equipment_profile']['ipxe_platform'] == 'efi' %} {# Finally, build file name depending of platform and previous parameters #}
+    {% if hostvars[host]['ep_ipxe_platform'] == 'efi' %} {# Finally, build file name depending of platform and previous parameters #}
       {% set ipxe_rom_filename = (ipxe_architecture + '/' + ipxe_embed + '_' + ipxe_driver + 'ipxe.efi') %}
     {% else %}{# Assume everything else is pcbios #}
       {% set ipxe_rom_filename = (ipxe_architecture + '/' + ipxe_embed + '_undionly.kpxe') %}

--- a/roles/advanced-core/advanced_dns_server/tasks/main.yml
+++ b/roles/advanced-core/advanced_dns_server/tasks/main.yml
@@ -30,7 +30,7 @@
     state: enabled
   when:
     - ansible_facts.os_family == "RedHat"
-    - equipment_profile['firewall'] | default(false) | bool
+    - ep_firewall | default(false) | bool
   loop: "{{ dns_server_firewall_services_to_add }}"
   tags:
     - firewall

--- a/roles/core/access_control/readme.rst
+++ b/roles/core/access_control/readme.rst
@@ -5,7 +5,7 @@ Description
 ^^^^^^^^^^^
 
 This role ensure the node current status comply with
-equipment_profile.access_control variable.
+ep_access_control variable.
 
 Instructions
 ^^^^^^^^^^^^
@@ -17,7 +17,7 @@ Input
 
 **hostvars[inventory_hostname]**
 
-* equipment_profile.access_control
+* ep_access_control
 
 Output
 ^^^^^^

--- a/roles/core/access_control/tasks/redhat_8.yml
+++ b/roles/core/access_control/tasks/redhat_8.yml
@@ -2,4 +2,4 @@
 - name: selinux █ Set SELinux state
   selinux:
     policy: targeted
-    state: "{{ equipment_profile.access_control | default('enforcing') }}"
+    state: "{{ ep_access_control | default('enforcing') }}"

--- a/roles/core/conman/molecule/default/molecule.yml
+++ b/roles/core/conman/molecule/default/molecule.yml
@@ -24,11 +24,10 @@ provisioner:
         icebergs_system: false
         enable_services: true
         start_services: true
-        equipment_profile:
-          equipment_type: server
-          equipment_authentication:
-            user: 'ADMIN'
-            password: 'ADMIN'
+        ep_equipment_type: server
+        ep_equipment_authentication:
+          user: 'ADMIN'
+          password: 'ADMIN'
         bmc:
           ip4: 10.10.102.1
           mac: 08:00:27:dc:f8:a7

--- a/roles/core/conman/readme.rst
+++ b/roles/core/conman/readme.rst
@@ -28,10 +28,9 @@ Mandatory inventory vars:
 
 **hostvars[hosts]**
 
-* equipment_profile
-   * .equipment_type (triggers if == "server")
-   * .equipment_authentication.user
-   * .equipment_authentication.password
+* ep_equipment_type (triggers if == "server")
+* ep_equipment_authentication.user
+* ep_equipment_authentication.password
 * bmc
    * .ip4
 

--- a/roles/core/conman/templates/conman.conf.j2
+++ b/roles/core/conman/templates/conman.conf.j2
@@ -22,9 +22,9 @@ GLOBAL logopts="timestamp"
 {% endif %}
 
 {% for host in range %}
-  {% if hostvars[host]['equipment_profile']['equipment_type'] == "server" %}
+  {% if hostvars[host]['ep_equipment_type'] == "server" %}
     {% if hostvars[host]['bmc'] is defined and hostvars[host]['bmc'] is not none and hostvars[host]['bmc']['ip4'] is defined and hostvars[host]['bmc']['ip4'] is not none %}
-console name="{{ host }}" dev="ipmitool.exp {{ hostvars[host]['bmc']['ip4'] }} {{ hostvars[host]['equipment_profile']['equipment_authentication']['user'] }} {{ hostvars[host]['equipment_profile']['equipment_authentication']['password'] }}"
+console name="{{ host }}" dev="ipmitool.exp {{ hostvars[host]['bmc']['ip4'] }} {{ hostvars[host]['ep_equipment_authentication']['user'] }} {{ hostvars[host]['ep_equipment_authentication']['password'] }}"
     {% endif %}
   {% endif %}
 {% endfor %}

--- a/roles/core/dhcp_server/tasks/main.yml
+++ b/roles/core/dhcp_server/tasks/main.yml
@@ -30,7 +30,7 @@
     state: enabled
   when:
     - ansible_facts.os_family == "RedHat"
-    - equipment_profile['firewall'] | default(false) | bool
+    - ep_firewall | default(false) | bool
   loop: "{{ dhcp_server_firewall_services_to_add }}"
   tags:
     - firewall

--- a/roles/core/dns_server/tasks/main.yml
+++ b/roles/core/dns_server/tasks/main.yml
@@ -30,7 +30,7 @@
     state: enabled
   when:
     - ansible_facts.os_family == "RedHat"
-    - equipment_profile['firewall'] | default(false) | bool
+    - ep_firewall | default(false) | bool
   loop: "{{ dns_server_firewall_services_to_add }}"
   tags:
     - firewall

--- a/roles/core/firewall/molecule/default/molecule.yml
+++ b/roles/core/firewall/molecule/default/molecule.yml
@@ -36,8 +36,7 @@ provisioner:
   inventory:
     group_vars:
       firewall:
-        equipment_profile:
-          firewall: true
+        ep_firewall: true
     host_vars:
       firewall-stock:
         network_interfaces:

--- a/roles/core/firewall/molecule/default/molecule.yml
+++ b/roles/core/firewall/molecule/default/molecule.yml
@@ -61,29 +61,28 @@ provisioner:
           - interface: ib0
             ip4: 10.21.0.2
             network: interconnect1
-        firewall:
-          zones:
-            - zone: internal
-              services_enabled:
-                - high-availability
-                - rsyncd
-              services_disabled:
-                - cockpit
-                - samba-client
-              ports_enabled:
-                - 1234/tcp
-              ports_disabled:
-                - 5678/tcp
-              rich_rules_enabled:
-                - 'rule family="ipv4" forward-port port="443" protocol="tcp" to-port="8443"'
-              rich_rules_disabled:
-                - 'rule service name="ftp" audit limit value="1/m" accept'
-              icmp_blocks_enabled:
-                - echo-request
-              icmp_block_inversion: no
-              masquerade: yes
-            - zone: public
-              services_disabled:
-                - cockpit
+        firewall_zones:
+          - zone: internal
+            services_enabled:
+              - high-availability
+              - rsyncd
+            services_disabled:
+              - cockpit
+              - samba-client
+            ports_enabled:
+              - 1234/tcp
+            ports_disabled:
+              - 5678/tcp
+            rich_rules_enabled:
+              - 'rule family="ipv4" forward-port port="443" protocol="tcp" to-port="8443"'
+            rich_rules_disabled:
+              - 'rule service name="ftp" audit limit value="1/m" accept'
+            icmp_blocks_enabled:
+              - echo-request
+            icmp_block_inversion: no
+            masquerade: yes
+          - zone: public
+            services_disabled:
+              - cockpit
 verifier:
   name: ansible

--- a/roles/core/firewall/readme.rst
+++ b/roles/core/firewall/readme.rst
@@ -45,37 +45,35 @@ To add a network of the host to a zone, define the zone name in
 
 
 To add or delete custom services that are not handled by any other role, define
-the `firewall.zones` parameter as below:
+the `firewall_zones` parameter as below:
 
 .. code-block:: yaml
 
-  firewall:
-    zones:
-      - zone: internal            <<< zone name
-        services_enabled:         <<< list of service to enable
-          - high-availability
-          - prometheus
-        services_disabled:        <<< list of service to disable
-          - cockpit
+  firewall_zones:
+    - zone: internal            <<< zone name
+      services_enabled:         <<< list of service to enable
+        - high-availability
+        - prometheus
+      services_disabled:        <<< list of service to disable
+        - cockpit
 
 It is possible to add or delete custom ports and rich rules with the same
 parameter:
 
 .. code-block:: yaml
 
-  firewall:
-    zones:
-      - zone: internal            <<< zone name
-        ports_enabled:            <<< list of ports to enable
-          - 1234/tcp
-        ports_disabled:           <<< list of ports to disable
-          - 5678/tcp
-        rich_rules_enabled:       <<< list of rich rules to enable
-          - "rule family=ipv4 forward-port port=443 protocol=tcp to-port=8443"
-        rich_rules_disabled:      <<< list of rich rules to disable
-          - 'rule service name="ftp" audit limit value="1/m" accept'
-        icmp_block_inversion: yes
-        masquerade: yes
+  firewall_zones:
+    - zone: internal            <<< zone name
+      ports_enabled:            <<< list of ports to enable
+        - 1234/tcp
+      ports_disabled:           <<< list of ports to disable
+        - 5678/tcp
+      rich_rules_enabled:       <<< list of rich rules to enable
+        - "rule family=ipv4 forward-port port=443 protocol=tcp to-port=8443"
+      rich_rules_disabled:      <<< list of rich rules to disable
+        - 'rule service name="ftp" audit limit value="1/m" accept'
+      icmp_block_inversion: yes
+      masquerade: yes
 
 
 **Integration with other roles**
@@ -110,19 +108,18 @@ Optional inventory vars:
 
 **hostvars[inventory_hostname]**
 
-* firewall
-   * zones
-      * zone
-      * services_enabled     (list)
-      * services_disabled    (list)
-      * ports_enabled        (list)
-      * ports_disabled       (list)
-      * rich_rules_enabled   (list)
-      * rich_rules_disabled  (list)
-      * icmp_blocks_enabled  (list)
-      * icmp_blocks_disabled (list)
-      * icmp_block_inversion (bool)
-      * masquerade           (bool)
+* firewall_zones
+    * zone
+    * services_enabled     (list)
+    * services_disabled    (list)
+    * ports_enabled        (list)
+    * ports_disabled       (list)
+    * rich_rules_enabled   (list)
+    * rich_rules_disabled  (list)
+    * icmp_blocks_enabled  (list)
+    * icmp_blocks_disabled (list)
+    * icmp_block_inversion (bool)
+    * masquerade           (bool)
 
 Output
 ^^^^^^

--- a/roles/core/firewall/readme.rst
+++ b/roles/core/firewall/readme.rst
@@ -20,8 +20,7 @@ Enable or disable the firewall service in the equipment profile:
 
 .. code-block:: yaml
 
-  equipment_profile:
-    firewall: true
+  ep_firewall: true
 
 To add a network of the host to a zone, define the zone name in
 **firewall.zone** in the network:
@@ -94,8 +93,7 @@ Mandatory inventory vars:
 
 **hostvars[inventory_hostname]**
 
-* equipment_profile
-   * .firewall
+* ep_firewall
 * network[item]
    * .subnet
    * .prefix

--- a/roles/core/firewall/tasks/RedHat.yml
+++ b/roles/core/firewall/tasks/RedHat.yml
@@ -30,7 +30,7 @@
     immediate: "yes"
     permanent: "yes"
     state: enabled
-  loop: "{{ firewall.zones | default({}) | subelements('services_enabled', skip_missing=True) }}"
+  loop: "{{ firewall_zones | default({}) | subelements('services_enabled', skip_missing=True) }}"
   loop_control:
     label: "Add service {{ item.1 }} to zone {{ item.0.zone }}"
 
@@ -41,7 +41,7 @@
     immediate: "yes"
     permanent: "yes"
     state: disabled
-  loop: "{{ firewall.zones | default({}) | subelements('services_disabled', skip_missing=True) }}"
+  loop: "{{ firewall_zones | default({}) | subelements('services_disabled', skip_missing=True) }}"
   loop_control:
     label: "Remove service {{ item.1 }} from zone {{ item.0.zone }}"
 
@@ -52,7 +52,7 @@
     immediate: "yes"
     permanent: "yes"
     state: enabled
-  loop: "{{ firewall.zones | default({}) | subelements('ports_enabled', skip_missing=True) }}"
+  loop: "{{ firewall_zones | default({}) | subelements('ports_enabled', skip_missing=True) }}"
   loop_control:
     label: "Add port {{ item.1 }} to zone {{ item.0.zone }}"
 
@@ -63,7 +63,7 @@
     immediate: "yes"
     permanent: "yes"
     state: disabled
-  loop: "{{ firewall.zones | default({}) | subelements('ports_disabled', skip_missing=True) }}"
+  loop: "{{ firewall_zones | default({}) | subelements('ports_disabled', skip_missing=True) }}"
   loop_control:
     label: "Remove port {{ item.1 }} from zone {{ item.0.zone }}"
 
@@ -74,7 +74,7 @@
     immediate: "yes"
     permanent: "yes"
     state: enabled
-  loop: "{{ firewall.zones | default({}) | subelements('rich_rules_enabled', skip_missing=True) }}"
+  loop: "{{ firewall_zones | default({}) | subelements('rich_rules_enabled', skip_missing=True) }}"
   loop_control:
     label: "Add rich rule '{{ item.1 }}' to zone {{ item.0.zone }}"
 
@@ -85,7 +85,7 @@
     immediate: "yes"
     permanent: "yes"
     state: disabled
-  loop: "{{ firewall.zones | default({}) | subelements('rich_rules_disabled', skip_missing=True) }}"
+  loop: "{{ firewall_zones | default({}) | subelements('rich_rules_disabled', skip_missing=True) }}"
   loop_control:
     label: "Remove rich rule '{{ item.1 }}' from zone {{ item.0.zone }}"
 
@@ -96,7 +96,7 @@
     immediate: "yes"
     permanent: "yes"
     state: enabled
-  loop: "{{ firewall.zones | default({}) | subelements('icmp_blocks_enabled', skip_missing=True) }}"
+  loop: "{{ firewall_zones | default({}) | subelements('icmp_blocks_enabled', skip_missing=True) }}"
   loop_control:
     label: "Add ICMP block '{{ item.1 }}' to zone {{ item.0.zone }}"
 
@@ -107,7 +107,7 @@
     immediate: "yes"
     permanent: "yes"
     state: disabled
-  loop: "{{ firewall.zones | default({}) | subelements('icmp_blocks_disabled', skip_missing=True) }}"
+  loop: "{{ firewall_zones | default({}) | subelements('icmp_blocks_disabled', skip_missing=True) }}"
   loop_control:
     label: "Remove ICMP block '{{ item.1 }}' from zone {{ item.0.zone }}"
 
@@ -118,7 +118,7 @@
     immediate: "yes"
     permanent: "yes"
     state: "{{ item.icmp_block_inversion | ternary('enabled', 'disabled') }}"
-  loop: "{{ firewall.zones | default([]) }}"
+  loop: "{{ firewall_zones | default([]) }}"
   when: item.icmp_block_inversion is defined
   loop_control:
     label: "{{ item.icmp_block_inversion | default(False) | ternary('Enable', 'Disable') }} ICMP block inversion in zone {{ item.zone }}"
@@ -130,7 +130,7 @@
     immediate: "yes"
     permanent: "yes"
     state: "{{ item.masquerade | ternary('enabled', 'disabled') }}"
-  loop: "{{ firewall.zones | default([]) }}"
+  loop: "{{ firewall_zones | default([]) }}"
   when: item.masquerade is defined
   loop_control:
     label: "{{ item.masquerade | default(False) | ternary('Enable', 'Disable') }} masquerade in zone {{ item.zone }}"

--- a/roles/core/firewall/tasks/main.yml
+++ b/roles/core/firewall/tasks/main.yml
@@ -31,14 +31,14 @@
 - name: "service █ Manage {{ firewall_services_to_start | join(' ') }} state"
   service:
     name: "{{ item }}"
-    enabled: "{{ (equipment_profile['firewall'] | bool) | ternary('yes','no') }}"
-    state: "{{ (equipment_profile['firewall'] | bool) | ternary('started', omit) }}"
+    enabled: "{{ (ep_firewall | bool) | ternary('yes','no') }}"
+    state: "{{ (ep_firewall | bool) | ternary('started', omit) }}"
   loop: "{{ firewall_services_to_start }}"
   tags:
     - service
 
 - name: "include_tasks ░ Configure firewall: {{ ansible_facts.os_family }}"
   include_tasks: "{{ ansible_facts.os_family }}.yml"
-  when: equipment_profile['firewall']
+  when: ep_firewall
   tags:
     - internal

--- a/roles/core/log_server/tasks/main.yml
+++ b/roles/core/log_server/tasks/main.yml
@@ -28,7 +28,7 @@
     state: enabled
   when:
     - ansible_facts.os_family == "RedHat"
-    - equipment_profile['firewall'] | default(false) | bool
+    - ep_firewall | default(false) | bool
   loop: "{{ log_server_firewall_services_to_add }}"
   tags:
     - firewall

--- a/roles/core/nfs_server/tasks/main.yml
+++ b/roles/core/nfs_server/tasks/main.yml
@@ -30,7 +30,7 @@
     state: enabled
   when:
     - ansible_facts.os_family == "RedHat"
-    - equipment_profile['firewall'] | default(false) | bool
+    - ep_firewall | default(false) | bool
   loop: "{{ nfs_server_firewall_services_to_add }}"
   tags:
     - firewall

--- a/roles/core/pxe_stack/readme.rst
+++ b/roles/core/pxe_stack/readme.rst
@@ -34,11 +34,11 @@ ip address and filename to use.
 
 This role will rely on multiple parts of the inventory, and is probably the most "invasive" role of the whole stack.
 
-* equipment_profile dictionaries are used for each equipment_profile group. All
+* equipment_profile parameters are used for each equipment_profile group. All
   boot configuration is made relying on it (operating system, cpu architecture,
   console, kernel parameters, etc.). It is recommended to ensure coherency of
   the equipment_profile files.
-* authentication dictionary is used to provide root password and default ssh
+* authentication parameters are used to provide root password and default ssh
   authorized key.
 * hosts **network_interfaces** dedicated variables, to be able to force static
   ip address at kernel boot.

--- a/roles/core/pxe_stack/tasks/main.yml
+++ b/roles/core/pxe_stack/tasks/main.yml
@@ -30,7 +30,7 @@
     state: enabled
   when:
     - ansible_facts.os_family == "RedHat"
-    - equipment_profile['firewall'] | default(false) | bool
+    - ep_firewall | default(false) | bool
   loop: "{{ pxe_stack_firewall_services_to_add }}"
   tags:
     - firewall
@@ -137,8 +137,8 @@
     group: "{{ pxe_stack_apache_user }}"
   with_items: "{{ j2_equipment_groups_list }}"
   when:
-    - hostvars[groups[item][0]]['equipment_profile']['equipment_type'] == 'server'
-    - (hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']|lower) in ['redhat','centos']
+    - hostvars[groups[item][0]]['ep_equipment_type'] == 'server'
+    - (hostvars[groups[item][0]]['ep_operating_system']['distribution']|lower) in ['redhat','centos']
   tags:
     - template
 
@@ -151,8 +151,8 @@
     group: "{{ pxe_stack_apache_user }}"
   with_items: "{{ j2_equipment_groups_list }}"
   when:
-    - hostvars[groups[item][0]]['equipment_profile']['equipment_type'] == 'server'
-    - (hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']|lower) in ['redhat','centos']
+    - hostvars[groups[item][0]]['ep_equipment_type'] == 'server'
+    - (hostvars[groups[item][0]]['ep_operating_system']['distribution']|lower) in ['redhat','centos']
   tags:
     - template
 
@@ -168,8 +168,8 @@
 #     group: "{{ pxe_stack_apache_user }}"
 #   with_items: "{{ j2_equipment_groups_list }}"
 #   when:
-#     - hostvars[groups[item][0]]['equipment_profile']['equipment_type'] == 'server'
-#     - (hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']|lower) == 'ubuntu'
+#     - hostvars[groups[item][0]]['ep_equipment_type'] == 'server'
+#     - (hostvars[groups[item][0]]['ep_operating_system']['distribution']|lower) == 'ubuntu'
 #   tags:
 #     - template
 #
@@ -182,8 +182,8 @@
 #     group: "{{ pxe_stack_apache_user }}"
 #   with_items: "{{ j2_equipment_groups_list }}"
 #   when:
-#     - hostvars[groups[item][0]]['equipment_profile']['equipment_type'] == 'server'
-#     - (hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']|lower) == 'ubuntu'
+#     - hostvars[groups[item][0]]['ep_equipment_type'] == 'server'
+#     - (hostvars[groups[item][0]]['ep_operating_system']['distribution']|lower) == 'ubuntu'
 #   tags:
 #     - template
 
@@ -199,8 +199,8 @@
 #     group: "{{ pxe_stack_apache_user }}"
 #   with_items: "{{ j2_equipment_groups_list }}"
 #   when:
-#     - hostvars[groups[item][0]]['equipment_profile']['equipment_type'] == 'server'
-#     - (hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']|lower) == 'opensuse'
+#     - hostvars[groups[item][0]]['ep_equipment_type'] == 'server'
+#     - (hostvars[groups[item][0]]['ep_operating_system']['distribution']|lower) == 'opensuse'
 #   tags:
 #     - template
 #
@@ -213,8 +213,8 @@
 #     group: "{{ pxe_stack_apache_user }}"
 #   with_items: "{{ j2_equipment_groups_list }}"
 #   when:
-#     - hostvars[groups[item][0]]['equipment_profile']['equipment_type'] == 'server'
-#     - (hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']|lower) == 'opensuse'
+#     - hostvars[groups[item][0]]['ep_equipment_type'] == 'server'
+#     - (hostvars[groups[item][0]]['ep_operating_system']['distribution']|lower) == 'opensuse'
 #   tags:
 #     - template
 #

--- a/roles/core/pxe_stack/templates/autoyast.xml.j2
+++ b/roles/core/pxe_stack/templates/autoyast.xml.j2
@@ -3,11 +3,11 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
   <keyboard>
-    <keymap>{{hostvars[groups[item][0]]['equipment_profile']['configuration']['keyboard_layout']|lower}}</keymap>
+    <keymap>{{hostvars[groups[item][0]]['ep_configuration']['keyboard_layout']|lower}}</keymap>
   </keyboard>
 
   <language>
-    <language>{{hostvars[groups[item][0]]['equipment_profile']['configuration']['system_language']|replace('.UTF-8','')}}</language>
+    <language>{{hostvars[groups[item][0]]['ep_configuration']['system_language']|replace('.UTF-8','')}}</language>
     <languages/>
   </language>
 
@@ -27,18 +27,18 @@
     </patterns>
   </software> 
 
-{{hostvars[groups[item][0]]['equipment_profile']['partitioning']}}
+{{hostvars[groups[item][0]]['ep_partitioning']}}
 
  <users config:type="list">
   <user>
     <username>root</username>
-    <user_password>{{hostvars[groups[item][0]]['authentication']['root_password_sha512']}}</user_password>
+    <user_password>{{hostvars[groups[item][0]]['authentication_root_password_sha512']}}</user_password>
     <uid>1001</uid>
     <gid>100</gid>
     <encrypted config:type="boolean">true</encrypted>
     <fullname>Root User</fullname>
     <authorized_keys config:type="list">
-{% for ssh_key in hostvars[groups[item][0]]['authentication']['ssh_keys'] %}
+{% for ssh_key in hostvars[groups[item][0]]['authentication_ssh_keys'] %}
       <listentry>{{ssh_key}}</listentry>
 {% endfor %}
     </authorized_keys>

--- a/roles/core/pxe_stack/templates/configuration_opensuse.ipxe.j2
+++ b/roles/core/pxe_stack/templates/configuration_opensuse.ipxe.j2
@@ -7,11 +7,11 @@ echo
 
 echo Loading linux ...
 
-kernel http://${next-server}/repositories/{{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']}}/{{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution_version']}}/{{hostvars[groups[item][0]]['equipment_profile']['hardware']['cpu']['architecture']}}/netboot/linux install=http://${next-server}/repositories/{{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']}}/{{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution_version']}}/{{hostvars[groups[item][0]]['equipment_profile']['hardware']['cpu']['architecture']}}/os autoyast=http://${next-server}/preboot_execution_environment/equipment_os_configurations/autoyast.{{item | replace('equipment_','') | trim}}.xml {{hostvars[groups[item][0]]['equipment_profile']['kernel_parameters']}} {{hostvars[groups[item][0]]['equipment_profile']['console']}} ipxe_next_server=${next-server} ${dedicated-parameters}
+kernel http://${next-server}/repositories/{{hostvars[groups[item][0]]['ep_operating_system']['distribution']}}/{{hostvars[groups[item][0]]['ep_operating_system']['distribution_version']}}/{{hostvars[groups[item][0]]['ep_hardware']['cpu']['architecture']}}/netboot/linux install=http://${next-server}/repositories/{{hostvars[groups[item][0]]['ep_operating_system']['distribution']}}/{{hostvars[groups[item][0]]['ep_operating_system']['distribution_version']}}/{{hostvars[groups[item][0]]['ep_hardware']['cpu']['architecture']}}/os autoyast=http://${next-server}/preboot_execution_environment/equipment_os_configurations/autoyast.{{item | replace('equipment_','') | trim}}.xml {{hostvars[groups[item][0]]['ep_kernel_parameters']}} {{hostvars[groups[item][0]]['ep_console']}} ipxe_next_server=${next-server} ${dedicated-parameters}
 
 echo Loading initial ramdisk ...
 
-initrd http://${next-server}/repositories/{{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']}}/{{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution_version']}}/{{hostvars[groups[item][0]]['equipment_profile']['hardware']['cpu']['architecture']}}/netboot/initrd
+initrd http://${next-server}/repositories/{{hostvars[groups[item][0]]['ep_operating_system']['distribution']}}/{{hostvars[groups[item][0]]['ep_operating_system']['distribution_version']}}/{{hostvars[groups[item][0]]['ep_hardware']['cpu']['architecture']}}/netboot/initrd
 
 echo ALL DONE! We are ready.
 echo Booting in 2 s ...

--- a/roles/core/pxe_stack/templates/configuration_ubuntu.ipxe.j2
+++ b/roles/core/pxe_stack/templates/configuration_ubuntu.ipxe.j2
@@ -7,11 +7,11 @@ echo
 
 echo Loading linux ...
 
-kernel http://${next-server}/repositories/{{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']}}/{{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution_version']}}/{{hostvars[groups[item][0]]['equipment_profile']['hardware']['cpu']['architecture']}}/os/install/netboot/ubuntu-installer/amd64/linux preseed/url=http://${next-server}/preboot_execution_environment/equipment_os_configurations/preseed.{{item | replace('equipment_','') | trim}}.cfg auto=true priority=critical locale=en_US.UTF-8 console-setup/charmap=UTF-8 console-keymaps-at/keymaps=pc105 console-setup/layoutcode=us console-setup/ask_detect=false netcfg/choose_interface=auto {{hostvars[groups[item][0]]['equipment_profile']['kernel_parameters']}} {{hostvars[groups[item][0]]['equipment_profile']['console']}} ipxe_next_server=${next-server} mirror/http/hostname=http://${next-server} ${dedicated-parameters}
+kernel http://${next-server}/repositories/{{hostvars[groups[item][0]]['ep_operating_system']['distribution']}}/{{hostvars[groups[item][0]]['ep_operating_system']['distribution_version']}}/{{hostvars[groups[item][0]]['ep_hardware']['cpu']['architecture']}}/os/install/netboot/ubuntu-installer/amd64/linux preseed/url=http://${next-server}/preboot_execution_environment/equipment_os_configurations/preseed.{{item | replace('equipment_','') | trim}}.cfg auto=true priority=critical locale=en_US.UTF-8 console-setup/charmap=UTF-8 console-keymaps-at/keymaps=pc105 console-setup/layoutcode=us console-setup/ask_detect=false netcfg/choose_interface=auto {{hostvars[groups[item][0]]['ep_kernel_parameters']}} {{hostvars[groups[item][0]]['ep_console']}} ipxe_next_server=${next-server} mirror/http/hostname=http://${next-server} ${dedicated-parameters}
 
 echo Loading initial ramdisk ...
 
-initrd http://${next-server}/repositories/{{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']}}/{{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution_version']}}/{{hostvars[groups[item][0]]['equipment_profile']['hardware']['cpu']['architecture']}}/os/install/netboot/ubuntu-installer/amd64/initrd.gz
+initrd http://${next-server}/repositories/{{hostvars[groups[item][0]]['ep_operating_system']['distribution']}}/{{hostvars[groups[item][0]]['ep_operating_system']['distribution_version']}}/{{hostvars[groups[item][0]]['ep_hardware']['cpu']['architecture']}}/os/install/netboot/ubuntu-installer/amd64/initrd.gz
 
 echo ALL DONE! We are ready.
 echo Booting in 2 s ...

--- a/roles/core/pxe_stack/templates/equipment_profile.ipxe.j2
+++ b/roles/core/pxe_stack/templates/equipment_profile.ipxe.j2
@@ -9,12 +9,12 @@ echo |
 # Ansible variables
 set eq-equipment-profile {{ item | replace('equipment_','') | trim }}
 set eq-architecture ${arch}
-set eq-distribution {{ hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']|lower }}
-set eq-distribution-major-version {{ hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution_major_version'] }}
-set eq-distribution-version {{ hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution_version'] | default('${eq-distribution-major-version}') }}
-set eq-console {{ hostvars[groups[item][0]]['equipment_profile']['console'] }}
-set eq-kernel-parameters {{ hostvars[groups[item][0]]['equipment_profile']['kernel_parameters'] }}
-set eq-repositories-environment {{ hostvars[groups[item][0]]['equipment_profile']['operating_system']['repositories_environment'] | default('') }}
+set eq-distribution {{ hostvars[groups[item][0]]['ep_operating_system']['distribution']|lower }}
+set eq-distribution-major-version {{ hostvars[groups[item][0]]['ep_operating_system']['distribution_major_version'] }}
+set eq-distribution-version {{ hostvars[groups[item][0]]['ep_operating_system']['distribution_version'] | default('${eq-distribution-major-version}') }}
+set eq-console {{ hostvars[groups[item][0]]['ep_console'] }}
+set eq-kernel-parameters {{ hostvars[groups[item][0]]['ep_kernel_parameters'] }}
+set eq-repositories-environment {{ hostvars[groups[item][0]]['ep_operating_system']['repositories_environment'] | default('') }}
 
 # Dynamic variables
 set images-root http://${next-server}/repositories/${eq-repositories-environment}/${eq-distribution}/${eq-distribution-version}/${eq-architecture}/

--- a/roles/core/pxe_stack/templates/kickstart.cfg.j2
+++ b/roles/core/pxe_stack/templates/kickstart.cfg.j2
@@ -10,10 +10,10 @@ text
 firstboot --enable
 
 # System keyboard layout
-keyboard --vckeymap={{ hostvars[groups[item][0]]['equipment_profile']['configuration']['keyboard_layout']|lower }} --xlayouts='{{ hostvars[groups[item][0]]['equipment_profile']['configuration']['keyboard_layout']|lower }}'
+keyboard --vckeymap={{ hostvars[groups[item][0]]['ep_configuration']['keyboard_layout']|lower }} --xlayouts='{{ hostvars[groups[item][0]]['ep_configuration']['keyboard_layout']|lower }}'
 
 # System language
-lang {{ hostvars[groups[item][0]]['equipment_profile']['configuration']['system_language'] }}
+lang {{ hostvars[groups[item][0]]['ep_configuration']['system_language'] }}
 
 # System timezone
 timezone {{ time_zone }} --isUtc
@@ -23,13 +23,13 @@ reboot
 
 ##### Authentication settings
 
-{% if hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution_major_version']|int < 8 %}
+{% if hostvars[groups[item][0]]['ep_operating_system']['distribution_major_version']|int < 8 %}
 # Define authentication method (sha512)
 auth --enableshadow --passalgo=sha512
 {% endif %}
 
 # Root password (sha512)
-rootpw --iscrypted {{ hostvars[groups[item][0]]['authentication']['root_password_sha512'] }}
+rootpw --iscrypted {{ hostvars[groups[item][0]]['authentication_root_password_sha512'] }}
 
 
 ##### Network
@@ -42,15 +42,15 @@ network --hostname=localhost.localdomain
 ##### Security
 
 # SELinux
-{% if hostvars[groups[item][0]]['equipment_profile']['access_control'] is defined and
-   hostvars[groups[item][0]]['equipment_profile']['access_control'] in ['enforcing', 'permissive'] %}
-selinux --{{ hostvars[groups[item][0]]['equipment_profile']['access_control'] }}
+{% if hostvars[groups[item][0]]['ep_access_control'] is defined and
+   hostvars[groups[item][0]]['ep_access_control'] in ['enforcing', 'permissive'] %}
+selinux --{{ hostvars[groups[item][0]]['ep_access_control'] }}
 {% else %}
 selinux --disabled
 {% endif %}
 
 # Firwalld
-{% if hostvars[groups[item][0]]['equipment_profile']['firewall'] is defined and hostvars[groups[item][0]]['equipment_profile']['firewall'] == true %}
+{% if hostvars[groups[item][0]]['ep_firewall'] is defined and hostvars[groups[item][0]]['ep_firewall'] == true %}
 firewall --enabled
 {% else %}
 firewall --disabled
@@ -60,10 +60,10 @@ firewall --disabled
 ##### Partitionning
 
 # Bootloader configuration
-bootloader --append="{{ hostvars[groups[item][0]]['equipment_profile']['kernel_parameters'] }}" --location=mbr
+bootloader --append="{{ hostvars[groups[item][0]]['ep_kernel_parameters'] }}" --location=mbr
 
 # Partitioning
-{{ hostvars[groups[item][0]]['equipment_profile']['partitioning'] }}
+{{ hostvars[groups[item][0]]['ep_partitioning'] }}
 
 
 ##### Packages
@@ -76,7 +76,7 @@ curl
 
 # This EFI first boot order restoration trick is from stacki, not from me.
 # See https://github.com/Teradata/stacki for more details
-{% if hostvars[groups[item][0]]['equipment_profile']['preserve_efi_first_boot_device'] == true %}
+{% if hostvars[groups[item][0]]['ep_preserve_efi_first_boot_device'] == true %}
 %pre
 set -x
 if [ -d /sys/firmware/efi ]; then
@@ -108,7 +108,7 @@ set -x
 # Add ssh keys from ssh_keys list
 mkdir /root/.ssh
 cat << xxEOFxx >> /root/.ssh/authorized_keys
-{% for ssh_key in hostvars[groups[item][0]]['authentication']['ssh_keys'] %}
+{% for ssh_key in hostvars[groups[item][0]]['authentication_ssh_keys'] %}
 {{ ssh_key }}
 {% endfor %}
 xxEOFxx
@@ -127,14 +127,14 @@ set +x
 
 
 # Custom scripts
-{% if hostvars[groups[item][0]]['equipment_profile']['autoinstall_pre_script'] is defined and hostvars[groups[item][0]]['equipment_profile']['autoinstall_pre_script'] is not none %}
+{% if hostvars[groups[item][0]]['ep_autoinstall_pre_script'] is defined and hostvars[groups[item][0]]['ep_autoinstall_pre_script'] is not none %}
 %pre --log /root/custom_pre.log
-{{ hostvars[groups[item][0]]['equipment_profile']['autoinstall_pre_script'] }}
+{{ hostvars[groups[item][0]]['ep_autoinstall_pre_script'] }}
 %end
 {% endif %}
 
-{% if hostvars[groups[item][0]]['equipment_profile']['autoinstall_post_script'] is defined and hostvars[groups[item][0]]['equipment_profile']['autoinstall_post_script'] is not none %}
+{% if hostvars[groups[item][0]]['ep_autoinstall_post_script'] is defined and hostvars[groups[item][0]]['ep_autoinstall_post_script'] is not none %}
 %post --log /root/custom_post.log
-{{ hostvars[groups[item][0]]['equipment_profile']['autoinstall_post_script'] }}
+{{ hostvars[groups[item][0]]['ep_autoinstall_post_script'] }}
 %end
 {% endif %}

--- a/roles/core/pxe_stack/templates/nodes_parameters.yml.j2
+++ b/roles/core/pxe_stack/templates/nodes_parameters.yml.j2
@@ -19,7 +19,7 @@
 {% endif %}
 
 {% for host in range %}
-  {% if hostvars[host]['equipment_profile']['equipment_type'] == "server" %}
+  {% if hostvars[host]['ep_equipment_type'] == "server" %}
     {% if hostvars[host]['network_interfaces'] is defined and hostvars[host]['network_interfaces'] is not none %}
 {{ host }}:
   equipment_profile: {{ hostvars[host]['group_names'] | select('match','^'+equipment_naming+'_.*') | list | unique | sort | first | replace(equipment_naming + '_','') | trim }}

--- a/roles/core/pxe_stack/templates/preseed.cfg.j2
+++ b/roles/core/pxe_stack/templates/preseed.cfg.j2
@@ -2,8 +2,8 @@
 
 
 ### zone
-d-i debian-installer/locale string {{hostvars[groups[item][0]]['equipment_profile']['configuration']['system_language']}}
-d-i keyboard-configuration/xkb-keymap select {{hostvars[groups[item][0]]['equipment_profile']['configuration']['keyboard_layout']|lower}}
+d-i debian-installer/locale string {{hostvars[groups[item][0]]['ep_configuration']['system_language']}}
+d-i keyboard-configuration/xkb-keymap select {{hostvars[groups[item][0]]['ep_configuration']['keyboard_layout']|lower}}
 #d-i debconf/language string us
 #d-i debian-installer/language string us
 #d-i debian-installer/country string US
@@ -30,7 +30,7 @@ d-i netcfg/no_default_route boolean
 d-i debian-installer/allow_unauthenticated string true # Allow local source
 d-i mirror/country string manual
 #d-i mirror/http/hostname string http://10.10.0.1
-d-i mirror/http/directory string /repositories/{{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution']}}/{{hostvars[groups[item][0]]['equipment_profile']['operating_system']['distribution_version']}}/{{hostvars[groups[item][0]]['equipment_profile']['hardware']['cpu']['architecture']}}/os/
+d-i mirror/http/directory string /repositories/{{hostvars[groups[item][0]]['ep_operating_system']['distribution']}}/{{hostvars[groups[item][0]]['ep_operating_system']['distribution_version']}}/{{hostvars[groups[item][0]]['ep_hardware']['cpu']['architecture']}}/os/
 d-i mirror/http/proxy string
 #d-i pkgsel/update-policy select none
 d-i pkgsel/install-language-support boolean false
@@ -54,7 +54,7 @@ d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 
-{{hostvars[groups[item][0]]['equipment_profile']['partitioning']}}
+{{hostvars[groups[item][0]]['ep_partitioning']}}
 
 # Good
 #d-i partman-auto/disk string /dev/sda
@@ -96,7 +96,7 @@ d-i partman/confirm_nooverwrite boolean true
 #d-i passwd/root-password-again password r00tme
 d-i passwd/root-login boolean true
 d-i passwd/make-user boolean false
-id-i passwd/root-password-crypted password {{hostvars[groups[item][0]]['authentication']['root_password_sha512']}}
+id-i passwd/root-password-crypted password {{hostvars[groups[item][0]]['authentication_root_password_sha512']}}
 #d-i passwd/user-fullname string root User
 #d-i passwd/username string root
 #d-i passwd/user-password password insecure

--- a/roles/core/repositories_client/molecule/default/molecule.yml
+++ b/roles/core/repositories_client/molecule/default/molecule.yml
@@ -19,24 +19,22 @@ provisioner:
     host_vars:
       instance-centos7: # platform.name
         j2_node_main_network: "ice1-1"
-        equipment_profile:
-          operating_system:
-            distribution: centos
-            distribution_major_version: 7
-            distribution_version: 7.7
-          hardware:
-            cpu:
-              architecture: x86_64
+        ep_operating_system:
+          distribution: centos
+          distribution_major_version: 7
+          distribution_version: 7.7
+        ep_hardware:
+          cpu:
+            architecture: x86_64
       instance-centos8: # platform.name
         j2_node_main_network: "ice1-1"
-        equipment_profile:
-          operating_system:
-            distribution: centos
-            distribution_major_version: 8
-            distribution_version: 8.1
-          hardware:
-            cpu:
-              architecture: aarch64
+        ep_operating_system:
+          distribution: centos
+          distribution_major_version: 8
+          distribution_version: 8.1
+        ep_hardware:
+          cpu:
+            architecture: aarch64
     group_vars:
       all:
         networks:

--- a/roles/core/repositories_client/readme.rst
+++ b/roles/core/repositories_client/readme.rst
@@ -62,10 +62,10 @@ Repository static path is computed using variables defined in the equipment_prof
 
 If equipment_profile is:
 
-  operating_system:
+  ep_operating_system:
     distribution: centos
     distribution_major_version: 8
-  hardware:
+  ep_hardware:
     cpu:
       architecture: x86_64
 
@@ -73,11 +73,11 @@ Then path will be: repositories/centos/8/x86_64/
 
 If equipment_profile is:
 
-  operating_system:
+  ep_operating_system:
     distribution: centos
     distribution_major_version: 8
     distribution_version: 8.1
-  hardware:
+  ep_hardware:
     cpu:
       architecture: x86_64
 
@@ -85,12 +85,12 @@ Then path will be: repositories/centos/8.1/x86_64/
 
 If equipment_profile is:
 
-  operating_system:
+  ep_operating_system:
     distribution: centos
     distribution_major_version: 8
     distribution_version: 8.1
     repositories_environment: production
-  hardware:
+  ep_hardware:
     cpu:
       architecture: aarch64
 
@@ -104,7 +104,17 @@ Mandatory inventory vars:
 **hostvars[inventory_hostname]**
 
 * repositories[item]
-* equipment_profile (see above)
+* eq_operating_system
+   * distribution
+   * distribution_major_version
+
+Optional inventory vars:
+
+**hostvars[inventory_hostname]**
+
+* eq_operating_system
+   * distribution_version
+   * repositories_environment
 
 Output
 ^^^^^^

--- a/roles/core/repositories_client/tasks/centos_7.yml
+++ b/roles/core/repositories_client/tasks/centos_7.yml
@@ -3,9 +3,9 @@
   set_fact:
     baseurl_prefix:
       "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/\
-      {{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/\
-      {{ equipment_profile['operating_system']['distribution'] }}/\
-      {{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/\
+      {{ ep_operating_system['repositories_environment'] | default('') }}/\
+      {{ ep_operating_system['distribution'] }}/\
+      {{ ep_operating_system['distribution_version'] | default(ep_operating_system['distribution_major_version']) }}/\
       $basearch/"
 
 - name: ini_file █ Disable CentOS-Base distro repositories

--- a/roles/core/repositories_client/tasks/centos_8.yml
+++ b/roles/core/repositories_client/tasks/centos_8.yml
@@ -3,9 +3,9 @@
   set_fact:
     baseurl_prefix:
       "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/\
-      {{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/\
-      {{ equipment_profile['operating_system']['distribution'] }}/\
-      {{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/\
+      {{ ep_operating_system['repositories_environment'] | default('') }}/\
+      {{ ep_operating_system['distribution'] }}/\
+      {{ ep_operating_system['distribution_version'] | default(ep_operating_system['distribution_major_version']) }}/\
       $basearch/"
 
 - name: ini_file █ Disable CentOS Extras repository

--- a/roles/core/repositories_client/tasks/opensuse_leap_15.yml
+++ b/roles/core/repositories_client/tasks/opensuse_leap_15.yml
@@ -4,7 +4,7 @@
   zypper_repository:
     name: "{{ item }}"
     description: "{{ item }} gen by Ansible"
-    repo: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/{{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/{{ equipment_profile['operating_system']['distribution'] }}/{{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/{{ equipment_profile['hardware']['cpu']['architecture'] }}/{{ item }}/"
+    repo: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/{{ ep_operating_system['repositories_environment'] | default('') }}/{{ ep_operating_system['distribution'] }}/{{ ep_operating_system['distribution_version'] | default(ep_operating_system['distribution_major_version']) }}/{{ ep_hardware['cpu']['architecture'] }}/{{ item }}/"
     disable_gpg_check: yes
     state: present
   with_items: "{{ repositories }}"

--- a/roles/core/repositories_client/tasks/redhat_7.yml
+++ b/roles/core/repositories_client/tasks/redhat_7.yml
@@ -3,9 +3,9 @@
   set_fact:
     baseurl_prefix:
       "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/\
-      {{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/\
-      {{ equipment_profile['operating_system']['distribution'] }}/\
-      {{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/\
+      {{ ep_operating_system['repositories_environment'] | default('') }}/\
+      {{ ep_operating_system['distribution'] }}/\
+      {{ ep_operating_system['distribution_version'] | default(ep_operating_system['distribution_major_version']) }}/\
       $basearch/"
 
 - name: yum_repository █ Setting repositories

--- a/roles/core/repositories_client/tasks/redhat_8.yml
+++ b/roles/core/repositories_client/tasks/redhat_8.yml
@@ -3,9 +3,9 @@
   set_fact:
     baseurl_prefix:
       "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/\
-      {{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/\
-      {{ equipment_profile['operating_system']['distribution'] }}/\
-      {{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/\
+      {{ ep_operating_system['repositories_environment'] | default('') }}/\
+      {{ ep_operating_system['distribution'] }}/\
+      {{ ep_operating_system['distribution_version'] | default(ep_operating_system['distribution_major_version']) }}/\
       $basearch/"
 
 - name: yum_repository █ Setting repositories

--- a/roles/core/repositories_client/tasks/ubuntu_18.yml
+++ b/roles/core/repositories_client/tasks/ubuntu_18.yml
@@ -2,6 +2,6 @@
 
 - name: Setting repositories
   apt_repository:
-    repo: "deb http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/{{ equipment_profile['operating_system']['repositories_environment'] | default('') }}/{{ equipment_profile['operating_system']['distribution'] }}/{{ equipment_profile['operating_system']['distribution_version'] | default(equipment_profile['operating_system']['distribution_major_version']) }}/{{ equipment_profile['hardware']['cpu']['architecture'] }}/{{ item }} bionic main"
+    repo: "deb http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/{{ ep_operating_system['repositories_environment'] | default('') }}/{{ ep_operating_system['distribution'] }}/{{ ep_operating_system['distribution_version'] | default(ep_operating_system['distribution_major_version']) }}/{{ ep_hardware['cpu']['architecture'] }}/{{ item }} bionic main"
     state: present
   with_items: "{{ repositories }}"

--- a/roles/core/repositories_server/tasks/main.yml
+++ b/roles/core/repositories_server/tasks/main.yml
@@ -30,7 +30,7 @@
     state: enabled
   when:
     - ansible_facts.os_family == "RedHat"
-    - equipment_profile['firewall'] | default(false) | bool
+    - ep_firewall | default(false) | bool
   loop: "{{ repositories_server_firewall_services_to_add }}"
   tags:
     - firewall

--- a/roles/core/ssh_slave/readme.rst
+++ b/roles/core/ssh_slave/readme.rst
@@ -22,7 +22,7 @@ Mandatory inventory vars:
 
 **hostvars[inventory_hostname]**
 
-* authentication.ssh_keys
+* authentication_ssh_keys
 
 Output
 ^^^^^^

--- a/roles/core/ssh_slave/tasks/main.yml
+++ b/roles/core/ssh_slave/tasks/main.yml
@@ -5,4 +5,4 @@
     key: "{{ item }}"
     exclusive: no
     state: present
-  with_items: "{{ authentication.ssh_keys }}"
+  with_items: "{{ authentication_ssh_keys }}"

--- a/roles/core/time/tasks/main.yml
+++ b/roles/core/time/tasks/main.yml
@@ -30,7 +30,7 @@
     state: enabled
   when:
     - ansible_facts.os_family == "RedHat"
-    - equipment_profile['firewall'] | default(false) | bool
+    - ep_firewall | default(false) | bool
   loop: "{{ time_firewall_services_to_add }}"
   tags:
     - firewall


### PR DESCRIPTION
Note: this is a proposal to open the discussion before 1.3 GA.

While porting my test bed from 1.2 to 1.3-rc1, I had to modify my inventory files because of the major changes we introduced (mainly due to removal of `hash_behaviour = merge` due to its deprecation in Ansible). I was copying the 
values of `group_vars/all/equipment_all/equipment_profile.yml` to the relevant `group_vars/equipment_type*/equipment_profile.yml` when I asked myself what is the purpose of the `equipment_profile` key now.

The `equipment_profile` key defined in equipment_profile.yml files was useful when the stack was using `hash_behaviour = merge`. Now, it prevents to inherit values from the global configuration file `groups_vars/all/equipment_all/equipment_profile.yml`, with no obvious added value (at least to me, I might miss it :sweat_smile:).

This change removes this key from inventory examples and usage of this key in the roles.
It does not change the logic of equipment_profile files.

With the breaking changes we are introducing in 1.3, I guess it is the right time to think about this. Converting an equipment_profile.yml file from a 1.2 inventory to a 1.3 inventory could be as easy as: remove `equipment_profile` key and decrease indentation by one level.