### PR TITLE
Revert "ci: do not install ansible 2.9.12"

### DIFF
--- a/.github/workflows/molecule-actions-addons-clustershell.yml
+++ b/.github/workflows/molecule-actions-addons-clustershell.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8
       - name: Run molecule test for addons/clustershell
         run: |
           cd roles/addons/clustershell && molecule test

--- a/.github/workflows/molecule-actions-addons-root_password.yml
+++ b/.github/workflows/molecule-actions-addons-root_password.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8
       - name: Run molecule test for addons/root_password
         run: |
           cd roles/addons/root_password && molecule test

--- a/.github/workflows/molecule-actions-addons-users_basic.yml
+++ b/.github/workflows/molecule-actions-addons-users_basic.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8
       - name: Run molecule test for addons/users_basic
         run: |
           cd roles/addons/users_basic && molecule test

--- a/.github/workflows/molecule-actions-core-bluebanquise.yml
+++ b/.github/workflows/molecule-actions-core-bluebanquise.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 jmespath netaddr 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8 jmespath netaddr
       - name: Run molecule test for core/bluebanquise
         run: |
           cd roles/core/bluebanquise && molecule test

--- a/.github/workflows/molecule-actions-core-conman.yml
+++ b/.github/workflows/molecule-actions-core-conman.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8
       - name: Run molecule test for core/conman
         run: |
           cd roles/core/conman && molecule test

--- a/.github/workflows/molecule-actions-core-display_tuning.yml
+++ b/.github/workflows/molecule-actions-core-display_tuning.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8
       - name: Run molecule test for core/display_tuning
         run: |
           cd roles/core/display_tuning && molecule test

--- a/.github/workflows/molecule-actions-core-dns_client.yml
+++ b/.github/workflows/molecule-actions-core-dns_client.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 jmespath netaddr 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8 jmespath netaddr
       - name: Run molecule test for core/dns_client
         run: |
           cd roles/core/dns_client && molecule test

--- a/.github/workflows/molecule-actions-core-dns_server.yml
+++ b/.github/workflows/molecule-actions-core-dns_server.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 jmespath netaddr 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8 jmespath netaddr
       - name: Run molecule test for core/dns_server
         run: |
           cd roles/core/dns_server && molecule test

--- a/.github/workflows/molecule-actions-core-firewall.yml
+++ b/.github/workflows/molecule-actions-core-firewall.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8
       - name: Run molecule test for core/firewall
         run: |
           cd roles/core/firewall && molecule test

--- a/.github/workflows/molecule-actions-core-log_client.yml
+++ b/.github/workflows/molecule-actions-core-log_client.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8
       - name: Run molecule test for core/log_client
         run: |
           cd roles/core/log_client && molecule test

--- a/.github/workflows/molecule-actions-core-log_server.yml
+++ b/.github/workflows/molecule-actions-core-log_server.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8
       - name: Run molecule test for core/log_server
         run: |
           cd roles/core/log_server && molecule test

--- a/.github/workflows/molecule-actions-core-repositories_client.yml
+++ b/.github/workflows/molecule-actions-core-repositories_client.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8
       - name: Run molecule test for core/repositories_client
         run: |
           cd roles/core/repositories_client && molecule test

--- a/.github/workflows/molecule-actions-core-ssh_master.yml
+++ b/.github/workflows/molecule-actions-core-ssh_master.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8
       - name: Run molecule test for core/ssh_master
         run: |
           cd roles/core/ssh_master && molecule test

--- a/.github/workflows/molecule-actions-core-time.yml
+++ b/.github/workflows/molecule-actions-core-time.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3,!=3.0.7' 'ansible-lint<4.3.0' flake8 'ansible!=2.9.12'
+          pip install 'molecule[docker]>3' ansible-lint flake8
       - name: Run molecule test for core/time
         run: |
           cd roles/core/time && molecule test

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-python@v1
 
       - name: Install packages
-        run: pip install 'ansible!=2.9.10' 'ansible-lint<4.3.0' flake8
+        run: pip install ansible ansible-lint flake8
 
       - name: Check python code
         run: flake8 . --statistics --ignore E501,E226


### PR DESCRIPTION
This reverts commit ac1b811c5c2852d5f804bc65d994d95b5deebc28.

Draft PR to troubleshoot the issues with CI after new ansible, molecule and ansible-lint releases.