### PR TITLE
feat: new addon role to install grafana

### DIFF
--- a/.github/TEST_MATRIX.md
+++ b/.github/TEST_MATRIX.md
@@ -19,5 +19,6 @@ Molecule unit tests
 |![core/ssh_master unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/ssh_master%20unit%20testing/badge.svg)                   | x | x | x |
 |![core/time unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/time%20unit%20testing/badge.svg)                               | x | x |   |
 |![addons/clustershell unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/clustershell%20unit%20testing/badge.svg)           | x | x | x |
+|![addons/grafana unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/grafana%20unit%20testing/badge.svg)                     | x | x |   |
 |![addons/root_password unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/root_password%20unit%20testing/badge.svg)         | x | x | x |
 |![addons/users_basic unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/users_basic%20unit%20testing/badge.svg)             | x | x | x |

--- a/.github/workflows/molecule-actions-addons-grafana.yml
+++ b/.github/workflows/molecule-actions-addons-grafana.yml
@@ -1,0 +1,40 @@
+---
+name: addons/grafana unit testing
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'roles/addons/grafana/**'
+      - '.github/workflows/molecule-actions-addons-grafana.yml'
+  pull_request:
+    paths:
+      - 'roles/addons/grafana/**'
+      - '.github/workflows/molecule-actions-addons-grafana.yml'
+
+jobs:
+  molecule_test:
+    name: ${{ matrix.distro }} - molecule test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - centos:7
+          - centos:8
+
+    env:
+      MOLECULE_DISTRO: ${{ matrix.distro }}
+      PY_COLORS: 1
+      ANSIBLE_FORCE_COLOR: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup python environment
+        uses: actions/setup-python@v1
+      - name: Install packages
+        run: |
+          pip install 'molecule[docker]>3' ansible-lint flake8
+      - name: Run molecule test for addons/grafana
+        run: |
+          cd roles/addons/grafana && molecule test

--- a/resources/packaging/bluebanquise.spec
+++ b/resources/packaging/bluebanquise.spec
@@ -1,8 +1,8 @@
 %{!?version: %define version 1.3.0-rc2}
 
-%define roles_addons clone clustershell diskless nic_nmcli ofed ofed_sm \
-openldap_client openldap_server powerman prometheus_client prometheus_server \
-report root_password slurm sssd users_basic
+%define roles_addons clone clustershell diskless grafana nic_nmcli ofed \
+ofed_sm openldap_client openldap_server powerman prometheus_client \
+prometheus_server report root_password slurm sssd users_basic
 
 Name:           bluebanquise
 Version:        %{version}

--- a/roles/addons/grafana/.yamllint
+++ b/roles/addons/grafana/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/addons/grafana/molecule/default/INSTALL.rst
+++ b/roles/addons/grafana/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/roles/addons/grafana/molecule/default/converge.yml
+++ b/roles/addons/grafana/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include grafana"
+      include_role:
+        name: "grafana"

--- a/roles/addons/grafana/molecule/default/converge.yml
+++ b/roles/addons/grafana/molecule/default/converge.yml
@@ -1,7 +1,16 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+    start_services: true
+    enable_services: false
   tasks:
+    - name: "Enable firewall for EL8"
+      set_fact:
+        ep_firewall: true
+      when:
+        - ansible_facts.os_family == "RedHat"
+        - ansible_facts.distribution_major_version == "8"
     - name: "Include grafana"
       include_role:
         name: "grafana"

--- a/roles/addons/grafana/molecule/default/molecule.yml
+++ b/roles/addons/grafana/molecule/default/molecule.yml
@@ -1,0 +1,13 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/roles/addons/grafana/molecule/default/molecule.yml
+++ b/roles/addons/grafana/molecule/default/molecule.yml
@@ -3,9 +3,20 @@ dependency:
   name: galaxy
 driver:
   name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
 platforms:
   - name: instance
-    image: docker.io/pycontribs/centos:8
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
+    override_command: false
+    capabilities:
+      - "SYS_ADMIN"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/addons/grafana/molecule/default/prepare.yml
+++ b/roles/addons/grafana/molecule/default/prepare.yml
@@ -1,0 +1,25 @@
+---
+- name: Prepare
+  hosts: all
+
+  tasks:
+    - name: "Install firewalld"
+      package:
+        name: firewalld
+      when: ansible_facts.os_family == "RedHat"
+
+    - name: "Start firewalld"
+      service:
+        name: firewalld
+        state: started
+      when: ansible_facts.os_family == "RedHat"
+
+    - name: "Configure Grafana repository for EL7"
+      yum_repository:
+        name: grafana
+        description: Grafana repository
+        baseurl: https://packages.grafana.com/oss/rpm
+        gpgcheck: False
+      when:
+        - ansible_facts.os_family == "RedHat"
+        - ansible_facts.distribution_major_version == "7"

--- a/roles/addons/grafana/molecule/default/verify.yml
+++ b/roles/addons/grafana/molecule/default/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/roles/addons/grafana/molecule/default/verify.yml
+++ b/roles/addons/grafana/molecule/default/verify.yml
@@ -1,9 +1,0 @@
----
-# This is an example playbook to execute Ansible tests.
-
-- name: Verify
-  hosts: all
-  tasks:
-  - name: Example assertion
-    assert:
-      that: true

--- a/roles/addons/grafana/readme.rst
+++ b/roles/addons/grafana/readme.rst
@@ -1,0 +1,17 @@
+Grafana
+-------
+
+Description
+^^^^^^^^^^^
+
+This role deploys grafana on the host.
+
+Instructions
+^^^^^^^^^^^^
+
+Grafana is available at http://localhost:3000
+
+Changelog
+^^^^^^^^^
+
+* 1.0.0: Role creation. Bruno Travouillon <devel@travouillon.fr>

--- a/roles/addons/grafana/tasks/main.yml
+++ b/roles/addons/grafana/tasks/main.yml
@@ -50,4 +50,3 @@
   loop: "{{ grafana_services_to_start }}"
   tags:
     - service
-

--- a/roles/addons/grafana/tasks/main.yml
+++ b/roles/addons/grafana/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+- name: include_vars ░ Gathering OS specific variables
+  # This task gathers variables defined in OS specific files.
+  #
+  # Search vars in:
+  #  - <distribution>_<major>.yml    # eg. CentOS_8.yml
+  #  - <os_family>_<major>.yml       # eg. RedHat_8.yml
+  #  - <distribution>.yml            # eg. CentOS.yml
+  #  - <os_family>.yml               # eg. RedHat.yml
+  #
+  # If no OS specific file is found, the role will default to vars/main.yml
+  #
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "vars/{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_major_version }}.yml"
+        - "vars/{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version }}.yml"
+        - "vars/{{ ansible_facts.distribution | replace(' ','_') }}.yml"
+        - "vars/{{ ansible_facts.os_family }}.yml"
+      skip: true
+  tags:
+    - internal
+
+- name: "firewalld █ Add services to firewall's {{ grafana_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ grafana_firewall_zone | default('public') }}"
+    service: "{{ item }}"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - ep_firewall | default(false) | bool
+  loop: "{{ grafana_firewall_services_to_add }}"
+  tags:
+    - firewall
+
+- name: "package █ Install {{ grafana_packages_to_install | join(' ') }} packages"
+  package:
+    name: "{{ grafana_packages_to_install }}"
+    state: present
+  tags:
+    - package
+
+- name: "service █ Manage {{ grafana_services_to_start | join(' ') }} services state"
+  service:
+    name: "{{ item }}"
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+    state: "{{ (start_services | bool) | ternary('started', omit) }}"
+  loop: "{{ grafana_services_to_start }}"
+  tags:
+    - service
+

--- a/roles/addons/grafana/vars/RedHat.yml
+++ b/roles/addons/grafana/vars/RedHat.yml
@@ -1,0 +1,7 @@
+---
+grafana_packages_to_install:
+  - grafana
+grafana_services_to_start:
+  - grafana-server
+grafana_firewall_services_to_add:
+  - grafana


### PR DESCRIPTION
I was reading #330 and thought it's a shame to install and start the service by hand. :stuck_out_tongue_closed_eyes: 

This is a basic role that add the grafana service to the appropriate firewall zone, install the RPM and start the service. No rocket science.

Tested on CentOS 8.2, management1, with prometheus running on management2.