### PR TITLE
fix: define mode for directories

### DIFF
--- a/roles/core/conman/tasks/main.yml
+++ b/roles/core/conman/tasks/main.yml
@@ -33,6 +33,7 @@
 - name: file █ Create /var/log/conman directory
   file:
     path: /var/log/conman
+    mode: 0750
     setype: conman_log_t
     state: directory
     recurse: yes

--- a/roles/core/log_server/tasks/main.yml
+++ b/roles/core/log_server/tasks/main.yml
@@ -43,6 +43,7 @@
 - name: Create /var/log/rsyslog directory
   file:
     path: /var/log/rsyslog
+    mode: 0750
     setype: var_log_t
     state: directory
     recurse: yes

--- a/roles/core/nfs_client/tasks/main.yml
+++ b/roles/core/nfs_client/tasks/main.yml
@@ -29,7 +29,7 @@
     - package
 
 - name: file █ Create NFS directories
-  file:
+  file:  # noqa 208
     path: "{{ item.0.mount }}"
     state: directory
   with_subelements:


### PR DESCRIPTION
Spotted by ansible-lint's rule E208. (#317)

Set mode 750 for /var/log/{conman,rsyslog}.
Skip the test for the nfs_client mount point.