### PR TITLE
fix: stop firewall service if ep_firewall = False

### DIFF
--- a/roles/core/firewall/tasks/main.yml
+++ b/roles/core/firewall/tasks/main.yml
@@ -32,7 +32,7 @@
   service:
     name: "{{ item }}"
     enabled: "{{ (ep_firewall | bool) | ternary('yes','no') }}"
-    state: "{{ (ep_firewall | bool) | ternary('started', omit) }}"
+    state: "{{ (ep_firewall | bool) | ternary('started', 'stopped') }}"
   loop: "{{ firewall_services_to_start }}"
   tags:
     - service


### PR DESCRIPTION
Identified during testing of 1.3-RC2: after enabling the firewall for some tests, I noticed a new run of my playbook which includes role firewall did not disable the service.
If ep_firewall is False, do not omit the state but ensure the service is stopped.

Note: I turned ep_firewall to True to enable the firewall for my test.