### PR TITLE
fix: enhance performance of bootset at scale

### DIFF
--- a/roles/core/pxe_stack/files/bootset.py
+++ b/roles/core/pxe_stack/files/bootset.py
@@ -182,14 +182,16 @@ elif passed_arguments.boot is not None:
             with open('/var/www/html/preboot_execution_environment/nodes/'+str(node)+'.ipxe', 'w') as ff:
                 ff.write(generic_node_ipxe)
             os.chown('/var/www/html/preboot_execution_environment/nodes/'+str(node)+'.ipxe', apache_uid, apache_gid)
-            if pxe_parameters["pxe_parameters"]["ansible_selinux_status"] == "enabled":
-                os.system('restorecon -v /var/www/html/preboot_execution_environment/nodes/'+str(node)+'.ipxe')
             logging.info('    ├── '+bcolors.OKGREEN+'[OK] Done.'+bcolors.ENDC)
 
             set_default_boot(node=node, boot=passed_arguments.boot, node_image=passed_arguments.image, extra_parameters=passed_arguments.extra_parameters)
 
         else:
             logging.warning(bcolors.WARNING+'Node '+str(node)+' do not exist. Skipping.'+bcolors.ENDC)
+
+    # Ensure SELinux context is correct
+    if pxe_parameters["pxe_parameters"]["ansible_selinux_status"] == "enabled":
+        os.system('restorecon -Rv /var/www/html/preboot_execution_environment/nodes/')
 
 elif passed_arguments.kickstart is not None:
 


### PR DESCRIPTION
Instead of running restorecon for each ipxe file in the for-loop, run a recursive restorecon once all the files are written.

Benchmark of the tool at scale demonstrated poor performance.

## Reference test : 80k nodes, no SELinux
```
[root@management1 ~]# find /var/www/html/preboot_execution_environment/nodes/ -name node\* -delete
[root@management1 ~]# echo 3 > /proc/sys/vm/drop_caches
[root@management1 ~]# cat /etc/bluebanquise/pxe/pxe_parameters.yml
pxe_parameters:
  apache_uid: apache
  apache_gid: apache
  ansible_selinux_status: disabled

[root@management1 ~]# time bootset -n node[00001-80000] -q -b osdeploy

real    1m10.953s
user    0m48.383s
sys     0m19.544s
```

## Test with SELinux enabled
```
[root@management1 ~]# find /var/www/html/preboot_execution_environment/nodes/ -type f -name node\* -delete
[root@management1 ~]# echo 3 > /proc/sys/vm/drop_caches
[root@management1 ~]# cat /etc/bluebanquise/pxe/pxe_parameters.yml
pxe_parameters:
  apache_uid: apache
  apache_gid: apache
  ansible_selinux_status: enabled

[root@management1 ~]# time bootset -n node[00001-80000] -q -b osdeploy

real    24m54.722s
user    5m30.858s
sys     19m0.458s
```

## Test with SELinux enabled + patch
```
[root@management1 ~]# find /var/www/html/preboot_execution_environment/nodes/ -type f -name node\* -delete
[root@management1 ~]# echo 3 > /proc/sys/vm/drop_caches
[root@management1 ~]# cat /etc/bluebanquise/pxe/pxe_parameters.yml
pxe_parameters:
  apache_uid: apache
  apache_gid: apache
  ansible_selinux_status: enabled
[root@management1 ~]# time bootset -n node[00001-80000] -q -b osdeploy

real    1m14.022s
user    0m52.958s
sys     0m18.005s
```