### PR TITLE
fix alias in hosts_file role (#359)

### DIFF
--- a/roles/core/hosts_file/templates/hosts.j2
+++ b/roles/core/hosts_file/templates/hosts.j2
@@ -21,7 +21,7 @@
 {% macro write_host(host,host_dict,current_iceberg) %}
 
   {%- if host_dict['network_interfaces'] is defined and host_dict['network_interfaces'] is iterable %}
-    {% set host_iceberg = node_current_iceberg(host) %}
+    {% set host_iceberg = node_current_iceberg(host) | trim %}
     {% set host_resolution_network = host_dict['network_interfaces'][0].network %}{# equivalent to j2_node_main_resolution_network, but no need for a macro here #}
     {% set alias_list = [] %}
     {% if host_dict['global_alias'] is defined and host_dict['global_alias'] is not none %}


### PR DESCRIPTION
alias were not generated due to \n at the end of the maccro

(cherry picked from commit 68701b7a69dfa867ce5947369bff98a3a51d15e3)