### PR TITLE
fix: document variables in role slurm

### DIFF
--- a/roles/addons/slurm/readme.rst
+++ b/roles/addons/slurm/readme.rst
@@ -62,6 +62,33 @@ And for a login (passive client), use:
     vars:
       slurm_profile: passive
 
+Input
+^^^^^
+
+Mandatory inventory vars:
+
+**hostvars[inventory_hostname]**
+
+* slurm_profile
+* slurm
+   * .cluster_name
+   * .control_machine
+   * .nodes_equipment_groups
+   * .slurm_packaging
+
+**hostvars[hosts]**
+
+* ep_hardware
+   * .cpu
+      * .core
+
+Optional inventory vars:
+
+**hostvars[inventory_hostname]**
+
+* slurm
+   * .MpiDefault
+
 To be done
 ^^^^^^^^^^
 

--- a/roles/addons/slurm/tasks/main.yml
+++ b/roles/addons/slurm/tasks/main.yml
@@ -77,10 +77,10 @@
   tags:
     - template
 
-- name: copy █ Copy cgroup.conf to /etc/slurm/cgroup.conf
+- name: "copy █ Copy cgroup.conf to {{ slurm_home_path }}/cgroup.conf"
   copy:
     src: cgroup.conf
-    dest: /etc/slurm/cgroup.conf
+    dest: "{{ slurm_home_path }}/cgroup.conf"
     owner: root
     group: root
     mode: 0644

--- a/roles/addons/slurm/templates/slurm.conf.j2
+++ b/roles/addons/slurm/templates/slurm.conf.j2
@@ -44,7 +44,7 @@ SelectType=select/cons_res
 
 ## Nodes list
 {% for equipment_group in slurm['nodes_equipment_groups'] %}
-{% if groups[equipment_group] is defined and not none %}
+{% if groups[equipment_group] is iterable %}
 {% for node in groups[equipment_group] %}
 NodeName={{node}} Procs={{hostvars[node]['ep_hardware']['cpu']['cores']}} State=UNKNOWN
 {% endfor %}
@@ -53,7 +53,7 @@ NodeName={{node}} Procs={{hostvars[node]['ep_hardware']['cpu']['cores']}} State=
 
 ## Partitions list
 {% for equipment_group in slurm['nodes_equipment_groups'] %}
-{% if groups[equipment_group] is defined and not none %}
+{% if groups[equipment_group] is iterable %}
 PartitionName={{equipment_group}} MaxTime=INFINITE State=UP Nodes={% for node in groups[equipment_group] %}{% if loop.first %}{{node}}{% else %},{{node}}{% endif %}{% endfor %}
 
 {% endif %}

--- a/roles/addons/slurm/vars/RedHat.yml
+++ b/roles/addons/slurm/vars/RedHat.yml
@@ -1,5 +1,5 @@
 ---
-slurm_home_path: /etc/slurm/
+slurm_home_path: /etc/slurm
 slurm_packages_to_install:
   before_17:
     controller:

--- a/roles/addons/slurm/vars/Ubuntu.yml
+++ b/roles/addons/slurm/vars/Ubuntu.yml
@@ -1,5 +1,5 @@
 ---
-slurm_home_path: /etc/slurm-llnl/
+slurm_home_path: /etc/slurm-llnl
 slurm_packages_to_install:
   before_17:
     controller:


### PR DESCRIPTION
List mandatory and optional variables in the readme.

Fixes #333.

Also fix the path to cgroup.conf (use slurm_home_path) and tests in
Jinja2 template.

(cherry picked from commit d9dc9c852305a00712a46254897d0bb9fbc75a9f)