### PR TITLE
backport: add firewall to prometheus  (#361)

### DIFF
--- a/roles/addons/prometheus_client/tasks/main.yml
+++ b/roles/addons/prometheus_client/tasks/main.yml
@@ -5,6 +5,21 @@
   loop: "{{ monitoring.exporters |dict2items }}"
   when: item.value.package is defined and item.key != "ipmi_exporter" and item.key != "snmp_exporter"
 
+- name: "firewalld █ Add services to firewall's {{ prometheus_client_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ prometheus_client_firewall_zone | default('public') }}"
+    port: "{{ item.port }}/tcp"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  loop: "{{ monitoring.exporters.values() | list }}"
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - ep_firewall | default(false) | bool
+    - item.port is defined
+  tags:
+    - firewall
+
 - name: set services
   service:
     name: "{{ item.value.service }}"

--- a/roles/addons/prometheus_server/files/alertmanager.xml
+++ b/roles/addons/prometheus_server/files/alertmanager.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>alertmanager</short>
+  <description>Alertmanager handles alerts sent by client applications such as the Prometheus server</description>
+  <port protocol="tcp" port="9093"/>
+</service>

--- a/roles/addons/prometheus_server/handlers/main.yml
+++ b/roles/addons/prometheus_server/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: reload firewalld
+  command: firewall-cmd --reload

--- a/roles/addons/prometheus_server/tasks/main.yml
+++ b/roles/addons/prometheus_server/tasks/main.yml
@@ -13,7 +13,7 @@
     - snmp_exporter
     - karma
 
-#for generator of oid walk for snmp_exporter     
+# for generator of oid walk for snmp_exporter     
 - name: Package
   package:
     name: "{{ item }}"
@@ -29,6 +29,38 @@
   when:
     - monitoring.exporters.snmp_exporter.with_generator is defined      
     - monitoring.exporters.snmp_exporter.with_generator
+
+- name: "copy █ Install firewalld service configuration file"
+  copy:
+    src: alertmanager.xml
+    dest: /etc/firewalld/services/alertmanager.xml
+    owner: root
+    group: root
+    mode: 0644
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - ep_firewall | default(false) | bool
+  notify: reload firewalld
+  tags:
+    - firewall
+
+- meta: flush_handlers
+
+- name: "firewalld █ Add services to firewall's {{ prometheus_server_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ prometheus_server_firewall_zone | default('public') }}"
+    service: "{{ item }}"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - ep_firewall | default(false) | bool
+  loop:
+    - prometheus
+    - alertmanager
+  tags:
+    - firewall
 
 - name: Create directories structure
   file:


### PR DESCRIPTION
* add firewall to prometheus_server role

* add firewall to prometheus_client role

* add alertmanager port to firewall

* remove node_exporter port, replace ports by services

* add alertmanager service file

* change "service" to "port" in firewalld task

* replace /usr/lib/firewalld by /etc/firewalld in prometheus_server

* Remove blank character at EOL

* reload firewalld after adding a service

* fix duplicated when condition in prometheus_client role

Co-authored-by: Bruno Travouillon <devel@travouillon.fr>
(cherry picked from commit cc6a3f576699cb40f4a0a3f3e65ab49322343077)