### PR TITLE
fix: don't create ini file if absent

### DIFF
--- a/roles/core/repositories_client/tasks/centos_7.yml
+++ b/roles/core/repositories_client/tasks/centos_7.yml
@@ -18,6 +18,7 @@
     option: enabled
     value: '0'
     no_extra_spaces: yes
+    create: no
   loop: [ 'base', 'updates', 'extras' ]
   when:
     - ( 'os' in repositories ) or

--- a/roles/core/repositories_client/tasks/centos_8.yml
+++ b/roles/core/repositories_client/tasks/centos_8.yml
@@ -22,6 +22,7 @@
     option: enabled
     value: '0'
     no_extra_spaces: yes
+    create: no
   when:
     - ( 'os' in repositories ) or
       ( repositories | selectattr('name', 'defined') | selectattr('name','equalto','os') | list | length == 1 )


### PR DESCRIPTION
The role repositories_client can change the default repository
configuration for CentOS with the ini_file module. This should only
apply if the file already exists. If it does not exist, do not create the
file.

ini_file defaults to `create: yes`, which makes the CI fail because the `mode` is not defined.