### PR TITLE
fix: check if diskless image_metadata.yml exists

### DIFF
--- a/roles/addons/diskless/files/disklessset.py
+++ b/roles/addons/diskless/files/disklessset.py
@@ -493,15 +493,18 @@ elif main_action == '4':
     sub_main_action = str(input('-->: ').lower().strip())
 
     if sub_main_action == '1':
-        for i in os.listdir(images_path):
-            image_info = read_yaml(os.path.join(images_path, str(i), 'image_metadata.yml'))
-            print('')
-            print('  Image name: '+str(i))
-            print('    ├── Kernel linked: '+str(image_info['image_kernel']))
-            print('    ├── Image type: '+str(image_info['image_type']))
-            if str(image_info['image_type']) == 'nfs':
-                print('    ├── image status: '+str(image_info['image_status']))
-            print('    └── Image creation date: '+str(image_info['image_creation_date']))
+        for image in os.listdir(images_path):
+            if os.path.exists(os.path.join(images_path, str(image), 'image_metadata.yml')):
+                image_info = read_yaml(os.path.join(images_path, str(image), 'image_metadata.yml'))
+                print('')
+                print('  Image name: '+str(image))
+                print('    ├── Kernel linked: '+str(image_info['image_kernel']))
+                print('    ├── Image type: '+str(image_info['image_type']))
+                if str(image_info['image_type']) == 'nfs':
+                    print('    ├── image status: '+str(image_info['image_status']))
+                print('    └── Image creation date: '+str(image_info['image_creation_date']))
+            else:
+                print(bcolors.WARNING + '[WARNING] The image \'' + image + '\' is incomplete.' + bcolors.ENDC)
 
     elif sub_main_action == '2':
         print('Manage kernels of an image.')


### PR DESCRIPTION
The image folder is created at the begining of the image creation
process while the image_metadata.yml file is created at the end. When
the image creation process fails, the directory exists but the metadata
file does not exist.

Check if the metadata file exists before read. Otherwise, print a
warning to inform the user the image is incomplete.

See: #296