### PR TITLE
fix: delete old variable from inventory

### DIFF
--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/repositories.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/repositories.yml
@@ -1,5 +1,3 @@
 repositories:
   - bluebanquise
   - os
-
-remove_distro_repositories: True

--- a/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/repositories.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/repositories.yml
@@ -1,5 +1,3 @@
 repositories:
   - bluebanquise
   - os
-
-remove_distro_repositories: True

--- a/roles/core/repositories_client/readme.rst
+++ b/roles/core/repositories_client/readme.rst
@@ -89,6 +89,10 @@ If equipment_profile is:
 
 Then path will be: repositories/production/centos/8.1/$basearch/
 
+For CentOS, the role will disable the default repositories of the distribution.
+If one want to keep the distro repositories, they must define
+`repositories_client_disable_distro_repos: False` in their inventory.
+
 Input
 ^^^^^
 
@@ -108,6 +112,7 @@ Optional inventory vars:
 * ep_operating_system
    * distribution_version
    * repositories_environment
+* repositories_client_disable_distro_repos (CentOS only)
 
 Output
 ^^^^^^


### PR DESCRIPTION
The variable remove_distro_repositories does not exist anymore.