### PR TITLE
fix: wrong images selinux context in disklessset

### DIFF
--- a/roles/addons/diskless/files/disklessset.py
+++ b/roles/addons/diskless/files/disklessset.py
@@ -489,6 +489,10 @@ elif main_action == '3':
                 write_yaml(os.path.join(images_path, selected_image_name, 'image_metadata.yml'), metadata)
             except Exception as e:
                 print(e)
+
+            if selinux:
+                os.system('restorecon -Rv {}'.format(os.path.join(images_path, selected_image_name)))
+
             print(bcolors.OKGREEN+'\n[OK] Done creating image.'+bcolors.ENDC)
 
 elif main_action == '4':


### PR DESCRIPTION
Hi

disklessset image generation leaves images (squash + boot.ipxe) files with the wrong selinux context. Thoses files cannot be served when selinux is enabled on managements.