### PR TITLE
Fix: pxe_stack - add grub2 shell in menu.ipxe

### DIFF
--- a/roles/core/pxe_stack/templates/menu.ipxe.j2
+++ b/roles/core/pxe_stack/templates/menu.ipxe.j2
@@ -40,7 +40,7 @@ item bootdeployclone      Deploy already made clone
 #item memtest              Memtest (To check Memory)
 item --gap                Other
 item startshell           iPXE shell (Go to an iPXE shell)
-item startgrubshell       Grub2 shell (Go to a Grub2 shell)
+item startgrubshell       Grub2 shell (Go to a Grub2 shell, EFI only)
 item showinfo             Display system infos
 choose --timeout ${menu-timeout} --default ${menu-default} selected || goto cancel
 set menu-timeout 0

--- a/roles/core/pxe_stack/templates/menu.ipxe.j2
+++ b/roles/core/pxe_stack/templates/menu.ipxe.j2
@@ -40,6 +40,7 @@ item bootdeployclone      Deploy already made clone
 #item memtest              Memtest (To check Memory)
 item --gap                Other
 item startshell           iPXE shell (Go to an iPXE shell)
+item startgrubshell       Grub2 shell (Go to a Grub2 shell)
 item showinfo             Display system infos
 choose --timeout ${menu-timeout} --default ${menu-default} selected || goto cancel
 set menu-timeout 0
@@ -53,6 +54,12 @@ shell
 set menu-timeout 0
 set submenu-timeout 0
 goto start
+
+:startgrubshell
+echo Booting on a Grub2 shell image...
+sleep 2
+chain http://${next-server}/preboot_execution_environment/bin/${arch}/grub2_shell.img || shell
+exit 1
 
 :showinfo
 echo


### PR DESCRIPTION
Add the grub2 shell entry in the menu.
Was present in the rpm, but missing here.

Related to https://github.com/bluebanquise/bluebanquise/issues/360