### PR TITLE
fix: ensure ep_ipxe_embed is defined before use

### DIFF
--- a/roles/addons/report/templates/equipment_profiles.html.j2
+++ b/roles/addons/report/templates/equipment_profiles.html.j2
@@ -9,7 +9,7 @@
   <ul class="lvl2">
     <li>iPXE driver:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_ipxe_driver']}}</span></li>
     <li>iPXE platform:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_ipxe_platform']}}</span></li>
-    <li>iPXE embed script:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_ipxe_embed']}}</span></li>
+    <li>iPXE embed script:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{ hostvars[groups[equipment][0]]['ep_ipxe_embed'] | default('standard') }}</span></li>
     <li>Preserve EFI first boot device during OS deployment:<span style="font-family: Courier, monospace, Monaco; font-size: 0.9em;"> {{hostvars[groups[equipment][0]]['ep_preserve_efi_first_boot_device']}}</span></li>
   </ul>
 

--- a/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
+++ b/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
@@ -28,7 +28,8 @@
     {% else %}{# Assume everything else is x86_64 #}
       {% set ipxe_architecture = 'x86_64' %}
     {% endif %}
-    {% if hostvars[host]['ep_ipxe_embed'] == 'dhcpretry' %} {# Now select embed script #}
+    {% if hostvars[host]['ep_ipxe_embed'] is defined and
+          hostvars[host]['ep_ipxe_embed'] == 'dhcpretry' %} {# Now select embed script #}
       {% set ipxe_embed = 'dhcpretry' %}
     {% else %}
       {% set ipxe_embed = 'standard' %}


### PR DESCRIPTION
If not defined, it will default to 'standard'.

(cherry picked from commit bd34757352d18a6ef875bc1615e429d52164b974)