### PR TITLE
ci: run molecule test with tox

### DIFF
--- a/.github/workflows/molecule-actions-addons-clustershell.yml
+++ b/.github/workflows/molecule-actions-addons-clustershell.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox
       - name: Run molecule test for addons/clustershell
         run: |
-          cd roles/addons/clustershell && molecule test
+          cd roles/addons/clustershell && tox

--- a/.github/workflows/molecule-actions-addons-grafana.yml
+++ b/.github/workflows/molecule-actions-addons-grafana.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox
       - name: Run molecule test for addons/grafana
         run: |
-          cd roles/addons/grafana && molecule test
+          cd roles/addons/grafana && tox

--- a/.github/workflows/molecule-actions-addons-root_password.yml
+++ b/.github/workflows/molecule-actions-addons-root_password.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox
       - name: Run molecule test for addons/root_password
         run: |
-          cd roles/addons/root_password && molecule test
+          cd roles/addons/root_password && tox

--- a/.github/workflows/molecule-actions-addons-users_basic.yml
+++ b/.github/workflows/molecule-actions-addons-users_basic.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox
       - name: Run molecule test for addons/users_basic
         run: |
-          cd roles/addons/users_basic && molecule test
+          cd roles/addons/users_basic && tox

--- a/.github/workflows/molecule-actions-core-bluebanquise.yml
+++ b/.github/workflows/molecule-actions-core-bluebanquise.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8 jmespath netaddr
+          pip install tox
       - name: Run molecule test for core/bluebanquise
         run: |
-          cd roles/core/bluebanquise && molecule test
+          cd roles/core/bluebanquise && tox

--- a/.github/workflows/molecule-actions-core-conman.yml
+++ b/.github/workflows/molecule-actions-core-conman.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox
       - name: Run molecule test for core/conman
         run: |
-          cd roles/core/conman && molecule test
+          cd roles/core/conman && tox

--- a/.github/workflows/molecule-actions-core-display_tuning.yml
+++ b/.github/workflows/molecule-actions-core-display_tuning.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox
       - name: Run molecule test for core/display_tuning
         run: |
-          cd roles/core/display_tuning && molecule test
+          cd roles/core/display_tuning && tox

--- a/.github/workflows/molecule-actions-core-dns_client.yml
+++ b/.github/workflows/molecule-actions-core-dns_client.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8 jmespath netaddr
+          pip install tox
       - name: Run molecule test for core/dns_client
         run: |
-          cd roles/core/dns_client && molecule test
+          cd roles/core/dns_client && tox

--- a/.github/workflows/molecule-actions-core-dns_server.yml
+++ b/.github/workflows/molecule-actions-core-dns_server.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8 jmespath netaddr
+          pip install tox
       - name: Run molecule test for core/dns_server
         run: |
-          cd roles/core/dns_server && molecule test
+          cd roles/core/dns_server && tox

--- a/.github/workflows/molecule-actions-core-firewall.yml
+++ b/.github/workflows/molecule-actions-core-firewall.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox
       - name: Run molecule test for core/firewall
         run: |
-          cd roles/core/firewall && molecule test
+          cd roles/core/firewall && tox

--- a/.github/workflows/molecule-actions-core-log_client.yml
+++ b/.github/workflows/molecule-actions-core-log_client.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox
       - name: Run molecule test for core/log_client
         run: |
-          cd roles/core/log_client && molecule test
+          cd roles/core/log_client && tox

--- a/.github/workflows/molecule-actions-core-log_server.yml
+++ b/.github/workflows/molecule-actions-core-log_server.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox
       - name: Run molecule test for core/log_server
         run: |
-          cd roles/core/log_server && molecule test
+          cd roles/core/log_server && tox

--- a/.github/workflows/molecule-actions-core-repositories_client.yml
+++ b/.github/workflows/molecule-actions-core-repositories_client.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox
       - name: Run molecule test for core/repositories_client
         run: |
-          cd roles/core/repositories_client && molecule test
+          cd roles/core/repositories_client && tox

--- a/.github/workflows/molecule-actions-core-ssh_master.yml
+++ b/.github/workflows/molecule-actions-core-ssh_master.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox
       - name: Run molecule test for core/ssh_master
         run: |
-          cd roles/core/ssh_master && molecule test
+          cd roles/core/ssh_master && tox

--- a/.github/workflows/molecule-actions-core-time.yml
+++ b/.github/workflows/molecule-actions-core-time.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox
       - name: Run molecule test for core/time
         run: |
-          cd roles/core/time && molecule test
+          cd roles/core/time && tox

--- a/roles/addons/clustershell/molecule/default/molecule.yml
+++ b/roles/addons/clustershell/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint:  |
   set -e
   yamllint .
-  ansible-lint
-  flake8
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"

--- a/roles/addons/grafana/molecule/default/molecule.yml
+++ b/roles/addons/grafana/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint: |
   set -e
   yamllint .
-  ansible-lint
-  flake8
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"

--- a/roles/addons/root_password/molecule/default/molecule.yml
+++ b/roles/addons/root_password/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint: |
   set -e
   yamllint .
-  ansible-lint
-  flake8
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"

--- a/roles/addons/users_basic/molecule/default/molecule.yml
+++ b/roles/addons/users_basic/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint:  |
   set -e
   yamllint .
-  ansible-lint
-  flake8
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"

--- a/roles/advanced-core/advanced_dns_server/molecule/default/molecule.yml
+++ b/roles/advanced-core/advanced_dns_server/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint: |
   set -e
   yamllint .
-  ansible-lint
-  flake8
 platforms:
   - name: mgmt0
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"

--- a/roles/advanced-core/advanced_dns_server/molecule/default/verify.yml
+++ b/roles/advanced-core/advanced_dns_server/molecule/default/verify.yml
@@ -14,5 +14,5 @@
 
     - name: assert files exist
       assert:
-        that: "{{ item }}.stat.exists"
+        that: "{{ item.stat.exists }}"
       loop: "{{ stat_results.results }}"

--- a/roles/core/bluebanquise/molecule/default/molecule.yml
+++ b/roles/core/bluebanquise/molecule/default/molecule.yml
@@ -15,11 +15,5 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
-  inventory:
-    host_vars:
-      ansiblectrl:
-        network_interfaces:
-          en0:
-            ip4: 10.10.0.1
 verifier:
   name: ansible

--- a/roles/core/bluebanquise/molecule/default/verify.yml
+++ b/roles/core/bluebanquise/molecule/default/verify.yml
@@ -8,14 +8,9 @@
     assert:
       that: ansible_facts.all_ipv4_addresses | ipaddr
 
-  - name: Test json_query filter in molecule controller
-    assert:
-      that: network_interfaces | json_query('*.ip4')
-
+- name: Verify filters in Ansible controller
+  hosts: localhost
+  tasks:
   - name: Test ipaddr filter in ansible controller
-    command: ansible localhost -c local -m assert -a "that={{ ansible_facts.all_ipv4_addresses }}|ipaddr"
-    changed_when: false
-
-  - name: Test json_query filter in ansible controller
-    command: ansible localhost -c local -m assert -a "that={'en0':{'ip4':'10.10.0.1'}}|json_query('*.ip4')"
-    changed_when: false
+    assert:
+      that: ansible_facts.all_ipv4_addresses | ipaddr

--- a/roles/core/display_tuning/molecule/default/molecule.yml
+++ b/roles/core/display_tuning/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint:  |
   set -e
   yamllint .
-  ansible-lint
-  flake8
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"

--- a/roles/core/display_tuning/molecule/default/verify.yml
+++ b/roles/core/display_tuning/molecule/default/verify.yml
@@ -14,5 +14,5 @@
 
   - name: assert files exist
     assert:
-      that: "{{ item }}.stat.exists"
+      that: "{{ item.stat.exists }}"
     loop: "{{ stat_results.results }}"

--- a/roles/core/dns_client/molecule/default/molecule.yml
+++ b/roles/core/dns_client/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint:  |
   set -e
   yamllint .
-  ansible-lint
-  flake8
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"

--- a/roles/core/dns_client/molecule/default/verify.yml
+++ b/roles/core/dns_client/molecule/default/verify.yml
@@ -11,5 +11,5 @@
 
     - name: assert files exist
       assert:
-        that: "{{ item }}.stat.exists"
+        that: "{{ item.stat.exists }}"
       loop: "{{ stat_results.results }}"

--- a/roles/core/dns_server/molecule/default/molecule.yml
+++ b/roles/core/dns_server/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint: |
   set -e
   yamllint .
-  ansible-lint
-  flake8
 platforms:
   - name: mgmt0
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"

--- a/roles/core/dns_server/molecule/default/verify.yml
+++ b/roles/core/dns_server/molecule/default/verify.yml
@@ -14,5 +14,5 @@
 
     - name: assert files exist
       assert:
-        that: "{{ item }}.stat.exists"
+        that: "{{ item.stat.exists }}"
       loop: "{{ stat_results.results }}"

--- a/roles/core/firewall/molecule/default/molecule.yml
+++ b/roles/core/firewall/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint: |
   set -e
   yamllint .
-  ansible-lint
-  flake8
 platforms:
   - name: firewall-stock
     groups:

--- a/roles/core/log_client/molecule/default/molecule.yml
+++ b/roles/core/log_client/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint:  |
   set -e
   yamllint .
-  ansible-lint
-  flake8
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"

--- a/roles/core/log_server/molecule/default/molecule.yml
+++ b/roles/core/log_server/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint:  |
   set -e
   yamllint .
-  ansible-lint
-  flake8
 platforms:
   - name: instance
     image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"

--- a/roles/core/time/molecule/default/converge.yml
+++ b/roles/core/time/molecule/default/converge.yml
@@ -1,6 +1,7 @@
 ---
 - name: Converge
   hosts: all
+  serial: 3
 
   vars:
     # Start the services by default

--- a/roles/core/time/molecule/default/molecule.yml
+++ b/roles/core/time/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint: |
   set -e
   yamllint .
-  ansible-lint
-  flake8
 platforms:
   - name: server-ext-pool
     groups:

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+envlist = py{27,3}-ansible{28,29,210}
+skipsdist = true
+
+[testenv]
+changedir = {env:PWD}
+passenv =
+    MOLECULE_DISTRO
+    INSTANCE_DISTRO
+    TERM
+    PY_COLORS
+    ANSIBLE_FORCE_COLOR
+deps =
+    ansible28: ansible==2.8
+    ansible29: ansible==2.9
+    ansible210: ansible==2.10
+    ansible-lint
+    flake8
+    jmespath
+    netaddr
+    py27: git+https://github.com/btravouillon/molecule.git@backport/3.0.2/2620#egg=molecule[docker]
+    py3: molecule[docker]
+commands =
+    molecule test


### PR DESCRIPTION
[tox](https://tox.readthedocs.io/en/latest/) helps to run `molecule test` in several environments.

This PR defines a combination of test environments:
-  Python 2.7 and Python 3
-  Ansible 2.8, 2.9 and 2.10

The purpose is to expand the test coverage.

Additional changes:
- Do not run ansible-lint and flake8 in molecule
    
    The static code analysis CI tests already run those tools with GitHub
    Actions for each PR or push to master. With the current tox
    configuration, the CI would run these 6x for each role, which is
    useless.

- Clean and fix some verify tests.

- Serialize the molecule converge for role time