### PR TITLE
Fix: hosts_file - Prevent massive empty lines generation

### DIFF
--- a/roles/core/hosts_file/templates/hosts.j2
+++ b/roles/core/hosts_file/templates/hosts.j2
@@ -77,9 +77,7 @@
 ## Internal hosts
 
 {% set current_iceberg = j2_current_iceberg %}
-{% for host in range %}
-{{ write_host(host,hostvars[host],current_iceberg) }}
-{% endfor %}
+{% for host in range %}{{ write_host(host,hostvars[host],current_iceberg) }}{% endfor %}
 
 ## External hosts
 

--- a/roles/core/hosts_file/templates/hosts.j2
+++ b/roles/core/hosts_file/templates/hosts.j2
@@ -77,7 +77,9 @@
 ## Internal hosts
 
 {% set current_iceberg = j2_current_iceberg %}
-{% for host in range %}{{ write_host(host,hostvars[host],current_iceberg) }}{% endfor %}
+{% for host in range -%}
+{{ write_host(host,hostvars[host],current_iceberg) }}
+{%- endfor %}
 
 ## External hosts
 


### PR DESCRIPTION
Prevent many empty lines when hosts are defined in the inventory, but without network_interfaces.