### PR TITLE
[diskless] customized image boots with incorrect interfaces names

### DIFF
--- a/roles/addons/diskless/files/disklessset.py
+++ b/roles/addons/diskless/files/disklessset.py
@@ -246,7 +246,7 @@ elif main_action == '2':
         exit(1)
 
     print(bcolors.OKBLUE+'[INFO] Now generating initramfs... May take some time.'+bcolors.ENDC)
-    os.system('dracut --xz -v -m "network base nfs" --add "livenet" --add-drivers xfs --no-hostonly --nolvmconf ' + kernels_path + '/initramfs-kernel-' + (kernel_list[selected_kernel].strip('vmlinuz-')) + ' --force --kver={}'.format(kernel_list[selected_kernel].strip('vmlinuz-')))
+    os.system('dracut --xz -v -m "network base nfs" --add "ifcfg livenet systemd systemd-initrd dracut-systemd" --add-drivers xfs --no-hostonly --nolvmconf ' + kernels_path + '/initramfs-kernel-' + (kernel_list[selected_kernel].strip('vmlinuz-')) + ' --force --kver={}'.format(kernel_list[selected_kernel].strip('vmlinuz-')))
     os.chmod(kernels_path + '/initramfs-kernel-' + (kernel_list[selected_kernel].strip('vmlinuz-')), 0o644)
     print(bcolors.OKGREEN+'\n[OK] Done.'+bcolors.ENDC)
 


### PR DESCRIPTION
Hello,
When a node boots on a customized diskless image, its interfaces names aren't renamed: 

```
systemd-udevd[4443]: Error changing net interface name 'eth0' to 'enp61s0f0': Device or resource busy
could not rename interface '2' from 'eth0' to 'enp61s0f0': Device or resource busy
```

And, diskless nodes got two "No DHCPOFFERS received" during les 10 minutes afterboot.

```
Oct  5 17:56:31 pm5-nod64 dhclient[4867]: No DHCPOFFERS received.
Oct  5 18:01:19 pm5-nod64 dhclient[4867]: No DHCPOFFERS received.
```

It missing two modules dracut in dracut CLI generator.

Regards