### PR TITLE
[diskless] The time role isn't functional for a custom diskless image

### DIFF
--- a/roles/addons/diskless/readme.rst
+++ b/roles/addons/diskless/readme.rst
@@ -303,6 +303,9 @@ Example Playbook
       - diskless
 
 
+Once the node is started, run your playbook with your roles.
+It is important to synchronize your node's time by running the role time.
+
 To be done
 ^^^^^^^^^^
 

--- a/roles/addons/diskless/readme.rst
+++ b/roles/addons/diskless/readme.rst
@@ -304,7 +304,7 @@ Example Playbook
 
 
 Once the node is started, run your playbook with your roles.
-It is important to synchronize your node's time by running the role time.
+It is important to synchronize your node's time by running the time role.
 
 To be done
 ^^^^^^^^^^

--- a/roles/core/time/tasks/main.yml
+++ b/roles/core/time/tasks/main.yml
@@ -56,8 +56,6 @@
 - name: "timezone █ Set system to {{ time_zone }} timezone"
   timezone:
     name: "{{ time_zone }}"
-  tags:
-    - identify
 
 - meta: flush_handlers
 

--- a/roles/core/time/tasks/main.yml
+++ b/roles/core/time/tasks/main.yml
@@ -56,6 +56,8 @@
 - name: "timezone █ Set system to {{ time_zone }} timezone"
   timezone:
     name: "{{ time_zone }}"
+  tags:
+    - identify
 
 - meta: flush_handlers
 


### PR DESCRIPTION
Hello,

The timezone module isn't designed to work in a chroot environment, so we have to add the identify tag in task role.

```
RUNNING HANDLER [log_client : Restart rsyslog services] 
*************************************************************
Thursday 01 October 2020 02:53:57 +0200 (0:00:00.338) 0:00:12.768 ******
ok: [/var/tmp/diskless/workdir/dkl_last_kernel_custom/mnt] => (item=rsyslog)
[WARNING]: Target is a chroot or systemd is offline. This can lead to false positives or prevent the init system tools from working.

TASK [log_client : Manage services state] 
*******************************************
```

Regards