### PR TITLE
ci: run ansible-lint on whole project tree

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -28,8 +28,5 @@ jobs:
       - name: Check python code
         run: flake8 . --statistics --ignore E501,E226
 
-      - name: Run linter on core and advanced-core roles
-        run: ansible-lint -v roles/{core,advanced-core}/* -x 204
-
-      - name: Run linter on example playbooks
-        run: ansible-lint -v --exclude . resources/examples/*/playbooks/*.yml
+      - name: Run ansible linter
+        run: ansible-lint -v -x 204

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### New roles
 
-  - addons/Lmod: allow to install Lmod and specify custom modulefiles path
+  - addons/lmod: allow to install Lmod and specify custom modulefiles path
 
 #### Roles improvement
 

--- a/resources/packaging/bluebanquise.spec
+++ b/resources/packaging/bluebanquise.spec
@@ -1,8 +1,8 @@
 %{!?version: %define version 1.3.0}
 
-%define roles_addons clone clustershell diskless grafana nic_nmcli ofed \
+%define roles_addons clone clustershell diskless grafana lmod nic_nmcli ofed \
 ofed_sm openldap_client openldap_server powerman prometheus_client \
-prometheus_server report root_password singularity slurm sssd users_basic Lmod
+prometheus_server report root_password singularity slurm sssd users_basic
 
 Name:           bluebanquise
 Version:        %{version}

--- a/roles/addons/Lmod/tasks/main.yml
+++ b/roles/addons/Lmod/tasks/main.yml
@@ -37,4 +37,4 @@
     mode: 0644
   tags:
     - template
-  when: Lmod_path is defined and Lmod_path is iterable 
+  when: Lmod_path is defined and Lmod_path is iterable

--- a/roles/addons/Lmod/templates/modules_extra_path.sh.j2
+++ b/roles/addons/Lmod/templates/modules_extra_path.sh.j2
@@ -1,1 +1,0 @@
-export MODULEPATH=$MODULEPATH{% for path in Lmod_path %}:{{ path }}{% endfor %}

--- a/roles/addons/Lmod/vars/RedHat.yml
+++ b/roles/addons/Lmod/vars/RedHat.yml
@@ -1,3 +1,0 @@
----
-Lmod_packages_to_install:
-  - Lmod

--- a/roles/addons/clone/tasks/main.yml
+++ b/roles/addons/clone/tasks/main.yml
@@ -1,19 +1,13 @@
 ---
-
-- name: file █ Create clone directory
+- name: file █ Create clone directories
   file:
-    path: /var/www/html/preboot_execution_environment/clone/
+    path: "{{ item }}"
     state: directory
-
-- name: file █ Create clonezilla directory
-  file:
-    path: /var/www/html/preboot_execution_environment/clone/clonezilla/
-    state: directory
-
-- name: file █ Create cloned_images directory
-  file:
-    path: /cloned_images
-    state: directory
+    mode: 0755
+  loop:
+    - /var/www/html/preboot_execution_environment/clone/
+    - /var/www/html/preboot_execution_environment/clone/clonezilla/
+    - /cloned_images
 
 - name: lineinfile █ Ensure cloned_images is exported over nfs (/etc/exports)
   lineinfile:
@@ -21,12 +15,11 @@
     regexp: ' # export name: cloned_images$'
     line: "/cloned_images *(rw,no_root_squash,sync) # export name: cloned_images"
 
-- name: copy █ Copy clone.ipxe
+- name: copy █ Copy clone.ipxe and deploy_clone.ipxe
   copy:
-    src: clone.ipxe
-    dest: /var/www/html/preboot_execution_environment/clone/clone.ipxe
-
-- name: copy █ Copy deploy_clone.ipxe
-  copy:
-    src: deploy_clone.ipxe
-    dest: /var/www/html/preboot_execution_environment/clone/deploy_clone.ipxe
+    src: "{{ item }}"
+    dest: "/var/www/html/preboot_execution_environment/clone/{{ item }}"
+    mode: 0644
+  loop:
+    - clone.ipxe
+    - deploy_clone.ipxe

--- a/roles/addons/lmod/readme.rst
+++ b/roles/addons/lmod/readme.rst
@@ -1,4 +1,4 @@
-Lmod
+lmod
 ----
 
 Description
@@ -13,13 +13,13 @@ Instructions
 Note that Lmod is available on EPEL repository, and requires Centos PowerTools to 
 to get all dependencies.
 
-If custom path are needed, define variable Lmod_path, as a list, in the inventory.
+If custom path are needed, define variable lmod_path, as a list, in the inventory.
 
 For example:
 
 .. code-block:: yaml
 
-  Lmod_path:
+  lmod_path:
     - /etc/modulefiles
     - /soft/modules
 
@@ -30,7 +30,7 @@ Optional inventory vars:
 
 **hostvars[inventory_hostname]**
 
-* Lmod (list)
+* lmod_path (list)
 
 Output
 ^^^^^^

--- a/roles/addons/lmod/tasks/main.yml
+++ b/roles/addons/lmod/tasks/main.yml
@@ -21,9 +21,9 @@
   tags:
     - internal
 
-- name: "package █ Install {{ Lmod_packages_to_install | join(' ') }}"
+- name: "package █ Install {{ lmod_packages_to_install | join(' ') }}"
   package:
-    name: "{{ Lmod_packages_to_install }}"
+    name: "{{ lmod_packages_to_install }}"
     state: present
   tags:
     - package
@@ -37,4 +37,4 @@
     mode: 0644
   tags:
     - template
-  when: Lmod_path is defined and Lmod_path is iterable
+  when: lmod_path is defined and lmod_path is iterable

--- a/roles/addons/lmod/templates/modules_extra_path.sh.j2
+++ b/roles/addons/lmod/templates/modules_extra_path.sh.j2
@@ -1,0 +1,1 @@
+export MODULEPATH=$MODULEPATH{% for path in lmod_path %}:{{ path }}{% endfor %}

--- a/roles/addons/lmod/vars/RedHat.yml
+++ b/roles/addons/lmod/vars/RedHat.yml
@@ -1,0 +1,3 @@
+---
+lmod_packages_to_install:
+  - Lmod

--- a/roles/addons/openldap_server/tasks/main.yml
+++ b/roles/addons/openldap_server/tasks/main.yml
@@ -40,6 +40,7 @@
     dest: /var/lib/ldap/DB_CONFIG
     owner: ldap
     group: ldap
+    mode: 0644
   when: not db_config.stat.exists
 
 - name: Enable/disable services
@@ -61,6 +62,7 @@
   template:
     src: chdomain.ldif.j2
     dest: /dev/shm/chdomain.ldif
+    mode: 0644
 #  when:
 #    - db_config.stat.exists == False
 
@@ -68,6 +70,7 @@
   template:
     src: basedomain.ldif.j2
     dest: /dev/shm/basedomain.ldif
+    mode: 0644
 #  when:
 #    - db_config.stat.exists == False
 

--- a/roles/addons/prometheus_server/tasks/main.yml
+++ b/roles/addons/prometheus_server/tasks/main.yml
@@ -27,7 +27,7 @@
     - net-snmp-libs
     - net-snmp-devel
   when:
-    - monitoring.exporters.snmp_exporter.with_generator is defined      
+    - monitoring.exporters.snmp_exporter.with_generator is defined
     - monitoring.exporters.snmp_exporter.with_generator
 
 - name: "copy █ Install firewalld service configuration file"
@@ -152,7 +152,7 @@
     - prometheus
     - alertmanager
     - ipmi_exporter
-    - snmp_exporter    
+    - snmp_exporter
     - karma
   when: (start_services | bool)
   tags:

--- a/roles/addons/sssd/tasks/main.yml
+++ b/roles/addons/sssd/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Package
   package:
-    name: 
+    name:
       - sssd
       - authconfig
     state: present
@@ -9,8 +9,9 @@
   file:
     path: /etc/sysconfig/authconfig
     state: touch
+    mode: 0644
 
-- name: Checking if SSSD is already activated 
+- name: Checking if SSSD is already activated
   command: grep "USESSSDAUTH=yes" /etc/sysconfig/authconfig
   register: sssd
   failed_when: sssd.rc != 0 and sssd.rc != 1

--- a/roles/addons/sssd/tasks/main.yml
+++ b/roles/addons/sssd/tasks/main.yml
@@ -5,21 +5,18 @@
       - authconfig
     state: present
 
-- name: Touch /etc/sysconfig/authconfig file to avoid failure later
-  file:
+- name: Checking if SSSD is already active
+  lineinfile:
     path: /etc/sysconfig/authconfig
-    state: touch
-    mode: 0644
-
-- name: Checking if SSSD is already activated
-  command: grep "USESSSDAUTH=yes" /etc/sysconfig/authconfig
-  register: sssd
-  failed_when: sssd.rc != 0 and sssd.rc != 1
+    regexp: '^USESSSDAUTH=yes$'
+    state: absent
+  check_mode: yes
+  changed_when: False
+  register: sssd_enabled
 
 - name: Enable SSSD
   command: authconfig --enablesssd --enablesssdauth --enablelocauthorize --enablemkhomedir --update
-  when:
-    - sssd.rc == 1
+  when: sssd_enabled.found is not defined or not sssd_enabled.found
 
 - name: Template >> /etc/sssd/sssd.conf
   template:

--- a/roles/core/ssh_master/molecule/default/prepare.yml
+++ b/roles/core/ssh_master/molecule/default/prepare.yml
@@ -9,4 +9,4 @@
         state: directory
         owner: root
         group: root
-        mode: 700
+        mode: 0700


### PR DESCRIPTION
We did a great job over the year to improve the quality of the code. It's now time to finish the work and enable the ansible linter on the whole project tree in the CI.

List of remaining errors:
 - 106  Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
 - 201  Trailing whitespace
 - 202  Octal file permissions must contain leading zero or be a string
 - 208  File permissions not mentioned
 - 301  Commands should not change things if nothing needs doing

List of changes to make the linter happy 😁 :
 - Remove trailing whitespaces
 - Set mode for file permissions: use the default values (0755 for dir, 0644 for files)
 - Update the check of /etc/sysconfig/authconfig in role sssd
 - Rename role Lmod to lmod ([Role names are now limited to contain only lowercase alphanumeric characters, plus _ and start with an alpha character](https://docs.ansible.com/ansible/devel/dev_guide/developing_collections.html#roles-directory)).
