### PR TITLE
Adding molecule unitary tests for advanced_dhcp_server role

### DIFF
--- a/.github/TEST_MATRIX.md
+++ b/.github/TEST_MATRIX.md
@@ -22,3 +22,4 @@ Molecule unit tests
 |![addons/grafana unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/grafana%20unit%20testing/badge.svg)                     | x | x |   |
 |![addons/root_password unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/root_password%20unit%20testing/badge.svg)         | x | x | x |
 |![addons/users_basic unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/users_basic%20unit%20testing/badge.svg)             | x | x | x |
+|![advanced-core/advanced_dhcp_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/advanced-core/advanced_dhcp_server%20unit%20testing/badge.svg)                   | x |   |   |

--- a/.github/TEST_MATRIX.md
+++ b/.github/TEST_MATRIX.md
@@ -22,4 +22,4 @@ Molecule unit tests
 |![addons/grafana unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/grafana%20unit%20testing/badge.svg)                     | x | x |   |
 |![addons/root_password unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/root_password%20unit%20testing/badge.svg)         | x | x | x |
 |![addons/users_basic unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/users_basic%20unit%20testing/badge.svg)             | x | x | x |
-|![advanced-core/advanced_dhcp_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/advanced-core/advanced_dhcp_server%20unit%20testing/badge.svg)                   | x |   |   |
+|![advanced-core/advanced_dhcp_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/advanced-core/advanced_dhcp_server%20unit%20testing/badge.svg)                   | x | x |   |

--- a/.github/workflows/molecule-actions-advanced-core-advanced_dhcp_server.yml
+++ b/.github/workflows/molecule-actions-advanced-core-advanced_dhcp_server.yml
@@ -1,0 +1,39 @@
+---
+name: advanced-core/advanced_dhcp_server unit testing
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'roles/advanced-core/advanced_dhcp_server/**'
+      - '.github/workflows/molecule-actions-advanced-core-advanced_dhcp_server.yml'
+  pull_request:
+    paths:
+      - 'roles/advanced-core/advanced_dhcp_server/**'
+      - '.github/workflows/molecule-actions-advanced-core-advanced_dhcp_server.yml'
+
+jobs:
+  molecule_test:
+    name: ${{ matrix.distro }} - molecule test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - centos:8
+
+    env:
+      MOLECULE_DISTRO: ${{ matrix.distro }}
+      PY_COLORS: 1
+      ANSIBLE_FORCE_COLOR: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup python environment
+        uses: actions/setup-python@v1
+      - name: Install packages
+        run: |
+          pip install 'molecule[docker]>3' ansible-lint flake8 jmespath netaddr
+      - name: Run molecule test for advanced-core/advanced_dhcp_server
+        run: |
+          cd roles/advanced-core/advanced_dhcp_server && molecule test

--- a/.github/workflows/molecule-actions-advanced-core-advanced_dhcp_server.yml
+++ b/.github/workflows/molecule-actions-advanced-core-advanced_dhcp_server.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         distro:
+          - centos:7
           - centos:8
 
     env:
@@ -33,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8 jmespath netaddr
+          pip install tox
       - name: Run molecule test for advanced-core/advanced_dhcp_server
         run: |
-          cd roles/advanced-core/advanced_dhcp_server && molecule test
+          cd roles/advanced-core/advanced_dhcp_server && tox

--- a/roles/advanced-core/advanced_dhcp_server/.yamllint
+++ b/roles/advanced-core/advanced_dhcp_server/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/advanced-core/advanced_dhcp_server/molecule/default/INSTALL.rst
+++ b/roles/advanced-core/advanced_dhcp_server/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/roles/advanced-core/advanced_dhcp_server/molecule/default/converge.yml
+++ b/roles/advanced-core/advanced_dhcp_server/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: management1
+  tasks:
+    - name: "Include advanced_dhcp_server"
+      include_role:
+        name: "advanced_dhcp_server"

--- a/roles/advanced-core/advanced_dhcp_server/molecule/default/molecule.yml
+++ b/roles/advanced-core/advanced_dhcp_server/molecule/default/molecule.yml
@@ -1,0 +1,164 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: management1
+    groups:
+      - mg_managements
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
+    override_command: false
+    capabilities:
+      - "SYS_ADMIN"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    docker_networks:
+      - name: bbnet
+        ipam_config:
+          - subnet: '10.11.0.0/16'
+            gateway: "10.11.0.254"
+    networks:
+      - name: bbnet
+        ipv4_address: "10.11.0.1"
+
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      management1:
+
+        network_interfaces:
+          - interface: enp0s3
+            ip4: 10.11.0.1
+            mac: 08:00:27:dc:f8:f5
+            network: ice1-1
+
+        start_services: true
+        enable_services: true
+        domain_name: tumulus.local
+        icebergs_system: false
+        j2_node_main_network: ice1-1
+        j2_current_iceberg_network: ice1
+
+        ep_firewall: true
+        ep_ipxe_driver: snponly
+        ep_ipxe_platform: pcbios
+        ep_hardware:
+          cpu:
+            architecture: x86_64
+
+        networks:
+          ice1-1:
+            subnet: 10.11.0.0
+            prefix: 16
+            shared_network: wolf
+            netmask: 255.255.0.0
+            broadcast: 10.11.255.255
+            dhcp_unknown_range: 10.11.254.1 10.11.254.254
+            gateway: 10.11.2.1
+            is_in_dhcp: true
+            is_in_dns: true
+            services_ip:
+              pxe_ip: 10.11.0.1
+              dns_ip: 10.11.0.1
+              repository_ip: 10.11.0.1
+              authentication_ip: 10.11.0.1
+              time_ip: 10.11.0.1
+              log_ip: 10.11.0.1
+
+          ice1-2:
+            subnet: 10.30.0.0
+            prefix: 16
+            shared_network: wolf
+            netmask: 255.255.0.0
+            broadcast: 10.30.255.255
+            dhcp_unknown_range: 10.30.254.1 10.30.254.254
+            gateway: 10.30.2.1
+            is_in_dhcp: true
+            is_in_dns: true
+            services_ip:
+              pxe_ip: 10.30.0.1
+              dns_ip: 10.30.0.1
+              repository_ip: 10.30.0.1
+              authentication_ip: 10.30.0.1
+              time_ip: 10.30.0.1
+              log_ip: 10.30.0.1
+
+    hosts:
+      computes:
+        hosts:
+
+          compute1:
+            network_interfaces:
+            - interface: enp0s3
+              ip4: 10.11.3.1
+              mac: 08:00:27:dc:f8:f6
+              network: ice1-1
+            bmc:
+              name: compute1-bmc
+              ip4: 10.11.103.1
+              mac: 08:00:27:dc:f8:f6
+              network: ice1-1
+
+            ep_ipxe_driver: default
+            ep_ipxe_platform: pcbios
+            ep_hardware:
+              cpu:
+                architecture: x86_64
+
+          compute2:
+            alias:
+              - compute2-opt82
+            network_interfaces:
+            - interface: enp0s3
+              match: |
+                (substring (option agent.remote-id, 0 , 14) = "0"
+                and option agent.circuit-id = 01:00:16
+                and not (substring(option vendor-class-identifier, 0, 15) = "VENDOR_NAME_1" or
+                substring(option vendor-class-identifier, 0, 13) = "VENDOR_NAME_2")) or
+                (option dhcp-message-type = 3 and binary-to-ascii(10, 8, ".", option dhcp-requested-address) = "10.11.3.2" ) 
+              ip4: 10.11.3.2
+              network: ice1-1
+            bmc:
+              name: compute2-bmc
+              alias:
+                - compute2-bmc
+              match: |
+                substring (option agent.remote-id, 0 , 44) = "0"
+                and option agent.circuit-id = 01:00:17
+                and (substring(option vendor-class-identifier, 0, 10) = "VENDOR_NAME_1")
+              ip4: 10.11.103.2
+              network: ice1-1
+
+            ep_ipxe_driver: default
+            ep_ipxe_platform: efi
+            ep_hardware:
+              cpu:
+                architecture: x86_64
+
+          compute3:
+            alias:
+              - compute3-opt61
+            network_interfaces:
+            - interface: enp0s3
+              ip4: 10.30.3.3
+              mac: 08:00:27:dc:f8:f7
+              network: ice1-2
+            bmc:
+              name: compute3-bmc
+              alias:
+                - compute3-bmc
+              dhcp_client_identifier: 00:30:18
+              ip4: 10.30.103.3
+              network: ice1-2
+            
+            ep_ipxe_driver: snponly
+            ep_ipxe_platform: efi
+            ep_hardware:
+              cpu:
+                architecture: x86_64
+verifier:
+  name: ansible

--- a/roles/advanced-core/advanced_dhcp_server/molecule/default/molecule.yml
+++ b/roles/advanced-core/advanced_dhcp_server/molecule/default/molecule.yml
@@ -15,15 +15,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
-    docker_networks:
-      - name: bbnet
-        ipam_config:
-          - subnet: '10.11.0.0/16'
-            gateway: "10.11.0.254"
-    networks:
-      - name: bbnet
-        ipv4_address: "10.11.0.1"
-
 provisioner:
   name: ansible
   inventory:
@@ -36,7 +27,7 @@ provisioner:
             mac: 08:00:27:dc:f8:f5
             network: ice1-1
 
-        start_services: true
+        start_services: false
         enable_services: true
         domain_name: tumulus.local
         icebergs_system: false
@@ -57,7 +48,6 @@ provisioner:
             shared_network: wolf
             netmask: 255.255.0.0
             broadcast: 10.11.255.255
-            dhcp_unknown_range: 10.11.254.1 10.11.254.254
             gateway: 10.11.2.1
             is_in_dhcp: true
             is_in_dns: true
@@ -75,7 +65,7 @@ provisioner:
             shared_network: wolf
             netmask: 255.255.0.0
             broadcast: 10.30.255.255
-            dhcp_unknown_range: 10.30.254.1 10.30.254.254
+            dhcp_unknown_range: 10.30.0.2 10.30.0.254
             gateway: 10.30.2.1
             is_in_dhcp: true
             is_in_dns: true
@@ -88,7 +78,7 @@ provisioner:
               log_ip: 10.30.0.1
 
     hosts:
-      computes:
+      fake_computes:
         hosts:
 
           compute1:
@@ -125,7 +115,7 @@ provisioner:
             bmc:
               name: compute2-bmc
               alias:
-                - compute2-bmc
+                - compute2-opt82-bmc
               match: |
                 substring (option agent.remote-id, 0 , 44) = "0"
                 and option agent.circuit-id = 01:00:17
@@ -150,7 +140,7 @@ provisioner:
             bmc:
               name: compute3-bmc
               alias:
-                - compute3-bmc
+                - compute3-opt61-bmc
               dhcp_client_identifier: 00:30:18
               ip4: 10.30.103.3
               network: ice1-2

--- a/roles/advanced-core/advanced_dhcp_server/molecule/default/prepare.yml
+++ b/roles/advanced-core/advanced_dhcp_server/molecule/default/prepare.yml
@@ -1,0 +1,14 @@
+---
+- name: Prepare
+  hosts: management1
+  tasks:
+    - name: Install firewall package
+      package:
+        name: firewalld
+        state: present
+
+    - name: Start firewall
+      service:
+        name: firewalld
+        enabled: yes
+        state: started

--- a/roles/advanced-core/advanced_dhcp_server/molecule/default/verify.yml
+++ b/roles/advanced-core/advanced_dhcp_server/molecule/default/verify.yml
@@ -97,7 +97,7 @@
     - name: Retrieve subnet 10.11.0.0 configuration in /etc/dhcp/dhcpd.networks.conf file
       lineinfile:
         path: /etc/dhcp/dhcpd.networks.conf
-        regexp: "subnet 10.10.0.0 netmask 255.255.0.0"
+        regexp: "subnet 10.11.0.0 netmask 255.255.0.0"
         state: absent
       check_mode: yes
       register: reg_dhcp_subnet1

--- a/roles/advanced-core/advanced_dhcp_server/molecule/default/verify.yml
+++ b/roles/advanced-core/advanced_dhcp_server/molecule/default/verify.yml
@@ -1,0 +1,197 @@
+---
+- name: Verify
+  hosts: management1
+  tasks:
+
+    - name: Collect package facts
+      package_facts:
+        manager: auto
+
+    - name: Collect services facts
+      service_facts:
+
+    - name: Collect services of zone public
+      command: firewall-cmd --zone=public --list-all
+      register: firewall_cmd_result
+      changed_when: False
+
+    - name: Firewall zone public check presence of service dhcp
+      assert:
+        that: firewall_cmd_result.stdout |
+                    regex_findall(('dhcp|dhcpv6-client'), multiline=False) | length == 2
+
+    - name: Assert dhcp-server package is installed
+      assert:
+        that: "'dhcp-server' in ansible_facts.packages"
+
+    - name: Check dhcpd is enabled
+      assert:
+        that: "ansible_facts.services['dhcpd.service'].status == 'enabled'"
+
+    - name: Check dhcpd is running
+      assert:
+        that: "ansible_facts.services['dhcpd.service'].state == 'running'"
+
+    # Check all conf files
+
+    - name: Retrieve file dhcpd.conf system status
+      stat:
+        path: /etc/dhcp/dhcpd.conf
+      register: reg_dhcp
+
+    - name: Assert file dhcpd.conf exist
+      assert:
+        that: reg_dhcp.stat.exists
+
+    - name: Retrieve file dhcpd.ice1-1.conf system status
+      stat:
+        path: /etc/dhcp/dhcpd.ice1-1.conf
+      register: reg_dhcp1
+
+    - name: Assert file dhcpd.ice1-1.conf exist
+      assert:
+        that: reg_dhcp1.stat.exists
+
+    - name: Retrieve file dhcpd.ice1-2.conf system status
+      stat:
+        path: /etc/dhcp/dhcpd.ice1-2.conf
+      register: reg_dhcp2
+
+    - name: Assert file dhcpd.ice1-2.conf exist
+      assert:
+        that: reg_dhcp2.stat.exists
+
+    - name: Retrieve file dhcpd.networks.conf system status
+      stat:
+        path: /etc/dhcp/dhcpd.networks.conf
+      register: reg_dhcp_network_file
+
+    - name: Assert file dhcpd.networks.conf exist
+      assert:
+        that: reg_dhcp_network_file.stat.exists
+
+    - name: Retrieve ignore-client-uids configuration in /etc/dhcp/dhcpd.conf file
+      lineinfile:
+        path: /etc/dhcp/dhcpd.conf
+        regexp: "ignore-client-uids False;"
+        state: absent
+      check_mode: yes
+      register: reg_dhcp_uids
+
+    - name: Check /etc/dhcp/dhcpd.conf file contains (ignore-client-uids=False)
+      assert:
+        that: reg_dhcp_uids.found
+
+    - name: Retrieve shared-network configuration in /etc/dhcp/dhcpd.networks.conf file
+      lineinfile:
+        path: /etc/dhcp/dhcpd.networks.conf
+        regexp: "shared-network wolf"
+        state: absent
+      check_mode: yes
+      register: reg_dhcp_shared_network
+
+    - name: Check /etc/dhcp/dhcpd.networks.conf file contains shared-network
+      assert:
+        that: reg_dhcp_shared_network.found
+
+    - name: Retrieve subnet 10.11.0.0 configuration in /etc/dhcp/dhcpd.networks.conf file
+      lineinfile:
+        path: /etc/dhcp/dhcpd.networks.conf
+        regexp: "subnet 10.10.0.0 netmask 255.255.0.0"
+        state: absent
+      check_mode: yes
+      register: reg_dhcp_subnet1
+
+    - name: Check /etc/dhcp/dhcpd.networks.conf file contains subnet 10.11.0.0
+      assert:
+        that: reg_dhcp_subnet1.found
+
+    - name: Retrieve subnet 10.30.0.0 configuration in /etc/dhcp/dhcpd.networks.conf file
+      lineinfile:
+        path: /etc/dhcp/dhcpd.networks.conf
+        regexp: "subnet 10.30.0.0 netmask 255.255.0.0"
+        state: absent
+      check_mode: yes
+      register: reg_dhcp_subnet2
+
+    - name: Check /etc/dhcp/dhcpd.networks.conf file contains subnet 10.30.0.0
+      assert:
+        that: reg_dhcp_subnet2.found
+
+    # Check compute with mac address
+
+    - name: Retrieve compute1-ice1-1 in /etc/dhcp/dhcpd.ice1-1.conf file
+      lineinfile:
+        path: /etc/dhcp/dhcpd.ice1-1.conf
+        regexp: "host compute1-ice1-1"
+        state: absent
+      check_mode: yes
+      register: register_stat_dhcp_file
+
+    - name: Check /etc/dhcp/dhcpd.ice1-1.conf file contains compute1-ice1-1
+      assert:
+        that: register_stat_dhcp_file.found
+
+    # Check compute with opt82
+
+    - name: Retrieve option_match_compute2 in /etc/dhcp/dhcpd.ice1-1.conf file
+      lineinfile:
+        path: /etc/dhcp/dhcpd.ice1-1.conf
+        regexp: "option_match_compute2"
+        state: absent
+      check_mode: yes
+      register: reg_dhcp_file_opt82
+
+    - name: Check /etc/dhcp/dhcpd.ice1-1.conf file contains opt82 configuration for compute2
+      assert:
+        that: reg_dhcp_file_opt82.found
+
+    - name: Retrieve circuit-id configuration in /etc/dhcp/dhcpd.ice1-1.conf file
+      lineinfile:
+        path: /etc/dhcp/dhcpd.ice1-1.conf
+        regexp: "circuit-id = 01:00:17"
+        state: absent
+      check_mode: yes
+      register: reg_dhcp_file_opt82_circuit_id
+
+    - name: Check /etc/dhcp/dhcpd.ice1-1.conf file contains circuit-id configuration for compute2
+      assert:
+        that: reg_dhcp_file_opt82_circuit_id.found
+
+    - name: Retrieve option_match_compute2-bmc in /etc/dhcp/dhcpd.ice1-1.conf file
+      lineinfile:
+        path: /etc/dhcp/dhcpd.ice1-1.conf
+        regexp: "option_match_compute2-bmc"
+        state: absent
+      check_mode: yes
+      register: reg_dhcp_file_opt82_bmc
+
+    - name: Check /etc/dhcp/dhcpd.ice1-1.conf file contains opt82 configuration for bmc in compute2
+      assert:
+        that: reg_dhcp_file_opt82_bmc.found
+
+    # Check compute with opt61
+
+    - name: Retrieve compute3-ice1-2 in /etc/dhcp/dhcpd.ice1-2.conf file
+      lineinfile:
+        path: /etc/dhcp/dhcpd.ice1-2.conf
+        regexp: "host compute3-ice1-2"
+        state: absent
+      check_mode: yes
+      register: reg_dhcp_file_opt61
+
+    - name: Check /etc/dhcp/dhcpd.ice1-2.conf file contains opt61 configuration for compute3-ice1-2
+      assert:
+        that: reg_dhcp_file_opt61.found
+
+    - name: Retrieve compute3-bmc in /etc/dhcp/dhcpd.ice1-2.conf file
+      lineinfile:
+        path: /etc/dhcp/dhcpd.ice1-2.conf
+        regexp: "host compute3-bmc"
+        state: absent
+      check_mode: yes
+      register: reg_dhcp_file_opt61_bmc
+
+    - name: Check /etc/dhcp/dhcpd.ice1-2.conf file contains opt82 configuration for bmc in compute3-ice1-2
+      assert:
+        that: reg_dhcp_file_opt61_bmc.found

--- a/roles/advanced-core/advanced_dhcp_server/molecule/default/verify.yml
+++ b/roles/advanced-core/advanced_dhcp_server/molecule/default/verify.yml
@@ -20,17 +20,23 @@
         that: firewall_cmd_result.stdout |
                     regex_findall(('dhcp|dhcpv6-client'), multiline=False) | length == 2
 
+    - name: Assert dhcp package is installed
+      assert:
+        that: "'dhcp' in ansible_facts.packages"
+      when:
+        - ansible_facts.os_family == "RedHat"
+        - ansible_facts.distribution_major_version == "7"
+
     - name: Assert dhcp-server package is installed
       assert:
         that: "'dhcp-server' in ansible_facts.packages"
+      when:
+        - ansible_facts.os_family == "RedHat"
+        - ansible_facts.distribution_major_version == "8"
 
     - name: Check dhcpd is enabled
       assert:
         that: "ansible_facts.services['dhcpd.service'].status == 'enabled'"
-
-    - name: Check dhcpd is running
-      assert:
-        that: "ansible_facts.services['dhcpd.service'].state == 'running'"
 
     # Check all conf files
 
@@ -38,6 +44,7 @@
       stat:
         path: /etc/dhcp/dhcpd.conf
       register: reg_dhcp
+      changed_when: False
 
     - name: Assert file dhcpd.conf exist
       assert:
@@ -47,6 +54,7 @@
       stat:
         path: /etc/dhcp/dhcpd.ice1-1.conf
       register: reg_dhcp1
+      changed_when: False
 
     - name: Assert file dhcpd.ice1-1.conf exist
       assert:
@@ -56,6 +64,7 @@
       stat:
         path: /etc/dhcp/dhcpd.ice1-2.conf
       register: reg_dhcp2
+      changed_when: False
 
     - name: Assert file dhcpd.ice1-2.conf exist
       assert:
@@ -65,6 +74,7 @@
       stat:
         path: /etc/dhcp/dhcpd.networks.conf
       register: reg_dhcp_network_file
+      changed_when: False
 
     - name: Assert file dhcpd.networks.conf exist
       assert:
@@ -77,6 +87,7 @@
         state: absent
       check_mode: yes
       register: reg_dhcp_uids
+      changed_when: False
 
     - name: Check /etc/dhcp/dhcpd.conf file contains (ignore-client-uids=False)
       assert:
@@ -89,6 +100,7 @@
         state: absent
       check_mode: yes
       register: reg_dhcp_shared_network
+      changed_when: False
 
     - name: Check /etc/dhcp/dhcpd.networks.conf file contains shared-network
       assert:
@@ -101,6 +113,7 @@
         state: absent
       check_mode: yes
       register: reg_dhcp_subnet1
+      changed_when: False
 
     - name: Check /etc/dhcp/dhcpd.networks.conf file contains subnet 10.11.0.0
       assert:
@@ -113,10 +126,21 @@
         state: absent
       check_mode: yes
       register: reg_dhcp_subnet2
+      changed_when: False
 
     - name: Check /etc/dhcp/dhcpd.networks.conf file contains subnet 10.30.0.0
       assert:
         that: reg_dhcp_subnet2.found
+
+    - name: Retrieve file state of /etc/dhcp/dhcpd.conf file
+      command: dhcpd -t -cf /etc/dhcp/dhcpd.conf
+      register: dhcpd_cmd_result
+      changed_when: False
+
+    - name: Check syntax in /etc/dhcp/dhcpd.conf file
+      assert:
+        that: dhcpd_cmd_result.stdout |
+                    regex_findall(('Configuration file errors encountered'), multiline=False) | length == 0
 
     # Check compute with mac address
 
@@ -127,6 +151,7 @@
         state: absent
       check_mode: yes
       register: register_stat_dhcp_file
+      changed_when: False
 
     - name: Check /etc/dhcp/dhcpd.ice1-1.conf file contains compute1-ice1-1
       assert:
@@ -141,6 +166,7 @@
         state: absent
       check_mode: yes
       register: reg_dhcp_file_opt82
+      changed_when: False
 
     - name: Check /etc/dhcp/dhcpd.ice1-1.conf file contains opt82 configuration for compute2
       assert:
@@ -153,6 +179,7 @@
         state: absent
       check_mode: yes
       register: reg_dhcp_file_opt82_circuit_id
+      changed_when: False
 
     - name: Check /etc/dhcp/dhcpd.ice1-1.conf file contains circuit-id configuration for compute2
       assert:
@@ -165,6 +192,7 @@
         state: absent
       check_mode: yes
       register: reg_dhcp_file_opt82_bmc
+      changed_when: False
 
     - name: Check /etc/dhcp/dhcpd.ice1-1.conf file contains opt82 configuration for bmc in compute2
       assert:
@@ -179,6 +207,7 @@
         state: absent
       check_mode: yes
       register: reg_dhcp_file_opt61
+      changed_when: False
 
     - name: Check /etc/dhcp/dhcpd.ice1-2.conf file contains opt61 configuration for compute3-ice1-2
       assert:
@@ -191,6 +220,7 @@
         state: absent
       check_mode: yes
       register: reg_dhcp_file_opt61_bmc
+      changed_when: False
 
     - name: Check /etc/dhcp/dhcpd.ice1-2.conf file contains opt82 configuration for bmc in compute3-ice1-2
       assert:


### PR DESCRIPTION
Molecule tests for advanced_dhcp_server role.

- Test shared networks feature in dhcp
- Check compute with mac address
- Check (opt61 and opt82) in dhcp configuration.
- Check dhcp syntax with `dhcpd -t -cf /etc/dhcp/dhcpd.conf`
- Check dhcpd service is enabled