### PR TITLE
Adding unitary molecule tests for pormetheus_server/client roles

### DIFF
--- a/.github/TEST_MATRIX.md
+++ b/.github/TEST_MATRIX.md
@@ -20,5 +20,7 @@ Molecule unit tests
 |![core/time unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/time%20unit%20testing/badge.svg)                               | x | x |   |
 |![addons/clustershell unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/clustershell%20unit%20testing/badge.svg)           | x | x | x |
 |![addons/grafana unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/grafana%20unit%20testing/badge.svg)                     | x | x |   |
+|![addons/prometheus_client unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/prometheus_client%20unit%20testing/badge.svg)                   | x | x |  |
+|![addons/prometheus_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/prometheus_server%20unit%20testing/badge.svg)                   | x | x |  |
 |![addons/root_password unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/root_password%20unit%20testing/badge.svg)         | x | x | x |
 |![addons/users_basic unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/users_basic%20unit%20testing/badge.svg)             | x | x | x |

--- a/.github/workflows/molecule-actions-addons-prometheus_client.yml
+++ b/.github/workflows/molecule-actions-addons-prometheus_client.yml
@@ -1,0 +1,40 @@
+---
+name: addons/prometheus_client unit testing
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'roles/addons/prometheus_client/**'
+      - '.github/workflows/molecule-actions-addons-prometheus_client.yml'
+  pull_request:
+    paths:
+      - 'roles/addons/prometheus_client/**'
+      - '.github/workflows/molecule-actions-addons-prometheus_client.yml'
+
+jobs:
+  molecule_test:
+    name: ${{ matrix.distro }} - molecule test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - centos:7
+          - centos:8
+
+    env:
+      MOLECULE_DISTRO: ${{ matrix.distro }}
+      PY_COLORS: 1
+      ANSIBLE_FORCE_COLOR: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup python environment
+        uses: actions/setup-python@v1
+      - name: Install packages
+        run: |
+          pip install 'molecule[docker]>3' ansible-lint flake8
+      - name: Run molecule test for addons/prometheus_client
+        run: |
+          cd roles/addons/prometheus_client && molecule test

--- a/.github/workflows/molecule-actions-addons-prometheus_client.yml
+++ b/.github/workflows/molecule-actions-addons-prometheus_client.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox 
       - name: Run molecule test for addons/prometheus_client
         run: |
-          cd roles/addons/prometheus_client && molecule test
+          cd roles/addons/prometheus_client && tox

--- a/.github/workflows/molecule-actions-addons-prometheus_server.yml
+++ b/.github/workflows/molecule-actions-addons-prometheus_server.yml
@@ -1,0 +1,40 @@
+---
+name: addons/prometheus_server unit testing
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'roles/addons/prometheus_server/**'
+      - '.github/workflows/molecule-actions-addons-prometheus_server.yml'
+  pull_request:
+    paths:
+      - 'roles/addons/prometheus_server/**'
+      - '.github/workflows/molecule-actions-addons-prometheus_server.yml'
+
+jobs:
+  molecule_test:
+    name: ${{ matrix.distro }} - molecule test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - centos:7
+          - centos:8
+
+    env:
+      MOLECULE_DISTRO: ${{ matrix.distro }}
+      PY_COLORS: 1
+      ANSIBLE_FORCE_COLOR: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup python environment
+        uses: actions/setup-python@v1
+      - name: Install packages
+        run: |
+          pip install 'molecule[docker]>3' ansible-lint flake8
+      - name: Run molecule test for addons/prometheus_server
+        run: |
+          cd roles/addons/prometheus_server && molecule test

--- a/.github/workflows/molecule-actions-addons-prometheus_server.yml
+++ b/.github/workflows/molecule-actions-addons-prometheus_server.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v1
       - name: Install packages
         run: |
-          pip install 'molecule[docker]>3' ansible-lint flake8
+          pip install tox
       - name: Run molecule test for addons/prometheus_server
         run: |
-          cd roles/addons/prometheus_server && molecule test
+          cd roles/addons/prometheus_server && tox

--- a/roles/addons/prometheus_client/.yamllint
+++ b/roles/addons/prometheus_client/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/addons/prometheus_client/molecule/default/INSTALL.rst
+++ b/roles/addons/prometheus_client/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/roles/addons/prometheus_client/molecule/default/converge.yml
+++ b/roles/addons/prometheus_client/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include prometheus_client"
+      include_role:
+        name: "prometheus_client"

--- a/roles/addons/prometheus_client/molecule/default/molecule.yml
+++ b/roles/addons/prometheus_client/molecule/default/molecule.yml
@@ -13,6 +13,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
+
 provisioner:
   name: ansible
   inventory:
@@ -29,9 +30,5 @@ provisioner:
               package: node_exporter
               service: node_exporter
               port: 9100
-            ha_cluster_exporter:
-              package: ha_cluster_exporter
-              service: ha_cluster_exporter
-              port: 9664
 verifier:
   name: ansible

--- a/roles/addons/prometheus_client/molecule/default/molecule.yml
+++ b/roles/addons/prometheus_client/molecule/default/molecule.yml
@@ -1,0 +1,37 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
+    override_command: false
+    capabilities:
+      - "SYS_ADMIN"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      instance:
+
+        start_services: true
+        enable_services: true
+        ep_firewall: true
+
+        monitoring:
+          exporters:
+            node_exporter:
+              package: node_exporter
+              service: node_exporter
+              port: 9100
+            ha_cluster_exporter:
+              package: ha_cluster_exporter
+              service: ha_cluster_exporter
+              port: 9664
+verifier:
+  name: ansible

--- a/roles/addons/prometheus_client/molecule/default/prepare.yml
+++ b/roles/addons/prometheus_client/molecule/default/prepare.yml
@@ -9,7 +9,6 @@
       when: ansible_facts.os_family == "RedHat"
       loop:
         - firewalld
-        - httpd
 
     - name: Start needed services
       service:
@@ -19,7 +18,6 @@
       when: ansible_facts.os_family == "RedHat"
       loop:
         - firewalld
-        - httpd
 
     - name: "Configure BlueBanquise repository"
       yum_repository:

--- a/roles/addons/prometheus_client/molecule/default/prepare.yml
+++ b/roles/addons/prometheus_client/molecule/default/prepare.yml
@@ -1,0 +1,30 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: Install needed packages
+      package:
+        name: "{{ item }}"
+        state: present
+      when: ansible_facts.os_family == "RedHat"
+      loop:
+        - firewalld
+        - httpd
+
+    - name: Start needed services
+      service:
+        name: "{{ item }}"
+        enabled: yes
+        state: started
+      when: ansible_facts.os_family == "RedHat"
+      loop:
+        - firewalld
+        - httpd
+
+    - name: "Configure BlueBanquise repository"
+      yum_repository:
+        name: bluebanquise
+        description: BlueBanquise 1.3 repository
+        baseurl: https://bluebanquise.com/repository/releases/1.3/el$releasever/$basearch/bluebanquise/
+        gpgcheck: False
+      when: ansible_facts.os_family == "RedHat"

--- a/roles/addons/prometheus_client/molecule/default/prepare.yml
+++ b/roles/addons/prometheus_client/molecule/default/prepare.yml
@@ -22,7 +22,7 @@
     - name: "Configure BlueBanquise repository"
       yum_repository:
         name: bluebanquise
-        description: BlueBanquise 1.3 repository
-        baseurl: https://bluebanquise.com/repository/releases/1.3/el$releasever/$basearch/bluebanquise/
+        description: BlueBanquise repository
+        baseurl: https://bluebanquise.com/repository/releases/latest/el$releasever/$basearch/bluebanquise/
         gpgcheck: False
       when: ansible_facts.os_family == "RedHat"

--- a/roles/addons/prometheus_client/molecule/default/verify.yml
+++ b/roles/addons/prometheus_client/molecule/default/verify.yml
@@ -20,17 +20,9 @@
         that: firewall_cmd_result.stdout |
                     regex_findall(('9100/tcp'), multiline=False) | length == 1
 
-    - name: Firewall zone public check presence of service ha_cluster_exporter = 9664/tcp
+    - name: Assert node_exporter is installed
       assert:
-        that: firewall_cmd_result.stdout |
-                    regex_findall(('9664/tcp'), multiline=False) | length == 1
-
-    - name: Assert node_exporter and ha_cluster_exporter packages are installed
-      assert:
-        that: "'{{item}}' in ansible_facts.packages"
-      loop:
-        - node_exporter
-        - ha_cluster_exporter
+        that: "'node_exporter' in ansible_facts.packages"
 
     - name: Check node_exporter is enabled
       assert:
@@ -39,14 +31,6 @@
     - name: Check node_exporter is running
       assert:
         that: "ansible_facts.services['node_exporter.service'].state == 'running'"
-
-    - name: Check ha_cluster_exporter is enabled
-      assert:
-        that: "ansible_facts.services['ha_cluster_exporter.service'].status == 'enabled'"
-
-    - name: Check ha_cluster_exporter is running
-      assert:
-        that: "ansible_facts.services['ha_cluster_exporter.service'].state == 'running'"
 
     - name: Check that Node_exporter is reachable
       uri:

--- a/roles/addons/prometheus_client/molecule/default/verify.yml
+++ b/roles/addons/prometheus_client/molecule/default/verify.yml
@@ -1,0 +1,59 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+
+    - name: Collect package facts
+      package_facts:
+        manager: auto
+
+    - name: Collect services facts
+      service_facts:
+
+    - name: Collect services of zone public
+      command: firewall-cmd --zone=public --list-all
+      register: firewall_cmd_result
+      changed_when: False
+
+    - name: Firewall zone public check presence of service node_exporter = 9100/tcp
+      assert:
+        that: firewall_cmd_result.stdout |
+                    regex_findall(('9100/tcp'), multiline=False) | length == 1
+
+    - name: Firewall zone public check presence of service ha_cluster_exporter = 9664/tcp
+      assert:
+        that: firewall_cmd_result.stdout |
+                    regex_findall(('9664/tcp'), multiline=False) | length == 1
+
+    - name: Assert node_exporter and ha_cluster_exporter packages are installed
+      assert:
+        that: "'{{item}}' in ansible_facts.packages"
+      loop:
+        - node_exporter
+        - ha_cluster_exporter
+
+    - name: Check node_exporter is enabled
+      assert:
+        that: "ansible_facts.services['node_exporter.service'].status == 'enabled'"
+
+    - name: Check node_exporter is running
+      assert:
+        that: "ansible_facts.services['node_exporter.service'].state == 'running'"
+
+    - name: Check ha_cluster_exporter is enabled
+      assert:
+        that: "ansible_facts.services['ha_cluster_exporter.service'].status == 'enabled'"
+
+    - name: Check ha_cluster_exporter is running
+      assert:
+        that: "ansible_facts.services['ha_cluster_exporter.service'].state == 'running'"
+
+    - name: Check that Node_exporter is reachable
+      uri:
+        url: http://localhost:9100
+        return_content: yes
+      register: reg_url
+
+    - name: Assert Node_exporter is available at http://localhost:9100
+      assert:
+        that: "'Node Exporter' in reg_url.content"

--- a/roles/addons/prometheus_client/molecule/default/verify.yml
+++ b/roles/addons/prometheus_client/molecule/default/verify.yml
@@ -37,6 +37,7 @@
         url: http://localhost:9100
         return_content: yes
       register: reg_url
+      changed_when: False
 
     - name: Assert Node_exporter is available at http://localhost:9100
       assert:

--- a/roles/addons/prometheus_server/.yamllint
+++ b/roles/addons/prometheus_server/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/addons/prometheus_server/files/prometheus.xml
+++ b/roles/addons/prometheus_server/files/prometheus.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>prometheus</short>
+  <description>Prometheus server</description>
+  <port protocol="tcp" port="9090"/>
+</service>

--- a/roles/addons/prometheus_server/molecule/default/INSTALL.rst
+++ b/roles/addons/prometheus_server/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/roles/addons/prometheus_server/molecule/default/converge.yml
+++ b/roles/addons/prometheus_server/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include prometheus_server"
+      include_role:
+        name: "prometheus_server"

--- a/roles/addons/prometheus_server/molecule/default/molecule.yml
+++ b/roles/addons/prometheus_server/molecule/default/molecule.yml
@@ -40,18 +40,3 @@ provisioner:
 
 verifier:
   name: ansible
-scenario:
-    test_sequence:
-    - dependency
-    - lint
-    - cleanup
-    - destroy
-    - syntax
-    - create
-    - prepare
-    - converge
-    #- idempotence # FIXME idempotence disabled because #366
-    - side_effect
-    - verify
-    - cleanup
-    - destroy

--- a/roles/addons/prometheus_server/molecule/default/molecule.yml
+++ b/roles/addons/prometheus_server/molecule/default/molecule.yml
@@ -1,0 +1,57 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: management1
+    groups:
+      - mg_managements
+    children:
+      - equipment_typeM
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
+    override_command: false
+    capabilities:
+      - "SYS_ADMIN"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      management1:
+
+        start_services: true
+        enable_services: true 
+        j2_equipment_groups_list:
+          - equipment_typeM
+        ep_firewall: true
+
+        prometheus:
+          scrape_interval: 1m
+          evaluation_interval: 2m
+          alertmanager:
+            group_wait: 1m
+            group_interval: 10m
+            repeat_interval: 3h
+
+verifier:
+  name: ansible
+scenario:
+    test_sequence:
+    - dependency
+    - lint
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    #- idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/roles/addons/prometheus_server/molecule/default/molecule.yml
+++ b/roles/addons/prometheus_server/molecule/default/molecule.yml
@@ -50,7 +50,7 @@ scenario:
     - create
     - prepare
     - converge
-    #- idempotence
+    #- idempotence # FIXME idempotence disabled because #366
     - side_effect
     - verify
     - cleanup

--- a/roles/addons/prometheus_server/molecule/default/prepare.yml
+++ b/roles/addons/prometheus_server/molecule/default/prepare.yml
@@ -9,7 +9,6 @@
       when: ansible_facts.os_family == "RedHat"
       loop:
         - firewalld
-        - httpd
 
     - name: Start needed services
       service:
@@ -19,7 +18,6 @@
       when: ansible_facts.os_family == "RedHat"
       loop:
         - firewalld
-        - httpd
 
     - name: "Configure BlueBanquise repository"
       yum_repository:

--- a/roles/addons/prometheus_server/molecule/default/prepare.yml
+++ b/roles/addons/prometheus_server/molecule/default/prepare.yml
@@ -1,0 +1,30 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: Install needed packages
+      package:
+        name: "{{ item }}"
+        state: present
+      when: ansible_facts.os_family == "RedHat"
+      loop:
+        - firewalld
+        - httpd
+
+    - name: Start needed services
+      service:
+        name: "{{ item }}"
+        enabled: yes
+        state: started
+      when: ansible_facts.os_family == "RedHat"
+      loop:
+        - firewalld
+        - httpd
+
+    - name: "Configure BlueBanquise repository"
+      yum_repository:
+        name: bluebanquise
+        description: BlueBanquise 1.3 repository
+        baseurl: https://bluebanquise.com/repository/releases/1.3/el$releasever/$basearch/bluebanquise/
+        gpgcheck: False
+      when: ansible_facts.os_family == "RedHat"

--- a/roles/addons/prometheus_server/molecule/default/prepare.yml
+++ b/roles/addons/prometheus_server/molecule/default/prepare.yml
@@ -22,7 +22,7 @@
     - name: "Configure BlueBanquise repository"
       yum_repository:
         name: bluebanquise
-        description: BlueBanquise 1.3 repository
-        baseurl: https://bluebanquise.com/repository/releases/1.3/el$releasever/$basearch/bluebanquise/
+        description: BlueBanquise repository
+        baseurl: https://bluebanquise.com/repository/releases/latest/el$releasever/$basearch/bluebanquise/
         gpgcheck: False
       when: ansible_facts.os_family == "RedHat"

--- a/roles/addons/prometheus_server/molecule/default/verify.yml
+++ b/roles/addons/prometheus_server/molecule/default/verify.yml
@@ -77,7 +77,7 @@
         that:
           - reg_file_prometheus.stat.exists
           - reg_file_prometheus.stat.mode == '0640'
-            
+
     - name: Retrieve file /etc/prometheus/alerts/general.yml system status
       stat:
         path: /etc/prometheus/alerts/general.yml

--- a/roles/addons/prometheus_server/molecule/default/verify.yml
+++ b/roles/addons/prometheus_server/molecule/default/verify.yml
@@ -89,7 +89,7 @@
         that:
           - reg_file_prometheus_alerts.stat.exists
           - reg_file_prometheus_alerts.stat.mode == '0640'
-            
+
     - name: Retrieve directory /etc/alertmanager system status
       stat:
         path: /etc/alertmanager

--- a/roles/addons/prometheus_server/molecule/default/verify.yml
+++ b/roles/addons/prometheus_server/molecule/default/verify.yml
@@ -13,6 +13,7 @@
     - name: Collect services of zone public
       command: firewall-cmd --zone=public --list-all
       register: firewall_cmd_result
+      changed_when: False
 
     - name: Firewall zone public check presence of service prometheus
       assert:
@@ -39,6 +40,7 @@
       stat:
         path: /etc/prometheus/alerts
       register: reg_prometheus
+      changed_when: False
 
     - name: Assert directory /etc/prometheus/alerts/ exists
       assert:
@@ -53,6 +55,7 @@
       stat:
         path: /var/lib/prometheus
       register: reg_var_prometheus
+      changed_when: False
 
     - name: Assert directory /etc/prometheus/alerts/ exists
       assert:
@@ -67,6 +70,7 @@
       stat:
         path: /etc/prometheus/prometheus.yml
       register: reg_file_prometheus
+      changed_when: False
 
     - name: Assert file /etc/prometheus/prometheus.yml exists
       assert:
@@ -78,6 +82,7 @@
       stat:
         path: /etc/prometheus/alerts/general.yml
       register: reg_file_prometheus_alerts
+      changed_when: False
 
     - name: Assert file /etc/prometheus/alerts/general.yml exists
       assert:
@@ -89,6 +94,7 @@
       stat:
         path: /etc/alertmanager
       register: reg_alertmanager
+      changed_when: False
 
     - name: Assert directory /etc/alertmanager exists
       assert:
@@ -103,6 +109,7 @@
       stat:
         path: /etc/alertmanager/alertmanager.yml
       register: reg_file_alertmanager
+      changed_when: False
 
     - name: Assert file /etc/alertmanager/alertmanager.yml exists
       assert:
@@ -116,6 +123,7 @@
       stat:
         path: /etc/ipmi_exporter/ipmi_config.yml
       register: reg_file_ipmi_conf
+      changed_when: False
 
     - name: Assert file /etc/ipmi_exporter/ipmi_config.yml exists
       assert:
@@ -129,6 +137,7 @@
       stat:
         path: /etc/karma/karma.yml
       register: reg_file_karma
+      changed_when: False
 
     - name: Assert file /etc/karma/karma.yml exists
       assert:
@@ -154,6 +163,7 @@
         url: http://localhost:9090
         return_content: yes
       register: reg_url
+      changed_when: False
 
     - name: Assert Prometheus is available at http://localhost:9090
       assert:
@@ -164,6 +174,7 @@
         url: http://localhost:9093
         return_content: yes
       register: reg_url_alert
+      changed_when: False
 
     - name: Assert Alertmanager is available at http://localhost:9093
       assert:

--- a/roles/addons/prometheus_server/molecule/default/verify.yml
+++ b/roles/addons/prometheus_server/molecule/default/verify.yml
@@ -1,0 +1,179 @@
+---
+- name: Verify
+  hosts: management1
+  tasks:
+
+    - name: Collect package facts
+      package_facts:
+        manager: auto
+
+    - name: Collect services facts
+      service_facts:
+
+    - name: Collect services of zone public
+      command: firewall-cmd --zone=public --list-all
+      register: firewall_cmd_result
+
+    - name: Firewall zone public check presence of service prometheus
+      assert:
+        that: firewall_cmd_result.stdout |
+                    regex_findall(('prometheus'), multiline=False) | length == 1
+
+    - name: Firewall zone public check presence of service alertmanager
+      assert:
+        that: firewall_cmd_result.stdout |
+                    regex_findall(('alertmanager'), multiline=False) | length == 1
+
+    - name: Assert monitoring packages are installed
+      assert:
+        that: "'{{ item }}' in ansible_facts.packages"
+      loop:
+        - prometheus
+        - alertmanager
+        - ipmi_exporter
+        - freeipmi
+        - snmp_exporter
+        - karma
+
+    - name: Retrieve directory /etc/prometheus/alerts system status
+      stat:
+        path: /etc/prometheus/alerts
+      register: reg_prometheus
+
+    - name: Assert directory /etc/prometheus/alerts/ exists
+      assert:
+        that:
+          - reg_prometheus.stat.exists
+          - reg_prometheus.stat.isdir
+          - reg_prometheus.stat.mode == '0750'
+          - reg_prometheus.stat.pw_name == 'prometheus'
+          - reg_prometheus.stat.gr_name == 'prometheus'
+
+    - name: Retrieve directory /var/lib/prometheus system status
+      stat:
+        path: /var/lib/prometheus
+      register: reg_var_prometheus
+
+    - name: Assert directory /etc/prometheus/alerts/ exists
+      assert:
+        that:
+          - reg_var_prometheus.stat.exists
+          - reg_var_prometheus.stat.isdir
+          - reg_var_prometheus.stat.mode == '0750'
+          - reg_var_prometheus.stat.pw_name == 'prometheus'
+          - reg_var_prometheus.stat.gr_name == 'prometheus'
+
+    - name: Retrieve file /etc/prometheus/prometheus.yml system status
+      stat:
+        path: /etc/prometheus/prometheus.yml
+      register: reg_file_prometheus
+
+    - name: Assert file /etc/prometheus/prometheus.yml exists
+      assert:
+        that:
+          - reg_file_prometheus.stat.exists
+          - reg_file_prometheus.stat.mode == '0640'
+            
+    - name: Retrieve file /etc/prometheus/alerts/general.yml system status
+      stat:
+        path: /etc/prometheus/alerts/general.yml
+      register: reg_file_prometheus_alerts
+
+    - name: Assert file /etc/prometheus/alerts/general.yml exists
+      assert:
+        that:
+          - reg_file_prometheus_alerts.stat.exists
+          - reg_file_prometheus_alerts.stat.mode == '0640'
+            
+    - name: Retrieve directory /etc/alertmanager system status
+      stat:
+        path: /etc/alertmanager
+      register: reg_alertmanager
+
+    - name: Assert directory /etc/alertmanager exists
+      assert:
+        that:
+          - reg_alertmanager.stat.exists
+          - reg_alertmanager.stat.isdir
+          - reg_alertmanager.stat.mode == '0750'
+          - reg_alertmanager.stat.pw_name == 'alertmanager'
+          - reg_alertmanager.stat.gr_name == 'alertmanager'
+
+    - name: Retrieve file /etc/alertmanager/alertmanager.yml system status
+      stat:
+        path: /etc/alertmanager/alertmanager.yml
+      register: reg_file_alertmanager
+
+    - name: Assert file /etc/alertmanager/alertmanager.yml exists
+      assert:
+        that:
+          - reg_file_alertmanager.stat.exists
+          - reg_file_alertmanager.stat.mode == '0640'
+          - reg_file_alertmanager.stat.pw_name == 'alertmanager'
+          - reg_file_alertmanager.stat.gr_name == 'alertmanager'
+
+    - name: Retrieve file /etc/ipmi_exporter/ipmi_config.yml system status
+      stat:
+        path: /etc/ipmi_exporter/ipmi_config.yml
+      register: reg_file_ipmi_conf
+
+    - name: Assert file /etc/ipmi_exporter/ipmi_config.yml exists
+      assert:
+        that:
+          - reg_file_ipmi_conf.stat.exists
+          - reg_file_ipmi_conf.stat.mode == '0640'
+          - reg_file_ipmi_conf.stat.pw_name == 'ipmi_exporter'
+          - reg_file_ipmi_conf.stat.gr_name == 'ipmi_exporter'
+
+    - name: Retrieve file /etc/karma/karma.yml system status
+      stat:
+        path: /etc/karma/karma.yml
+      register: reg_file_karma
+
+    - name: Assert file /etc/karma/karma.yml exists
+      assert:
+        that:
+          - reg_file_karma.stat.exists
+          - reg_file_karma.stat.mode == '0640'
+          - reg_file_karma.stat.pw_name == 'karma'
+          - reg_file_karma.stat.gr_name == 'karma'
+
+    - name: Check prometheus, alertmanager, ipmi_exporter snmp_exporter are enabled/running
+      assert:
+        that:
+          - "ansible_facts.services['{{ item }}.service'].status == 'enabled'"
+          - "ansible_facts.services['{{ item }}.service'].state == 'running'"
+      loop:
+        - prometheus
+        - alertmanager
+        - ipmi_exporter
+        - karma
+
+    - name: Check that Prometheus is reachable
+      uri:
+        url: http://localhost:9090
+        return_content: yes
+      register: reg_url
+
+    - name: Assert Prometheus is available at http://localhost:9090
+      assert:
+        that: "'Prometheus Time Series Collection and Processing Server' in reg_url.content"
+
+    - name: Check that Alertmanager is reachable
+      uri:
+        url: http://localhost:9093
+        return_content: yes
+      register: reg_url_alert
+
+    - name: Assert Alertmanager is available at http://localhost:9093
+      assert:
+        that: "'Alertmanager' in reg_url_alert.content"
+
+    - name: Check snmp_exporter is enabled/running
+      assert:
+        that:
+          - "ansible_facts.services['snmp_exporter.service'].status == 'enabled'"
+          - "ansible_facts.services['snmp_exporter.service'].state == 'running'"
+        fail_msg: |
+          "Missing file /etc/snmp_exporter/snmp_config.yml
+           Refer to https://github.com/bluebanquise/bluebanquise/issues/366"

--- a/roles/addons/prometheus_server/readme.rst
+++ b/roles/addons/prometheus_server/readme.rst
@@ -75,5 +75,6 @@ Allow groups alerts selection.
 Changelog
 ^^^^^^^^^
 
+* 1.0.2: Adding firewalld conf for el7 prometheus. osmocl <osmocl@osmo.cl>
 * 1.0.1: Documentation. johnnykeats <johnny.keats@outlook.com>
 * 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/addons/prometheus_server/tasks/main.yml
+++ b/roles/addons/prometheus_server/tasks/main.yml
@@ -32,8 +32,8 @@
 
 - name: "copy █ Install firewalld service configuration file"
   copy:
-    src: alertmanager.xml
-    dest: /etc/firewalld/services/alertmanager.xml
+    src: "{{ item }}.xml"
+    dest: "/etc/firewalld/services/{{ item }}.xml"
     owner: root
     group: root
     mode: 0644
@@ -41,6 +41,9 @@
     - ansible_facts.os_family == "RedHat"
     - ep_firewall | default(false) | bool
   notify: reload firewalld
+  loop:
+    - prometheus
+    - alertmanager
   tags:
     - firewall
 
@@ -157,3 +160,4 @@
   when: (start_services | bool)
   tags:
     - service
+    - molecule-idempotence-notest # FIXME idempotence disabled because of (https://github.com/bluebanquise/bluebanquise/issues/366)


### PR DESCRIPTION
Molecule tests for:

- prometheus_server
- prometheus_client

Note that in `prometheus_server `role, the `snmp_exporter `service is not started and that cause an idempotency fail.
This error is tracked and being discussed here: [https://github.com/bluebanquise/bluebanquise/issues/366](https://github.com/bluebanquise/bluebanquise/issues/366)

Also packages `slurm_exporter` and `ha_cluster_exporter` described in `roles/addons/prometheus_client/readme.rst` are missing in bluebanquise repositories.
Issue open here: [https://github.com/bluebanquise/bluebanquise/issues/429](https://github.com/bluebanquise/bluebanquise/issues/429)