### PR TITLE
Fix: core/nic - Update readme

### DIFF
--- a/roles/core/nic/readme.rst
+++ b/roles/core/nic/readme.rst
@@ -38,18 +38,18 @@ To configure an LACP bonding, specify slave interfaces, and then create the bond
 .. code-block:: yaml
 
   network_interfaces:
-    - interface: eth0
-      type: bond-slave
-      master: bond0
-    - interface: eth1
-      type: bond-slave
-      master: bond0
     - interface: bond0
       type: bond
       vlan: false
       bond_options: "mode=4 xmit_hash_policy=layer3+4 miimon=100 lacp_rate=1"
       ip4: 10.100.0.1
       network: ice1-1
+    - interface: eth0
+      type: bond-slave
+      master: bond0
+    - interface: eth1
+      type: bond-slave
+      master: bond0
 
 To configure a vlan, simply set vlan to true:
 


### PR DESCRIPTION
Fix readme, since having slave NIC first in the list break the rules defined in the CHANGELOG.md:


1. The main resolution network of hosts is the value of the network parameter of the first item of the list (e.g., c001 will be on the same line than c001-ice1-1 in the hosts file).
2. First management network related item in the list will be the ansible main ssh target interface (from ssh_master role), and also the main management network interface for the client (services_ip to target on client side).