### PR TITLE
ci: add advanced_dns_server molecule test

### DIFF
--- a/.github/TEST_MATRIX.md
+++ b/.github/TEST_MATRIX.md
@@ -18,6 +18,7 @@ Molecule unit tests
 |![core/repositories_client unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/repositories_client%20unit%20testing/badge.svg) | x | x |   |
 |![core/ssh_master unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/ssh_master%20unit%20testing/badge.svg)                   | x | x | x |
 |![core/time unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/time%20unit%20testing/badge.svg)                               | x | x |   |
+|![advanced_core/advanced_dns_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/advanced_core/advanced_dns_server%20unit%20testing/badge.svg)                   | x | x |   |
 |![addons/clustershell unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/clustershell%20unit%20testing/badge.svg)           | x | x | x |
 |![addons/grafana unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/grafana%20unit%20testing/badge.svg)                     | x | x |   |
 |![addons/root_password unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/root_password%20unit%20testing/badge.svg)         | x | x | x |

--- a/.github/workflows/molecule-actions-advanced_core-advanced_dns_server.yml
+++ b/.github/workflows/molecule-actions-advanced_core-advanced_dns_server.yml
@@ -1,0 +1,40 @@
+---
+name: advanced_core/advanced_dns_server unit testing
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'roles/advanced-core/advanced_dns_server/**'
+      - '.github/workflows/molecule-actions-advanced_core-advanced_dns_server.yml'
+  pull_request:
+    paths:
+      - 'roles/advanced-core/advanced_dns_server/**'
+      - '.github/workflows/molecule-actions-advanced_core-advanced_dns_server.yml'
+
+jobs:
+  molecule_test:
+    name: ${{ matrix.distro }} - molecule test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - centos:7
+          - centos:8
+
+    env:
+      MOLECULE_DISTRO: ${{ matrix.distro }}
+      PY_COLORS: 1
+      ANSIBLE_FORCE_COLOR: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup python environment
+        uses: actions/setup-python@v1
+      - name: Install packages
+        run: |
+          pip install tox
+      - name: Run molecule test for advanced_core/advanced_dns_server
+        run: |
+          cd roles/advanced-core/advanced_dns_server && tox

--- a/roles/advanced-core/advanced_dns_server/molecule/default/converge.yml
+++ b/roles/advanced-core/advanced_dns_server/molecule/default/converge.yml
@@ -19,6 +19,6 @@
     enable_services: false
 
   tasks:
-    - name: "Include dns_server"
+    - name: "Include advanced_dns_server"
       include_role:
-        name: "dns_server"
+        name: "advanced_dns_server"


### PR DESCRIPTION
We forgot the CI during the move of role core/dns_server to advanced-core/advanced_dns_server...