### PR TITLE
Fix: adv_core/adv_dns_server

### DIFF
--- a/roles/advanced-core/advanced_dns_server/templates/forward.j2
+++ b/roles/advanced-core/advanced_dns_server/templates/forward.j2
@@ -12,7 +12,7 @@ $INCLUDE "/var/named/forward.soa"
     {% for nic in hostvars[host]['network_interfaces'] %}
       {% if nic.ip4 is defined and nic.ip4 is not none %}
         {% if nic.network is defined and nic.network == hostvars[host]['j2_node_main_network'] %}
-          {% if hostvars[host]['alias'] is defined and hostvars[host]['alias'] is not none %}
+          {% if hostvars[host]['alias'] is defined and hostvars[host]['alias'] %}
             {% for alias in hostvars[host]['alias'] %}
 {{ alias }} IN A {{ nic.ip4 }}
             {% endfor %}
@@ -29,6 +29,11 @@ $INCLUDE "/var/named/forward.soa"
     {% if hostvars[host]['bmc'] is defined %}
     {% set bmc_args = hostvars[host]['bmc'] %}
       {% if (bmc_args.name is defined and bmc_args.name is not none) and (bmc_args.ip4 is defined and bmc_args.ip4 is not none) and (bmc_args.network is defined and bmc_args.network is not none) %}
+        {% if bmc_args.alias is defined and bmc_args.alias %}
+          {% for alias in bmc_args.alias %}
+{{ alias }} IN A {{ bmc_args.ip4 }}
+          {% endfor %}
+        {% endif %}
 {{ bmc_args.name }} IN A {{ bmc_args.ip4 }}
 {{ bmc_args.name }}-{{ bmc_args.network }} IN A {{ bmc_args.ip4 }}
       {% endif %}


### PR DESCRIPTION
Missing bmc alias in advanced dns server.