### PR TITLE
ci: test timezone is 'Europe/Paris'

### DIFF
--- a/roles/core/time/molecule/default/verify.yml
+++ b/roles/core/time/molecule/default/verify.yml
@@ -13,9 +13,14 @@
       debug:
         msg: "Timestamp format: {{ ansible_facts.date_time }}"
 
+    - name: Stat /etc/localtime
+      stat:
+        path: /etc/localtime
+      register: localtime
+
     - name: assert timezone to Europe/Paris
       assert:
-        that: "'CEST' in ansible_facts.date_time.tz"
+        that: localtime.stat.lnk_source == "/usr/share/zoneinfo/Europe/Paris"
 
     - name: Set chrony.conf path for RedHat OS family
       set_fact:


### PR DESCRIPTION
Previous test was unreliable: when summer time is over, tz = CET.

Because we define the timezone to be 'Europe/Paris', check the
host configuration is updated to reflect that change. For this, check
/etc/localtime is a symlink to /usr/share/zoneinfo/Europe/Paris.

Tests are failing since Sunday when the time changed in Europe/Paris: https://github.com/bluebanquise/bluebanquise/runs/1310835559