### PR TITLE
feat: add parameter state to repositories_client

### DIFF
--- a/roles/core/repositories_client/molecule/default/molecule.yml
+++ b/roles/core/repositories_client/molecule/default/molecule.yml
@@ -134,6 +134,7 @@ provisioner:
           - name: epel
             baseurl: 'https://dl.fedoraproject.org/pub/epel/$$releasever/$$basearch/'
             proxy: 'https://proxy:8080'
+          - { name: 'deleteme', state: 'absent' }
         external_repositories:
           - fakerepo
       distrorepos:

--- a/roles/core/repositories_client/molecule/default/prepare.yml
+++ b/roles/core/repositories_client/molecule/default/prepare.yml
@@ -7,3 +7,11 @@
         name: epel-release
         state: absent
       when: ansible_facts.os_family == "RedHat"
+
+    - name: "Create a repo to delete with the role"
+      yum_repository:
+        name: deleteme
+        baseurl: "https://www.example.tld/repo/"
+        description: "This repo MUST be absent after converge"
+        state: present
+      when: ansible_facts.os_family == "RedHat"

--- a/roles/core/repositories_client/molecule/default/verify.yml
+++ b/roles/core/repositories_client/molecule/default/verify.yml
@@ -147,7 +147,7 @@
         that: baseos_repo['content'] | b64decode |
                 regex_search(("^gpgcheck = 1$"), multiline=True)
 
-- name: Verify epel is configured
+- name: Verify epel is configured and repo deleteme is absent
   hosts: advanced
   tasks:
     - name: Read /etc/yum.repos.d/epel.repo
@@ -169,6 +169,14 @@
       assert:
         that: epel_repo['content'] | b64decode |
                 regex_search(("^proxy = https://proxy:8080$"), multiline=True)
+
+    - name: Read /etc/yum.repos.d/deleteme.repo
+      stat:
+        path: /etc/yum.repos.d/deleteme.repo
+      register: deleteme_repo
+    - name: Check deleteme.repo is absent
+      assert:
+        that: not deleteme_repo.stat.exists
 
 - name: Verify CentOS 7 distro repos are enabled
   hosts: centos7:&distrorepos

--- a/roles/core/repositories_client/readme.rst
+++ b/roles/core/repositories_client/readme.rst
@@ -43,6 +43,7 @@ Available advanced variables are:
 * gpgcheck
 * gpgkey
 * proxy
+* state
 
 Repository static path is computed using variables defined in the equipment_profile.
 
@@ -129,6 +130,7 @@ sources.list file.
 Changelog
 ^^^^^^^^^
 
+* 1.0.8: Add state parameter. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.7: Simplified version of the role. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.6: Deprecate external_repositories. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.5: Added support for excluding packages from CentOS and RHEL repositories. Neil Munday <neil@mundayweb.com>

--- a/roles/core/repositories_client/tasks/centos_7.yml
+++ b/roles/core/repositories_client/tasks/centos_7.yml
@@ -36,4 +36,5 @@
     gpgcheck: "{{ item.gpgcheck | default(0) }}"
     gpgkey: "{{ item.gpgkey | default(omit) }}"
     proxy: "{{ item.proxy | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
   with_items: "{{ repositories | union(external_repositories|default([])) }}"

--- a/roles/core/repositories_client/tasks/centos_8.yml
+++ b/roles/core/repositories_client/tasks/centos_8.yml
@@ -39,6 +39,7 @@
     gpgcheck: "{{ item.gpgcheck | default(0) }}"
     gpgkey: "{{ item.gpgkey | default(omit) }}"
     proxy: "{{ item.proxy | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
   with_items: "{{ repositories | union(external_repositories|default([])) }}"
   when: ( item != 'os' ) and ( item.name is not defined or item.name != 'os' )
 
@@ -57,6 +58,7 @@
     gpgcheck: "{{ item.gpgcheck | default(0) }}"
     gpgkey: "{{ item.gpgkey | default(omit) }}"
     proxy: "{{ item.proxy | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
   loop:
   # Combine BaseOS and AppStream with 'os' parameters if any. Otherwise, this
   # will configure BaseOS and AppStream with default values.

--- a/roles/core/repositories_client/tasks/opensuse_leap_15.yml
+++ b/roles/core/repositories_client/tasks/opensuse_leap_15.yml
@@ -6,5 +6,5 @@
     description: "{{ item }} gen by Ansible"
     repo: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/{{ ep_operating_system['repositories_environment'] | default('') }}/{{ ep_operating_system['distribution'] }}/{{ ep_operating_system['distribution_version'] | default(ep_operating_system['distribution_major_version']) }}/{{ ep_hardware['cpu']['architecture'] }}/{{ item }}/"
     disable_gpg_check: yes
-    state: present
+    state: "{{ item.state | default('present') }}"
   with_items: "{{ repositories }}"

--- a/roles/core/repositories_client/tasks/redhat_7.yml
+++ b/roles/core/repositories_client/tasks/redhat_7.yml
@@ -18,4 +18,5 @@
     gpgcheck: "{{ item.gpgcheck | default(0) }}"
     gpgkey: "{{ item.gpgkey | default(omit) }}"
     proxy: "{{ item.proxy | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
   with_items: "{{ repositories | union(external_repositories|default([])) }}"

--- a/roles/core/repositories_client/tasks/redhat_8.yml
+++ b/roles/core/repositories_client/tasks/redhat_8.yml
@@ -18,6 +18,7 @@
     gpgcheck: "{{ item.gpgcheck | default(0) }}"
     gpgkey: "{{ item.gpgkey | default(omit) }}"
     proxy: "{{ item.proxy | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
   with_items: "{{ repositories | union(external_repositories|default([])) }}"
   when: ( item != 'os' ) and ( item.name is not defined or item.name != 'os' )
 
@@ -31,6 +32,7 @@
     gpgcheck: "{{ item.gpgcheck | default(0) }}"
     gpgkey: "{{ item.gpgkey | default(omit) }}"
     proxy: "{{ item.proxy | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
   loop:
   # Combine BaseOS and AppStream with 'os' parameters if any. Otherwise, this
   # will configure BaseOS and AppStream with default values.

--- a/roles/core/repositories_client/tasks/ubuntu_18.yml
+++ b/roles/core/repositories_client/tasks/ubuntu_18.yml
@@ -3,5 +3,5 @@
 - name: Setting repositories
   apt_repository:
     repo: "deb http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/{{ ep_operating_system['repositories_environment'] | default('') }}/{{ ep_operating_system['distribution'] }}/{{ ep_operating_system['distribution_version'] | default(ep_operating_system['distribution_major_version']) }}/{{ ep_hardware['cpu']['architecture'] }}/{{ item }} bionic main"
-    state: present
+    state: "{{ item.state | default('present') }}"
   with_items: "{{ repositories }}"

--- a/roles/core/repositories_client/vars/main.yml
+++ b/roles/core/repositories_client/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-repositories_client_role_version: 1.0.7
+repositories_client_role_version: 1.0.8


### PR DESCRIPTION
It is possible to ensure a repository does not exist with:

```
repositories:
    - { name: 'repo_to_delete', state: 'absent'}
```

See #455.