### PR TITLE
ci: test timezone is 'Europe/Paris'

### DIFF
--- a/roles/core/time/molecule/default/converge.yml
+++ b/roles/core/time/molecule/default/converge.yml
@@ -1,6 +1,7 @@
 ---
 - name: Converge
   hosts: all
+  serial: 3
 
   vars:
     # Start the services by default

--- a/roles/core/time/molecule/default/verify.yml
+++ b/roles/core/time/molecule/default/verify.yml
@@ -13,9 +13,14 @@
       debug:
         msg: "Timestamp format: {{ ansible_facts.date_time }}"
 
+    - name: Stat /etc/localtime
+      stat:
+        path: /etc/localtime
+      register: localtime
+
     - name: assert timezone to Europe/Paris
       assert:
-        that: "'CEST' in ansible_facts.date_time.tz"
+        that: localtime.stat.lnk_source == "/usr/share/zoneinfo/Europe/Paris"
 
     - name: Set chrony.conf path for RedHat OS family
       set_fact:


### PR DESCRIPTION
Previous test was unreliable: when summer time is over, tz = CET.

Because we define the timezone to be 'Europe/Paris', check the
host configuration is updated to reflect that change. For this, check
/etc/localtime is a symlink to /usr/share/zoneinfo/Europe/Paris.

(cherry picked from commit 72a3d2f1b84690f032a53c90872c7517a8ae5ec1)

Also cherry-picked commit below for 1.3:
Execute the converge (and idempotence) 3 hosts at a time to avoid a race
with timedatectl during idempotence test.

(cherry picked from commit 4a505f2)