### PR TITLE
Add molecule tests for repositories_server and ssh_slave roles

### DIFF
--- a/.github/TEST_MATRIX.md
+++ b/.github/TEST_MATRIX.md
@@ -19,7 +19,9 @@ Molecule unit tests
 |![core/nfs_client unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/nfs_client%20unit%20testing/badge.svg)                   | x | x |   |
 |![core/nfs_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/nfs_server%20unit%20testing/badge.svg)                   | x | x |   |
 |![core/repositories_client unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/repositories_client%20unit%20testing/badge.svg) | x | x |   |
+|![core/repositories_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/repositories_server%20unit%20testing/badge.svg) | x | x |   |
 |![core/ssh_master unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/ssh_master%20unit%20testing/badge.svg)                   | x | x | x |
+|![core/ssh_slave unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/ssh_slave%20unit%20testing/badge.svg)                     | x | x | x |
 |![core/time unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/time%20unit%20testing/badge.svg)                               | x | x |   |
 |![advanced_core/advanced_dns_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/advanced_core/advanced_dns_server%20unit%20testing/badge.svg)                   | x | x |   |
 |![addons/clustershell unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/clustershell%20unit%20testing/badge.svg)           | x | x | x |

--- a/.github/workflows/molecule-actions-core-repositories_server.yml
+++ b/.github/workflows/molecule-actions-core-repositories_server.yml
@@ -28,8 +28,6 @@ jobs:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1
     steps:
-      - name: Set INSTANCE_DISTRO variable
-        run: echo "::set-env name=INSTANCE_DISTRO::${MOLECULE_DISTRO/:/}"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup python environment

--- a/.github/workflows/molecule-actions-core-repositories_server.yml
+++ b/.github/workflows/molecule-actions-core-repositories_server.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - master
     paths:
-      - 'roles/core/repositories_client/**'
-      - '.github/workflows/molecule-actions-core-repositories_client.yml'
+      - 'roles/core/repositories_server/**'
+      - '.github/workflows/molecule-actions-core-repositories_server.yml'
   pull_request:
     paths:
-      - 'roles/core/repositories_client/**'
-      - '.github/workflows/molecule-actions-core-repositories_client.yml'
+      - 'roles/core/repositories_server/**'
+      - '.github/workflows/molecule-actions-core-repositories_server.yml'
 
 jobs:
   molecule_test:
@@ -37,6 +37,6 @@ jobs:
       - name: Install packages
         run: |
           pip install tox
-      - name: Run molecule test for core/repositories_client
+      - name: Run molecule test for core/repositories_server
         run: |
-          cd roles/core/repositories_client && tox
+          cd roles/core/repositories_server && tox

--- a/.github/workflows/molecule-actions-core-repositories_server.yml
+++ b/.github/workflows/molecule-actions-core-repositories_server.yml
@@ -1,0 +1,42 @@
+---
+name: core/repositories_server unit testing
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'roles/core/repositories_client/**'
+      - '.github/workflows/molecule-actions-core-repositories_client.yml'
+  pull_request:
+    paths:
+      - 'roles/core/repositories_client/**'
+      - '.github/workflows/molecule-actions-core-repositories_client.yml'
+
+jobs:
+  molecule_test:
+    name: ${{ matrix.distro }} - molecule test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - centos:7
+          - centos:8
+
+    env:
+      MOLECULE_DISTRO: ${{ matrix.distro }}
+      PY_COLORS: 1
+      ANSIBLE_FORCE_COLOR: 1
+    steps:
+      - name: Set INSTANCE_DISTRO variable
+        run: echo "::set-env name=INSTANCE_DISTRO::${MOLECULE_DISTRO/:/}"
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup python environment
+        uses: actions/setup-python@v1
+      - name: Install packages
+        run: |
+          pip install tox
+      - name: Run molecule test for core/repositories_client
+        run: |
+          cd roles/core/repositories_client && tox

--- a/.github/workflows/molecule-actions-core-ssh_slave.yml
+++ b/.github/workflows/molecule-actions-core-ssh_slave.yml
@@ -1,0 +1,41 @@
+---
+name: core/ssh_slave unit testing
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'roles/core/ssh_slave/**'
+      - '.github/workflows/molecule-actions-core-ssh_slave.yml'
+  pull_request:
+    paths:
+      - 'roles/core/ssh_slave/**'
+      - '.github/workflows/molecule-actions-core-ssh_slave.yml'
+
+jobs:
+  molecule_test:
+    name: ${{ matrix.distro }} - molecule test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - centos:7
+          - centos:8
+          - opensuseleap:15.1
+
+    env:
+      MOLECULE_DISTRO: ${{ matrix.distro }}
+      PY_COLORS: 1
+      ANSIBLE_FORCE_COLOR: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup python environment
+        uses: actions/setup-python@v1
+      - name: Install packages
+        run: |
+          pip install tox
+      - name: Run molecule test for core/ssh_slave
+        run: |
+          cd roles/core/ssh_slave && tox

--- a/roles/core/repositories_server/.yamllint
+++ b/roles/core/repositories_server/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/core/repositories_server/molecule/default/INSTALL.rst
+++ b/roles/core/repositories_server/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/roles/core/repositories_server/molecule/default/converge.yml
+++ b/roles/core/repositories_server/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include repositories_server"
+      include_role:
+        name: "repositories_server"

--- a/roles/core/repositories_server/molecule/default/molecule.yml
+++ b/roles/core/repositories_server/molecule/default/molecule.yml
@@ -1,0 +1,28 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: management1
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
+    override_command: false
+    capabilities:
+      - "SYS_ADMIN"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      management1:
+        icebergs_system: false
+        start_services: true
+        enable_services: true
+        ep_firewall: true
+
+verifier:
+  name: ansible

--- a/roles/core/repositories_server/molecule/default/prepare.yml
+++ b/roles/core/repositories_server/molecule/default/prepare.yml
@@ -1,0 +1,14 @@
+---
+- name: Prepare
+  hosts: management1
+  tasks:
+    - name: Install firewall package
+      package:
+        name: firewalld
+        state: present
+
+    - name: Start firewall
+      service:
+        name: firewalld
+        enabled: yes
+        state: started

--- a/roles/core/repositories_server/molecule/default/verify.yml
+++ b/roles/core/repositories_server/molecule/default/verify.yml
@@ -20,19 +20,9 @@
         that: firewall_cmd_result.stdout |
                     regex_findall(('http'), multiline=False) | length == 1
 
-    - name: Assert pxe needed packages are installed
+    - name: Assert httpd package is installed
       assert:
         that: "'httpd' in ansible_facts.packages"
-
-    - name: Retrieve file /etc/httpd/conf/httpd.conf system status
-      stat:
-        path: /etc/httpd/conf/httpd.conf
-      register: reg_httpd_conf
-      changed_when: False
-
-    - name: Assert file /etc/httpd/conf/httpd.conf exist
-      assert:
-        that: reg_httpd_conf.stat.exists
 
     - name: Check services httpd is enabled
       assert:

--- a/roles/core/repositories_server/molecule/default/verify.yml
+++ b/roles/core/repositories_server/molecule/default/verify.yml
@@ -1,0 +1,43 @@
+---
+- name: Verify
+  hosts: management1
+  tasks:
+
+    - name: Collect package facts
+      package_facts:
+        manager: auto
+
+    - name: Collect services facts
+      service_facts:
+
+    - name: Collect services of zone public
+      command: firewall-cmd --zone=public --list-all
+      register: firewall_cmd_result
+      changed_when: False
+
+    - name: Firewall zone public check presence of service http
+      assert:
+        that: firewall_cmd_result.stdout |
+                    regex_findall(('http'), multiline=False) | length == 1
+
+    - name: Assert pxe needed packages are installed
+      assert:
+        that: "'httpd' in ansible_facts.packages"
+
+    - name: Retrieve file /etc/httpd/conf/httpd.conf system status
+      stat:
+        path: /etc/httpd/conf/httpd.conf
+      register: reg_httpd_conf
+      changed_when: False
+
+    - name: Assert file /etc/httpd/conf/httpd.conf exist
+      assert:
+        that: reg_httpd_conf.stat.exists
+
+    - name: Check services httpd is enabled
+      assert:
+        that: "ansible_facts.services['httpd.service'].status == 'enabled'"
+
+    - name: Check services httpd is running
+      assert:
+        that: "ansible_facts.services['httpd.service'].state == 'running'"

--- a/roles/core/ssh_slave/.yamllint
+++ b/roles/core/ssh_slave/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/core/ssh_slave/molecule/default/INSTALL.rst
+++ b/roles/core/ssh_slave/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/roles/core/ssh_slave/molecule/default/converge.yml
+++ b/roles/core/ssh_slave/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include ssh_slave"
+      include_role:
+        name: "ssh_slave"

--- a/roles/core/ssh_slave/molecule/default/molecule.yml
+++ b/roles/core/ssh_slave/molecule/default/molecule.yml
@@ -1,0 +1,26 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: compute
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
+    override_command: false
+    capabilities:
+      - "SYS_ADMIN"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      compute:
+        authentication_ssh_keys:
+          - ssh-rsa fakeAuthKey root@localhost.localdomain
+
+verifier:
+  name: ansible

--- a/roles/core/ssh_slave/molecule/default/verify.yml
+++ b/roles/core/ssh_slave/molecule/default/verify.yml
@@ -1,0 +1,17 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+
+    - name: Retrieve key in /root/.ssh/authorized_keys file
+      lineinfile:
+        path: /root/.ssh/authorized_keys
+        regexp: "ssh-rsa fakeAuthKey root@localhost.localdomain"
+        state: absent
+      check_mode: yes
+      register: reg_key
+      changed_when: false
+
+    - name: Check /root/.ssh/authorized_keys file contains expected key
+      assert:
+        that: reg_key.found


### PR DESCRIPTION
Adding molecule test for remaining core roles:

- repositories_server 
- ssh_slave roles

The following roles cannot be tested in containers, due to limits of docker (`error: Device or resource busy`)
These roles will be tested in a full virtualized environment with kitchen.

- hosts_file
- set_hostname