### PR TITLE
RDMA requires higher lockable memory than the default. Memlock is set…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
     - add all ansible nmcli module capabilities (#444)
     - add routes handling on interfaces (#469)
     - convert to new inventory format (#401)
+  - addons/ofed:
+    - add tunables to set soft/hard memlock limits. Default to unlimited (#492)
   - advanced_core/advanced_dhcp_server:
     - add multiple entries per host capability (#470)
     - add custome options definition for each host (#470)

--- a/roles/addons/ofed/defaults/main.yml
+++ b/roles/addons/ofed/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for ofed
+ofed_memlock_soft: 'unlimited'
+ofed_memlock_hard: 'unlimited'

--- a/roles/addons/ofed/readme.rst
+++ b/roles/addons/ofed/readme.rst
@@ -9,7 +9,7 @@ This role install and start all needed for OFED based interconnects (Mellanox, e
 Instructions
 ^^^^^^^^^^^^
 
-Only for Centos/Rhel.
+Only for CentOS/RHEL.
 
 To be done
 ^^^^^^^^^^
@@ -19,5 +19,5 @@ Need to add support for Ubuntu and OpenSuse if exist.
 Changelog
 ^^^^^^^^^
 
+* 1.1.0: add tunables to set soft/hard memlock limits.
 * 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>
- 

--- a/roles/addons/ofed/tasks/main.yml
+++ b/roles/addons/ofed/tasks/main.yml
@@ -13,6 +13,18 @@
   tags:
     - package
 
+- name: pam_limits █ Configure system memlock settings for rdma
+  pam_limits:
+    domain: '*'
+    limit_type: "{{ item.limit_type }}"
+    limit_item: "{{ item.limit_item }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { limit_type: 'soft', limit_item: 'memlock', value: "{{ ofed_memlock_soft }}" }
+    - { limit_type: 'hard', limit_item: 'memlock', value: "{{ ofed_memlock_hard }}" }
+  tags:
+    - pam_limits
+
 - name: service █ Enforce rdma state
   service:
     name: rdma

--- a/roles/addons/ofed/vars/main.yml
+++ b/roles/addons/ofed/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-ofed_role_version: 1.0.0
+ofed_role_version: 1.1.0


### PR DESCRIPTION
When deploying ofed role we need to set memlock to a high limit for rdma. Default is low in CentOS8.
The Mellanox guide suggest to set it to unlimited.
This patch add in ofed role tha ability to set memlock to unlimited in /etc/security/limits.conf