### PR TITLE
feat: template custom NHC files from the inventory

### DIFF
--- a/roles/addons/nhc/defaults/main.yml
+++ b/roles/addons/nhc/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
 nhc_custom_packages_to_install: []
-nhc_files: []

--- a/roles/addons/nhc/readme.rst
+++ b/roles/addons/nhc/readme.rst
@@ -6,7 +6,8 @@ Description
 
 This role install and configure NHC.
 
-To find more information on NHC or grab latest release, refer to `project github <https://github.com/mej/nhc>`_
+To find more information on NHC or grab latest release, refer to the `NHC
+project <https://github.com/mej/nhc>`_ on GitHub.
 
 Instructions
 ^^^^^^^^^^^^
@@ -14,7 +15,7 @@ Instructions
 General usage
 """""""""""""
 
-To set checks, simply create variable **nhc_checks** and provide all checks with
+To set checks, define the variable **nhc_checks** and provide all checks with
 check name as key and arguments of this check as value. For example:
 
 .. code-block:: yaml
@@ -24,8 +25,8 @@ check name as key and arguments of this check as value. For example:
     check_fs_mount_rw: -f /scratch
     ...
 
-If you need to define multiple time the same check, but with different arguments,
-simply provide a list of arguments:
+If you need to define the same check with several parameters, provide a list of
+arguments:
 
 .. code-block:: yaml
 
@@ -36,34 +37,32 @@ simply provide a list of arguments:
       - -f /home
     ...
 
-You can force usage of a static file content instead of a generated one by 
-setting **nhc_static_configuration** into inventory.
-**nhc_static_configuration** is a multi lines variable that should contain 
-the full desired content of the target nhc.conf file.
-
-For example:
-
-  nhc_static_configuration: |
-    * || export TS=1
-    * || export DEBUG=0
-    * || export DF_FLAGS="-Tk"
-    * || export DFI_FLAGS="-Ti"
-    * || check_ps_service -u root -S sshd
-    ...   
-
 Advanced usage
 """"""""""""""
 
-It is possible to force copy of multiple nhc files (custom checks, scripts, etc) 
-by setting variable *nhc_files* as a list of files names that should be copied 
-from files folder of the role to */etc/nhc* to the target host.
+It is possible to force copy of multiple nhc files (custom checks, scripts,
+etc) by setting variable *nhc_files* as a list of file names and content that
+should be copied to */etc/nhc/* on the target host. This allows to define your
+own **nhc.conf** file, without the default templating.
 
 For example:
 
 .. code-block:: yaml
 
   nhc_files:
-    - my_custom_check.nhc
+    - name: nhc.conf
+      content: |
+        * || export TS=1
+        * || export DEBUG=0
+        * || export DF_FLAGS="-Tk"
+        * || export DFI_FLAGS="-Ti"
+        * || check_ps_service -u root -S sshd
+        ...
+    - name: my_custom_check.nhc
+      content: |
+        * || SOMEVAR="value"
+        * || check_something
+        *.foo || another_check 1 2 3
 
 You can require installation of additional custom packages (for example
 smartmontools, dmidecode, etc), by providing a list named
@@ -73,4 +72,5 @@ checks.
 Changelog
 ^^^^^^^^^
 
+* 1.1.0: Template nhc_files. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/addons/nhc/tasks/main.yml
+++ b/roles/addons/nhc/tasks/main.yml
@@ -34,12 +34,16 @@
     owner: root
     group: root
     mode: 0644
+  when: "'nhc.conf' not in (nhc_files | default([]) | selectattr('name','defined') | map(attribute='name') | list)"
 
-- name: copy █ Copy nhc custom files
-  copy:
-    src: "{{ item }}"
-    dest: /etc/nhc/"{{ item }}"
+- name: template █ Copy nhc custom files
+  template:
+    src: nhc_custom_file.j2
+    dest: "/etc/nhc/{{ item.name }}"
     owner: root
     group: root
     mode: 0644
   loop: "{{ nhc_files }}"
+  loop_control:
+    label: "Copy file {{ item.name }}"
+  when: nhc_files is defined and nhc_files is iterable

--- a/roles/addons/nhc/templates/nhc.conf.j2
+++ b/roles/addons/nhc/templates/nhc.conf.j2
@@ -2,12 +2,6 @@
 #### BlueBanquise file ####
 ## {{ ansible_managed }}
 
-{% if nhc_static_configuration is defined and nhc_static_configuration is not none %}
-
-{{ nhc_static_configuration }}
-
-{% else %}
-
 ######################
 ####### STATIC #######
 ######################
@@ -42,6 +36,4 @@
     {% endif %}
 
   {% endfor %}
-{% endif %}
-
 {% endif %}

--- a/roles/addons/nhc/templates/nhc_custom_file.j2
+++ b/roles/addons/nhc/templates/nhc_custom_file.j2
@@ -1,0 +1,5 @@
+#### BlueBanquise file ####
+## {{ansible_managed}}
+## {{ item.name }}
+
+{{ item.content }}

--- a/roles/addons/nhc/vars/main.yml
+++ b/roles/addons/nhc/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-nhc_role_version: 1.0.0
+nhc_role_version: 1.1.0


### PR DESCRIPTION
This change allows to define the name and content of each custom files
one want to install in /etc/nhc/ in the user inventory. This helps to
keep all the configuration in the inventory instead of splitting some
values in the inventory for templates and in the role for files.