### PR TITLE
feat: add configuration of firewall zone to nic

### DIFF
--- a/roles/core/nic/readme.rst
+++ b/roles/core/nic/readme.rst
@@ -117,7 +117,18 @@ It is also possible to configure multiple ip per interface, using:
         - 172.16.0.3/16
         - 192.168.1.117/24
 
-MTU and/or Gateway can be set in the network file, and will be applyed to NIC linked to this network.
+To assign a network interface to a firewall zone:
+
+.. code-block:: yaml
+
+  network_interfaces:
+    - interface: ens5
+      ip4: 192.168.121.124
+      network: bb
+      zone: external
+
+MTU and/or Gateway can be set in the network file, and will be applied to NIC
+linked to this network.
 
 .. code-block:: yaml
 
@@ -140,7 +151,6 @@ MTU and/or Gateway can be set in the network file, and will be applyed to NIC li
         time_ip: 10.10.0.1
         log_ip: 10.10.0.1
 
-
 To be done
 ^^^^^^^^^^
 
@@ -149,6 +159,7 @@ Add Ubuntu and Opensuse compatibility if asked for.
 Changelog
 ^^^^^^^^^
 
+* 1.1.0: Assign a network interface to a firewall zone. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.3: Update readme. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.2: Update to new network_interfaces syntax. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.1: Fix VLAN and BOND. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/core/nic/templates/ifcfg.j2
+++ b/roles/core/nic/templates/ifcfg.j2
@@ -85,3 +85,7 @@ BONDING_OPTS="{{ item.bond_options }}"
 SLAVE=yes
 MASTER={{ item.master }}
 {% endif %}
+{# 8. Do we have a firewall zone defined ? #}
+{% if item.zone is defined and item.zone is not none %}
+ZONE={{ item.zone }}
+{% endif %}

--- a/roles/core/nic/vars/main.yml
+++ b/roles/core/nic/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-nic_role_version: 1.0.3
+nic_role_version: 1.1.0


### PR DESCRIPTION
If you want to assign a firewalld zone to a network interface, define
the zone in the network linked to the interface. The zone name will be
added to the ZONE parameter of the ifcfg file.

As for other changes made by the nic role, the network service needs
to be restarted for changes to take effect.