### PR TITLE
Fix: Documentation on firewalld service in diskless images (#495)

### DIFF
--- a/roles/addons/diskless/readme.rst
+++ b/roles/addons/diskless/readme.rst
@@ -274,6 +274,7 @@ Notes:
 * The multiple `-i` defines Ansible inventories to gather. By default, in BlueBanquise, the first two inventories are used. We simply add the third one, corresponding to the mounting point.
 * The `-e` (extra vars) are here to specify to the stack which iceberg and main network are to be used in the configuration of the node. (System cannot know on which nodes the image will be used).
 * The `--skip-tags identify` prevents hostname and static ip to be set, since the image should be generic for multiple hosts.
+* By default, diskless images have the firewalld service enabled. Adding the **firewall** BlueBanquise role to this customization playbook will manage the firewalld service per the **ep_firewall** variable in the chosen **image_equipment_profile** (e.g. the default equipment_typeC profile will disable the firewalld service in the diskless image).
 
 Before closing, also remember to clean dnf cache into the image chroot to save space.
 


### PR DESCRIPTION
Please see #495.

This fix is to document how to use the customization playbook to manage the firewall in diskless images.
Notice that adding `ep_firewall` variable is not needed as long as `image_equipment_profile` is provided in the playbook.

The approach has been tested on a customized livenet image, firewalld service is disabled after boot.

Playbook used:
```
- name: Computes diskless playbook
  hosts: /var/tmp/diskless/workdir/{{ diskless_image }}/mnt
  connection: chroot
  vars:
    j2_current_iceberg: iceberg1
    j2_node_main_network: ice1-1
    start_service: false
    image_equipment_profile: equipment_typeC
  
  pre_tasks:
    - name: Add current host to defined equipment_profile
      add_host:
        hostname: "{{ inventory_hostname }}"
        groups: "{{ image_equipment_profile }}"

  roles:
    - firewall
```

Playbook result:

   ```
       TASK [firewall : include_vars ░ Gather OS specific variables] ******************
       Saturday 28 November 2020  00:39:29 +0100 (0:00:00.073)       0:00:04.331 ***** 
       ok: [/var/tmp/diskless/workdir/name_of_image/mnt] => (item=/etc/bluebanquise/roles/core/firewall/vars/RedHat.yml)
       
       TASK [package █ Install firewalld packages] ************************************
       Saturday 28 November 2020  00:39:29 +0100 (0:00:00.104)       0:00:04.436 ***** 
       ok: [/var/tmp/diskless/workdir/name_of_image/mnt]
       
       TASK [service █ Manage firewalld state] ****************************************
       Saturday 28 November 2020  00:39:33 +0100 (0:00:04.164)       0:00:08.600 ***** 
       changed: [/var/tmp/diskless/workdir/name_of_image/mnt] => (item=firewalld)
       [WARNING]: Target is a chroot. This can lead to false positives or prevent the
       init system tools from working.
       
       TASK [include_tasks ░ Configure firewall: RedHat] ******************************
       Saturday 28 November 2020  00:39:34 +0100 (0:00:00.976)       0:00:09.577 ***** 
       skipping: [/var/tmp/diskless/workdir/name_of_image/mnt]
```
