### PR TITLE
ci: fix some issues with GitHub Actions

### DIFF
--- a/.github/workflows/molecule-actions-core-repositories_client.yml
+++ b/.github/workflows/molecule-actions-core-repositories_client.yml
@@ -29,7 +29,7 @@ jobs:
       ANSIBLE_FORCE_COLOR: 1
     steps:
       - name: Set INSTANCE_DISTRO variable
-        run: echo "::set-env name=INSTANCE_DISTRO::${MOLECULE_DISTRO/:/}"
+        run: echo "INSTANCE_DISTRO=${MOLECULE_DISTRO/:/}" >> $GITHUB_ENV
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup python environment

--- a/roles/core/ssh_master/molecule/default/molecule.yml
+++ b/roles/core/ssh_master/molecule/default/molecule.yml
@@ -42,7 +42,7 @@ platforms:
 provisioner:
   name: ansible
   env:
-    ANSIBLE_CONFIG: "../../../../../ansible.cfg"
+    ANSIBLE_CONFIG: "${MOLECULE_PROJECT_DIRECTORY}/../../../ansible.cfg"
   inventory:
     host_vars:
       icebergs-off:


### PR DESCRIPTION
I'm currently testing the GitHub Actions with the image **ubuntu-20.04** to prepare the coming change of **ubuntu-latest**: *Ubuntu-latest workflows will use Ubuntu-20.04 soon. For more details, see https://github.com/actions/virtual-environments/issues/1816*.

I identified some issues with the CI which I'm trying to fix in this PR. So far, the changes below are not related to ubuntu-20.04, but to some changes in GitHub Actions and molecule since the last run of the test. We could identify this kind of changes earlier by running each test at least once a week.

### ci: replace set-env with Environment Files

The set-env command is disabled in GitHub Actions due to CVE-2020-15228.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

### ci: use relative path to ansible.cfg in molecule
    
molecule 3.2.0 was released a couple of days ago. The current working directory changed and the ANSIBLE_CONFIG required to test role `ssh_master` is now incorrect. Use a path relative to MOLECULE_PROJECT_DIRECTORY instead.
