### PR TITLE
Feat: addons/nic_nmcli - Update routes, add zones

### DIFF
--- a/roles/addons/nic_nmcli/readme.rst
+++ b/roles/addons/nic_nmcli/readme.rst
@@ -10,6 +10,11 @@ The role also cover routes definitions on interfaces.
 This role provides all features availables in the main nmcli module.
 Please refer to `nmcli module documentation <https://docs.ansible.com/ansible/latest/collections/community/general/nmcli_module.html>`_ .
 
+.. warning:
+  This role needs **latest** nmcli.py module, from
+  https://github.com/ansible-collections/community.general/
+  ansible-collections:main branch.
+
 Instructions
 ^^^^^^^^^^^^
 
@@ -20,12 +25,14 @@ While all of the nmcli module options are supported,
 some provides more integrated features:
 
 * **conn_name**: is equal to **interface**, but has higher precedence over **interface** if both are set.
-* **ifname**: is equal to **physical_device**, but has higher precedence over **ifname**  if both are set.
+* **ifname**: is equal to **physical_device**, but has higher precedence over **ifname** if both are set.
 * **type**: is set to *ethernet* by default if not set.
-* **ip4**: can be set using a simple ipv4, then role will use **networks[item.network]['.prefix4']** or if not exist to **networks[item.network]['.prefix']** to complete address, or force address with prefix if string *'/'* is present.
+* **ip4**: can be set using a simple ipv4, then role will use **networks[item.network]['.prefix4']** or if not exist to **networks[item.network]['.prefix']** to complete address. You can force address with prefix if string *'/'* is present.
 * **mtu**: has higher precedence over **networks[item.network]['mtu']** if both are set.
-* **gw4**: has higher precedence over **networks[item.network]['.gateway4']** which has higher precedence over **networks[item.network]['.gateway']** (if set).
-* **routes4**: is a list, that defines routes to be set on the interface. See examples bellow.
+* **gw4**: has higher precedence over **networks[item.network]['.gateway4']** if set which has higher precedence over **networks[item.network]['.gateway']** if set. Note that gw4 is cannot be set at the same time than never_default4 (mutually exclusives).
+* **routes4**: is a list, that defines routes to be set on the interface. See examples bellow. Has higher precedence over **networks[item.network]['.routes4']** if set.
+* **route_metric4**: is to set general metric for gateway or routes (if not set on route level) for this interface. Has higher precedence over **networks[item.network]['.route_metric4']** if set.
+* **never_default4**: is related to ipv4.never-default nmcli parameter (DEFROUTE). Has higher precedence over **networks[item.network]['.never_default4']** if set.
 
 Basic ipv4
 """"""""""
@@ -113,8 +120,8 @@ You can define routes at two levels:
       netmask: 255.255.0.0
       broadcast: 10.10.255.255
       routes4:
-        - ip = 10.11.0.0/24, nh = 10.10.0.2
-        - ip = 10.12.0.0/24, nh = 10.10.0.2
+        - 10.11.0.0/24 10.10.0.2
+        - 10.12.0.0/24 10.10.0.2 300
 
 * Or under host definition, so in hostvars:
 
@@ -127,22 +134,17 @@ You can define routes at two levels:
               mac: 08:00:27:36:c0:ac
               network: ice1-1
               routes4:
-                - ip = 10.11.0.0/24, nh = 10.10.0.2
-                - ip = 10.12.0.0/24, nh = 10.10.0.2
+                - 10.11.0.0/24 10.10.0.2
+                - 10.12.0.0/24 10.10.0.2 300
 
-.. note::
-  Note that to define a default route/gateway, use *0.0.0.0/0* as route to be defined.
-
-To remove a route later (here *10.12.0.0/24 10.10.0.2* on *enp0s8*), use the nmcli command this way:
-
-.. code-block:: text
-
-  nmcli connection show enp0s8 | grep ipv4.routes
-  nmcli connection modify enp0s8 -ipv4.routes "10.12.0.0/24 10.10.0.2"
+.. note:
+  In route4 list, first element is network to reach (0.0.0.0/0 for all), second
+  is gateway to use, and last optional one is metric to set for this route.
 
 Changelog
 ^^^^^^^^^
 
+* 1.2.0: Add routes4, route_metric4, never_default4 and zone. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.1.1: Add routes support on NIC. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.1.0: Rewamp full role to handle all nmcli module features. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.2: Adding Ubuntu 18.04 compatibility. johnnykeats <johnny.keats@outlook.com>

--- a/roles/addons/nic_nmcli/readme.rst
+++ b/roles/addons/nic_nmcli/readme.rst
@@ -11,7 +11,7 @@ This role provides all features availables in the main nmcli module.
 Please refer to `nmcli module documentation <https://docs.ansible.com/ansible/latest/collections/community/general/nmcli_module.html>`_ .
 
 .. warning:
-  This role needs **latest** nmcli.py module, from
+  This role needs **latest** (2.0.0) nmcli.py module, from
   https://github.com/ansible-collections/community.general/
   ansible-collections:main branch.
 

--- a/roles/addons/nic_nmcli/readme.rst
+++ b/roles/addons/nic_nmcli/readme.rst
@@ -11,9 +11,11 @@ This role provides all features availables in the main nmcli module.
 Please refer to `nmcli module documentation <https://docs.ansible.com/ansible/latest/collections/community/general/nmcli_module.html>`_ .
 
 .. warning:
-  This role needs **latest** (2.0.0) nmcli.py module, from
-  https://github.com/ansible-collections/community.general/
-  ansible-collections:main branch.
+  This role needs **latest** (2.0.0) nmcli.py module. If you plan to configure
+  routes or zones with this role, you will have to install the development
+  version of the community.general collection which is available at
+  https://github.com/ansible-collections/community.general/ until the General
+  Availability of the 2.0.0 release.
 
 Instructions
 ^^^^^^^^^^^^
@@ -24,15 +26,30 @@ Stack specific behaviors
 While all of the nmcli module options are supported,
 some provides more integrated features:
 
-* **conn_name**: is equal to **interface**, but has higher precedence over **interface** if both are set.
-* **ifname**: is equal to **physical_device**, but has higher precedence over **ifname** if both are set.
+* **conn_name**: is equal to **interface**, but has higher precedence over
+  **interface** if both are set.
+* **ifname**: is equal to **physical_device**, but has higher precedence over
+  **ifname** if both are set.
 * **type**: is set to *ethernet* by default if not set.
-* **ip4**: can be set using a simple ipv4, then role will use **networks[item.network]['.prefix4']** or if not exist to **networks[item.network]['.prefix']** to complete address. You can force address with prefix if string *'/'* is present.
-* **mtu**: has higher precedence over **networks[item.network]['mtu']** if both are set.
-* **gw4**: has higher precedence over **networks[item.network]['.gateway4']** if set which has higher precedence over **networks[item.network]['.gateway']** if set. Note that gw4 is cannot be set at the same time than never_default4 (mutually exclusives).
-* **routes4**: is a list, that defines routes to be set on the interface. See examples bellow. Has higher precedence over **networks[item.network]['.routes4']** if set.
-* **route_metric4**: is to set general metric for gateway or routes (if not set on route level) for this interface. Has higher precedence over **networks[item.network]['.route_metric4']** if set.
-* **never_default4**: is related to ipv4.never-default nmcli parameter (DEFROUTE). Has higher precedence over **networks[item.network]['.never_default4']** if set.
+* **ip4**: can be set using a simple ipv4, then role will use
+  **networks[item.network]['prefix4']** or default to
+  **networks[item.network]['prefix']** to complete address. You can force
+  address with prefix if string *'/'* is present.
+* **mtu**: has higher precedence over **networks[item.network]['mtu']** if
+  both are set.
+* **gw4**: has higher precedence over **networks[item.network]['.gateway4']**
+  if set which has higher precedence over **networks[item.network]['.gateway']**
+  if set. Note that gw4 is cannot be set at the same time than never_default4
+  (mutually exclusives).
+* **routes4**: is a list, that defines routes to be set on the interface. See
+  examples bellow. Has higher precedence over
+  **networks[item.network]['.routes4']** if set.
+* **route_metric4**: is to set general metric for gateway or routes (if not set
+  on route level) for this interface. Has higher precedence over
+  **networks[item.network]['.route_metric4']** if set.
+* **never_default4**: is related to ipv4.never-default nmcli parameter
+  (DEFROUTE). Has higher precedence over
+  **networks[item.network]['.never_default4']** if set.
 
 Basic ipv4
 """"""""""
@@ -138,8 +155,9 @@ You can define routes at two levels:
                 - 10.12.0.0/24 10.10.0.2 300
 
 .. note:
-  In route4 list, first element is network to reach (0.0.0.0/0 for all), second
-  is gateway to use, and last optional one is metric to set for this route.
+  In route4 list, each element of the list is a tuple with the network
+  destination in first position, gateway in second position and optionally
+  the metric in third position.
 
 Changelog
 ^^^^^^^^^

--- a/roles/addons/nic_nmcli/tasks/main.yml
+++ b/roles/addons/nic_nmcli/tasks/main.yml
@@ -66,6 +66,7 @@
     # Allows to provide a simple ip4, or an ip4/prefix
     # Also support old prefix format (to be replaced by prefix4)
     gw4: "{{ (item.never_default4 | default(networks[item.network].never_default4) is not defined) | ternary( item.gw4 | default(networks[item.network].gateway4) | default(networks[item.network].gateway) | default(omit), omit) }}"
+    # Check here if never_default4 is set or not. If set, gw4 cannot be used as both are mutually exclusive. If not set, then get gw4 from network_interfaces, then default to network.gateway4 then default to network.gateway then omit.
     routes4: "{{ (item.routes4 is defined or networks[item.network]['routes4'] is defined) |ternary( item.routes4 | default(networks[item.network]['routes4'] | default([]) ), omit) }}"
     route_metric4: "{{ item.route_metric4 | default(networks[item.network].route_metric4) | default(omit) }}"
     never_default4: "{{ item.never_default4 | default(networks[item.network].never_default4) | default(omit) }}"

--- a/roles/addons/nic_nmcli/tasks/main.yml
+++ b/roles/addons/nic_nmcli/tasks/main.yml
@@ -65,7 +65,10 @@
     # {% endif %}
     # Allows to provide a simple ip4, or an ip4/prefix
     # Also support old prefix format (to be replaced by prefix4)
-    gw4: "{{ item.gw4 | default(networks[item.network].gateway4) | default(networks[item.network].gateway) | default(omit) }}"
+    gw4: "{{ (item.never_default4 | default(networks[item.network].never_default4) is not defined) | ternary( item.gw4 | default(networks[item.network].gateway4) | default(networks[item.network].gateway) | default(omit), omit) }}"
+    routes4: "{{ (item.routes4 is defined or networks[item.network]['routes4'] is defined) |ternary( item.routes4 | default(networks[item.network]['routes4'] | default([]) ), omit) }}"
+    route_metric4: "{{ item.route_metric4 | default(networks[item.network].route_metric4) | default(omit) }}"
+    never_default4: "{{ item.never_default4 | default(networks[item.network].never_default4) | default(omit) }}"
     mtu: "{{ item.mtu | default(networks[item.network].mtu) | default(omit) }}"
     type: "{{ item.type | default('ethernet') }}" # Even if in the documentation type is optional, it is in fact mandatory. Default to ethernet.
     # Standard
@@ -107,37 +110,10 @@
     vxlan_id: "{{ item.vxlan_id | default(omit) }}"
     vxlan_local: "{{ item.vxlan_local | default(omit) }}"
     vxlan_remote: "{{ item.vxlan_remote | default(omit) }}"
+    zone: "{{ item.zone | default(omit) }}"
   notify: command █ Reload connections
   loop: "{{ network_interfaces }}"
   tags:
     - identify
-
-# Check route 0.0.0.0/0 is only set once
-- name: assert ░ Assert there are only one default route
-  assert:
-    that:
-      - (network_interfaces | selectattr('routes4','defined') | map(attribute='routes4') | select('match', '.*0.0.0.0/0.*') | list | length) <= 1
-
-- name: shell ░ Gather routes
-  shell: "set -o pipefail && nmcli connection show {{ item.interface }} | grep ipv4.routes"
-  loop: "{{ network_interfaces }}"
-  when: item.interface is defined and item.ip4 is defined
-  register: current_ipv4_routes
-  changed_when: False
-
-- name: set_fact ░ Combine inventory routes
-  set_fact:
-    inventory_routes4: "{{ (inventory_routes4|default({})) | combine( {item.interface: ( '{ ' + (item.routes4 | default(networks[item.network]['routes4'])| join(' }; { ')) + ' }')} ) }}"
-  loop: "{{ network_interfaces }}"
-  when: (item.routes4 is defined and item.routes4) or (networks[item.network]['routes4'] is defined and networks[item.network]['routes4'])
-
-- name: command █ Set routes via nmcli
-  command: "nmcli connection modify {{ item.0.interface }} +ipv4.routes '{{ item.0.routes4 | default(networks[item.0.network]['routes4']) | join(',') | replace('ip = ','') | replace(', nh = ',' ') }}'"
-  loop: "{{ network_interfaces | product(current_ipv4_routes.results) | list }}"
-  notify: command █ Reload connections
-  when:
-    - item.0.interface == item.1.item.interface
-    - inventory_routes4[item.0.interface] is defined
-    - inventory_routes4[item.0.interface] not in item.1.stdout
 
 - meta: flush_handlers

--- a/roles/addons/nic_nmcli/vars/main.yml
+++ b/roles/addons/nic_nmcli/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-nic_nmcli_role_version: 1.1.1
+nic_nmcli_role_version: 1.2.0


### PR DESCRIPTION
It is a feat, branch name mention fix, this is a mistake.

* Update routes to a much simpler format.
* Add Firewall zone.

Note that routes format change. Previous format was introduced recently, and should still not be used by any one, but in case of.