### PR TITLE
fix: skip ansible-lint rule 208 when recurse: yes

### DIFF
--- a/roles/core/conman/tasks/main.yml
+++ b/roles/core/conman/tasks/main.yml
@@ -31,9 +31,8 @@
     - package
 
 - name: file █ Create /var/log/conman directory
-  file:
+  file: # noqa 208
     path: /var/log/conman
-    mode: 0750
     setype: conman_log_t
     state: directory
     recurse: yes

--- a/roles/core/log_server/tasks/main.yml
+++ b/roles/core/log_server/tasks/main.yml
@@ -60,9 +60,8 @@
     - package
 
 - name: Create /var/log/rsyslog directory
-  file:
+  file: # noqa 208
     path: /var/log/rsyslog
-    mode: 0750
     setype: var_log_t
     state: directory
     recurse: yes


### PR DESCRIPTION
Remove mode: 0750 for file tasks where recurse: yes.

All the files in the directory will inherit this mode, which is wrong.
This mode was added in commit d70ad62 to resolve an error reported by
ansible-lint. Use #noqa 208 instead to skip the qa for this task, we can
rely on default mode set during the installation of the RPM.