### PR TITLE
ci: setup molecule for set_hostname

### DIFF
--- a/.github/TEST_MATRIX.md
+++ b/.github/TEST_MATRIX.md
@@ -16,17 +16,18 @@ Molecule unit tests
 |![core/firewall unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/firewall%20unit%20testing/badge.svg)                       | x | x |   |
 |![core/log_client unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/log_client%20unit%20testing/badge.svg)                   | x | x | x |
 |![core/log_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/log_server%20unit%20testing/badge.svg)                   | x | x | x |
-|![core/pxe_stack unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/pxe_stack%20unit%20testing/badge.svg)                     | x | x |   |
 |![core/nfs_client unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/nfs_client%20unit%20testing/badge.svg)                   | x | x |   |
 |![core/nfs_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/nfs_server%20unit%20testing/badge.svg)                   | x | x |   |
+|![core/pxe_stack unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/pxe_stack%20unit%20testing/badge.svg)                     | x | x |   |
 |![core/repositories_client unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/repositories_client%20unit%20testing/badge.svg) | x | x |   |
 |![core/repositories_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/repositories_server%20unit%20testing/badge.svg) | x | x |   |
+|![core/set_hostname unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/set_hostname%20unit%20testing/badge.svg)               | x | x |   |
 |![core/ssh_master unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/ssh_master%20unit%20testing/badge.svg)                   | x | x | x |
 |![core/ssh_slave unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/ssh_slave%20unit%20testing/badge.svg)                     | x | x | x |
 |![core/time unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/time%20unit%20testing/badge.svg)                               | x | x |   |
+|![advanced-core/advanced_dhcp_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/advanced-core/advanced_dhcp_server%20unit%20testing/badge.svg)                 | x | x |   |
 |![advanced_core/advanced_dns_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/advanced_core/advanced_dns_server%20unit%20testing/badge.svg)                   | x | x |   |
 |![addons/clustershell unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/clustershell%20unit%20testing/badge.svg)           | x | x | x |
 |![addons/grafana unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/grafana%20unit%20testing/badge.svg)                     | x | x |   |
 |![addons/root_password unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/root_password%20unit%20testing/badge.svg)         | x | x | x |
 |![addons/users_basic unit testing](https://github.com/bluebanquise/bluebanquise/workflows/addons/users_basic%20unit%20testing/badge.svg)             | x | x | x |
-|![advanced-core/advanced_dhcp_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/advanced-core/advanced_dhcp_server%20unit%20testing/badge.svg)                   | x | x |   |

--- a/.github/workflows/molecule-actions-core-set_hostname.yml
+++ b/.github/workflows/molecule-actions-core-set_hostname.yml
@@ -1,0 +1,40 @@
+---
+name: core/set_hostname unit testing
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'roles/core/set_hostname/**'
+      - '.github/workflows/molecule-actions-core-set_hostname.yml'
+  pull_request:
+    paths:
+      - 'roles/core/set_hostname/**'
+      - '.github/workflows/molecule-actions-core-set_hostname.yml'
+
+jobs:
+  molecule_test:
+    name: ${{ matrix.distro }} - molecule test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - centos:7
+          - centos:8
+
+    env:
+      MOLECULE_DISTRO: ${{ matrix.distro }}
+      PY_COLORS: 1
+      ANSIBLE_FORCE_COLOR: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup python environment
+        uses: actions/setup-python@v1
+      - name: Install packages
+        run: |
+          pip install tox
+      - name: Run molecule test for core/set_hostname
+        run: |
+          cd roles/core/set_hostname && tox

--- a/roles/core/set_hostname/molecule/default/converge.yml
+++ b/roles/core/set_hostname/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include set_hostname"
+      include_role:
+        name: "set_hostname"

--- a/roles/core/set_hostname/molecule/default/molecule.yml
+++ b/roles/core/set_hostname/molecule/default/molecule.yml
@@ -1,0 +1,13 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/roles/core/set_hostname/molecule/default/molecule.yml
+++ b/roles/core/set_hostname/molecule/default/molecule.yml
@@ -5,7 +5,13 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: docker.io/pycontribs/centos:8
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
+    override_command: false
+    capabilities:
+      - "SYS_ADMIN"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/core/set_hostname/molecule/default/verify.yml
+++ b/roles/core/set_hostname/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/roles/core/set_hostname/molecule/default/verify.yml
+++ b/roles/core/set_hostname/molecule/default/verify.yml
@@ -1,10 +1,7 @@
 ---
-# This is an example playbook to execute Ansible tests.
-
 - name: Verify
   hosts: all
-  gather_facts: false
   tasks:
-  - name: Example assertion
+  - name: Assert hostname
     assert:
-      that: true
+      that: ansible_hostname == "instance"


### PR DESCRIPTION
The purpose of this test is to ensure the role can run, even if it's a single task role today.

The test does not change the hostname of the instance because it is not possible to change the hostname with hostnamectl in a running container (Could not set property: Failed to set static hostname: Device or resource busy).
Molecule, with the docker driver, will create a container with hostname `instance`, then will use this name as `inventory_hostname`. The role uses this variable in the task, which should not change the hostname. In the verify step, molecule gathers the facts and check that `ansible_hostname` is `instance`.