### PR TITLE
ci: setup molecule test for nic

### DIFF
--- a/.github/TEST_MATRIX.md
+++ b/.github/TEST_MATRIX.md
@@ -19,6 +19,7 @@ Molecule unit tests
 |![core/pxe_stack unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/pxe_stack%20unit%20testing/badge.svg)                     | x | x |   |
 |![core/nfs_client unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/nfs_client%20unit%20testing/badge.svg)                   | x | x |   |
 |![core/nfs_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/nfs_server%20unit%20testing/badge.svg)                   | x | x |   |
+|![core/nic unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/nic%20unit%20testing/badge.svg)                                 | x | x |   |
 |![core/repositories_client unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/repositories_client%20unit%20testing/badge.svg) | x | x |   |
 |![core/repositories_server unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/repositories_server%20unit%20testing/badge.svg) | x | x |   |
 |![core/ssh_master unit testing](https://github.com/bluebanquise/bluebanquise/workflows/core/ssh_master%20unit%20testing/badge.svg)                   | x | x | x |

--- a/.github/workflows/molecule-actions-core-nic.yml
+++ b/.github/workflows/molecule-actions-core-nic.yml
@@ -1,0 +1,40 @@
+---
+name: core/nic unit testing
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'roles/core/nic/**'
+      - '.github/workflows/molecule-actions-core-nic.yml'
+  pull_request:
+    paths:
+      - 'roles/core/nic/**'
+      - '.github/workflows/molecule-actions-core-nic.yml'
+
+jobs:
+  molecule_test:
+    name: ${{ matrix.distro }} - molecule test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - centos:7
+          - centos:8
+
+    env:
+      MOLECULE_DISTRO: ${{ matrix.distro }}
+      PY_COLORS: 1
+      ANSIBLE_FORCE_COLOR: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup python environment
+        uses: actions/setup-python@v1
+      - name: Install packages
+        run: |
+          pip install tox
+      - name: Run molecule test for core/nic
+        run: |
+          cd roles/core/nic && tox

--- a/roles/core/nic/.yamllint
+++ b/roles/core/nic/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/core/nic/defaults/main.yml
+++ b/roles/core/nic/defaults/main.yml
@@ -1,1 +1,2 @@
+---
 nic_nm_controlled: yes

--- a/roles/core/nic/molecule/default/INSTALL.rst
+++ b/roles/core/nic/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/roles/core/nic/molecule/default/converge.yml
+++ b/roles/core/nic/molecule/default/converge.yml
@@ -1,0 +1,18 @@
+---
+- name: Converge
+  hosts: all
+
+  vars:
+    networks:
+      testnetwork:
+        subnet: 10.1.0.0
+        prefix: 16
+        gateway: 10.1.0.1
+        mtu: 9000
+      interconnect-1:
+        netmask: "255.255.0.0"
+
+  tasks:
+    - name: "Include nic"
+      include_role:
+        name: "nic"

--- a/roles/core/nic/molecule/default/molecule.yml
+++ b/roles/core/nic/molecule/default/molecule.yml
@@ -1,0 +1,60 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:  |
+  set -e
+  yamllint .
+platforms:
+  - name: instance
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
+    override_command: false
+    capabilities:
+      - "SYS_ADMIN"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      instance:
+        network_interfaces:
+          - interface: eth0
+            ip4: "10.0.0.42"
+          - interface: eth1
+            ip4: "10.1.0.42"
+            network: testnetwork
+            zone: external
+          - interface: bond0
+            type: bond
+            vlan: false
+            bond_options: "mode=4 xmit_hash_policy=layer3+4 miimon=100 lacp_rate=1"
+            ip4: "10.1.0.100"
+            network: testnetwork
+          - interface: slave0
+            type: bond-slave
+            master: bond0
+          - interface: slave1
+            type: bond-slave
+            master: bond0
+          - interface: ib0
+            ip4: "10.2.0.42"
+            network: interconnect-1
+            autoconnect: False
+            type: infiniband
+          - interface: eth0.100
+            vlan: true
+            vlan_id: 100
+            physical_device: eth0
+            ip4: "10.1.100.42"
+            network: testnetwork
+          - interface: multi0
+            ip4_multi:
+              - 172.16.0.2/16
+              - 172.16.0.3/16
+              - 192.168.1.117/24
+verifier:
+  name: ansible

--- a/roles/core/nic/molecule/default/prepare.yml
+++ b/roles/core/nic/molecule/default/prepare.yml
@@ -1,0 +1,11 @@
+---
+- name: Prepare
+  hosts: all
+
+  tasks:
+    - name: Install core packages missing from container
+      package:
+        name: initscripts
+      when:
+        - ansible_facts.os_family == "RedHat"
+        - ansible_facts.distribution_major_version == "7"

--- a/roles/core/nic/molecule/default/verify.yml
+++ b/roles/core/nic/molecule/default/verify.yml
@@ -1,0 +1,170 @@
+---
+- name: Verify
+  hosts: all
+
+  tasks:
+    - name: Read ifcfg-eth0
+      slurp:
+        src: /etc/sysconfig/network-scripts/ifcfg-eth0
+      register: ifcfg_eth0
+
+    - name: Display ifcfg-eth0
+      debug:
+        msg: "{{ ifcfg_eth0['content'] | b64decode }}"
+
+    - name: Check absence of IPADDR in ifcfg-eth0
+      assert:
+        that: not ifcfg_eth0['content'] | b64decode |
+                regex_search('^IPADDR=', multiline=True)
+
+    - name: Check presence of parameters in ifcfg-eth0
+      assert:
+        that: ifcfg_eth0['content'] | b64decode |
+                regex_search('{{ item }}', multiline=True)
+      loop:
+        - '^NAME=eth0$'
+        - '^DEVICE=eth0$'
+        - '^TYPE=ethernet$'
+
+    - name: Check presence of NM_MANAGED for EL7 in ifcfg-eth0
+      assert:
+        that: ifcfg_eth0['content'] | b64decode |
+                regex_search('^NM_MANAGED=yes$', multiline=True)
+      when: ansible_facts.distribution_major_version|int < 8
+
+    - name: Read ifcfg-eth1
+      slurp:
+        src: /etc/sysconfig/network-scripts/ifcfg-eth1
+      register: ifcfg_eth1
+
+    - name: Display ifcfg-eth1
+      debug:
+        msg: "{{ ifcfg_eth1['content'] | b64decode }}"
+
+    - name: Check presence of parameters in ifcfg-eth1
+      assert:
+        that: ifcfg_eth1['content'] | b64decode |
+                regex_search('{{ item }}', multiline=True)
+      loop:
+        - '^NAME=eth1$'
+        - '^DEVICE=eth1$'
+        - '^IPADDR=10.1.0.42$'
+        - '^PREFIX=16$'
+        - '^ONBOOT=yes$'
+        - '^TYPE=ethernet$'
+        - '^GATEWAY=10.1.0.1$'
+        - '^MTU=9000$'
+        - '^ZONE=external$'
+
+    - name: Read ifcfg-bond0
+      slurp:
+        src: /etc/sysconfig/network-scripts/ifcfg-bond0
+      register: ifcfg_bond0
+
+    - name: Display ifcfg-bond0
+      debug:
+        msg: "{{ ifcfg_bond0['content'] | b64decode }}"
+
+    - name: Check presence of parameters in ifcfg-bond0
+      assert:
+        that: ifcfg_bond0['content'] | b64decode |
+                regex_search('{{ item }}', multiline=True)
+      loop:
+        - '^NAME=bond0$'
+        - '^DEVICE=bond0$'
+        - '^IPADDR=10.1.0.100$'
+        - '^PREFIX=16$'
+        - '^ONBOOT=yes$'
+        - '^TYPE=bond$'
+        - '^BONDING_MASTER=yes$'
+        - '^BONDING_OPTS="mode=4 xmit_hash_policy=layer3.4 miimon=100 lacp_rate=1"$'
+
+    - name: Check absence of VLAN in ifcfg-bond0
+      assert:
+        that: not ifcfg_eth0['content'] | b64decode |
+                regex_search('^VLAN', multiline=True)
+
+    - name: Read ifcfg-slave1
+      slurp:
+        src: /etc/sysconfig/network-scripts/ifcfg-slave1
+      register: ifcfg_slave1
+
+    - name: Display ifcfg-slave1
+      debug:
+        msg: "{{ ifcfg_slave1['content'] | b64decode }}"
+
+    - name: Check presence of parameters in ifcfg-slave1
+      assert:
+        that: ifcfg_slave1['content'] | b64decode |
+                regex_search('{{ item }}', multiline=True)
+      loop:
+        - '^NAME=slave1$'
+        - '^DEVICE=slave1$'
+        - '^SLAVE=yes$'
+        - '^MASTER=bond0$'
+
+    - name: Read ifcfg-ib0
+      slurp:
+        src: /etc/sysconfig/network-scripts/ifcfg-ib0
+      register: ifcfg_ib0
+
+    - name: Display ifcfg-ib0
+      debug:
+        msg: "{{ ifcfg_ib0['content'] | b64decode }}"
+
+    - name: Check presence of parameters in ifcfg-ib0
+      assert:
+        that: ifcfg_ib0['content'] | b64decode |
+                regex_search('{{ item }}', multiline=True)
+      loop:
+        - '^NAME=ib0$'
+        - '^DEVICE=ib0$'
+        - '^IPADDR=10.2.0.42$'
+        - '^NETMASK=255.255.0.0$'
+        - '^ONBOOT=no$'
+        - '^TYPE=infiniband$'
+
+    - name: Read ifcfg-eth0.100
+      slurp:
+        src: /etc/sysconfig/network-scripts/ifcfg-eth0.100
+      register: ifcfg_eth0_100
+
+    - name: Display ifcfg-eth0.100
+      debug:
+        msg: "{{ ifcfg_eth0_100['content'] | b64decode }}"
+
+    - name: Check presence of parameters in ifcfg-eth0.100
+      assert:
+        that: ifcfg_eth0_100['content'] | b64decode |
+                regex_search('{{ item }}', multiline=True)
+      loop:
+        - '^NAME=eth0.100$'
+        - '^DEVICE=eth0.100$'
+        - '^IPADDR=10.1.100.42$'
+        - '^PREFIX=16$'
+        - '^VLAN=yes$'
+        - '^VLAN_ID=100$'
+        - '^PHYSDEV=eth0$'
+
+    - name: Read ifcfg-multi0
+      slurp:
+        src: /etc/sysconfig/network-scripts/ifcfg-multi0
+      register: ifcfg_multi0
+
+    - name: Display ifcfg-multi0
+      debug:
+        msg: "{{ ifcfg_multi0['content'] | b64decode }}"
+
+    - name: Check presence of parameters in ifcfg-multi0
+      assert:
+        that: ifcfg_multi0['content'] | b64decode |
+                regex_search('{{ item }}', multiline=True)
+      loop:
+        - '^NAME=multi0$'
+        - '^DEVICE=multi0$'
+        - '^IPADDR0=172.16.0.2$'
+        - '^PREFIX0=16$'
+        - '^IPADDR1=172.16.0.3$'
+        - '^PREFIX1=16$'
+        - '^IPADDR2=191.168.1.117$'
+        - '^PREFIX2=24$'

--- a/roles/core/nic/readme.rst
+++ b/roles/core/nic/readme.rst
@@ -159,6 +159,7 @@ Add Ubuntu and Opensuse compatibility if asked for.
 Changelog
 ^^^^^^^^^
 
+* 1.1.1: vlan parameter is a boolean. Bruno Travouillon <devel@travouillon.fr>
 * 1.1.0: Assign a network interface to a firewall zone. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.3: Update readme. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.2: Update to new network_interfaces syntax. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/core/nic/tasks/main.yml
+++ b/roles/core/nic/tasks/main.yml
@@ -5,7 +5,7 @@
     name: 8021q
     state: present
   with_items: "{{ network_interfaces }}"
-  when: item.vlan is defined and item.vlan is not none
+  when: item.vlan is defined and item.vlan
 
 - name: Load bonding module if needed
   modprobe:

--- a/roles/core/nic/tasks/main.yml
+++ b/roles/core/nic/tasks/main.yml
@@ -6,6 +6,8 @@
     state: present
   with_items: "{{ network_interfaces }}"
   when: item.vlan is defined and item.vlan
+  tags:
+    - molecule-notest
 
 - name: Load bonding module if needed
   modprobe:
@@ -13,6 +15,8 @@
     state: present
   with_items: "{{ network_interfaces }}"
   when: item.type is defined and (item.type == 'bond' or item.type == 'bond-slave')
+  tags:
+    - molecule-notest
 
 - name: Set NIC configuration
   template:

--- a/roles/core/nic/vars/main.yml
+++ b/roles/core/nic/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-nic_role_version: 1.1.0
+nic_role_version: 1.1.1


### PR DESCRIPTION
Add molecule tests for role `nic`.
Add the tag `molecule-notest` to the modprobe tasks to avoid issues in the Docker containers. These modules are not required to test the role.

One test fails with `ip4_multi` using the example from the readme:
```
          - interface: multi0
            ip4_multi:
              - 172.16.0.2/16
              - 172.16.0.3/16
              - 192.168.1.117/24
```

Ansible skips the template task **Set NIC configuration** when `ip4` is not defined, thus this interface is not configured. This might be a bug in the task, or an error in the documentation. @oxedions @johnnykeats please tell me if you need me to fix the task or the documentation.

I also fixed a condition where `vlan` was not considered as a boolean in task **Load VLAN module if needed**. (task was not skipped with `vlan: False`)