### PR TITLE
Fix: pxe_stack - Forcing hostname via kernel command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## 1.4.0 - Next-release
+## 1.5.0 - Next-release
+
+### Major changes
+
+#### New roles
+  
+#### Roles improvement or fix
+
+  - pxe_stack: fix issues with hostname not set during kickstart on RHEL 8.3 (#522)
+
+### Breaking changes
+
+## 1.4.0
 
 ### Major changes
 
@@ -11,7 +23,7 @@
   - addons/lvm: allow to configure lvm storage (#446)
   - addons/nhc: allow to install and setup nhc (#448)
   - addons/singularity: allow to install Singularity (#403)
-  
+
 #### Roles improvement or fix
 
   - addons/nic_nmcli:

--- a/roles/core/pxe_stack/files/osdeploy/centos_7.ipxe
+++ b/roles/core/pxe_stack/files/osdeploy/centos_7.ipxe
@@ -18,7 +18,7 @@ echo | > Target kickstart: ${eq-equipment-profile}.kickstart.cfg
 echo |
 echo | Loading linux ...
 
-kernel ${images-root}/os/images/pxeboot/vmlinuz initrd=initrd.img inst.stage2=${images-root}/os/ inst.repo=${repository-root}/os/ ks=${kickstart-path} ${eq-console} ${eq-kernel-parameters} ${dedicated-kernel-parameters} ipxe_next_server=${next-server}
+kernel ${images-root}/os/images/pxeboot/vmlinuz initrd=initrd.img inst.stage2=${images-root}/os/ inst.repo=${repository-root}/os/ ks=${kickstart-path} ${eq-console} ${eq-kernel-parameters} ${dedicated-kernel-parameters} ipxe_next_server=${next-server} node_hostname=${hostname}
 
 echo | Loading initial ramdisk ...
 

--- a/roles/core/pxe_stack/files/osdeploy/centos_8.ipxe
+++ b/roles/core/pxe_stack/files/osdeploy/centos_8.ipxe
@@ -18,7 +18,7 @@ echo | > Target kickstart: ${eq-equipment-profile}.kickstart.cfg
 echo |
 echo | Loading linux ...
 
-kernel ${images-root}/os/images/pxeboot/vmlinuz initrd=initrd.img inst.stage2=${images-root}/os/ inst.repo=${repository-root}/os/BaseOS/ ks=${kickstart-path} ${eq-console} ${eq-kernel-parameters} ${dedicated-kernel-parameters} ipxe_next_server=${next-server}
+kernel ${images-root}/os/images/pxeboot/vmlinuz initrd=initrd.img inst.stage2=${images-root}/os/ inst.repo=${repository-root}/os/BaseOS/ ks=${kickstart-path} ${eq-console} ${eq-kernel-parameters} ${dedicated-kernel-parameters} ipxe_next_server=${next-server} node_hostname=${hostname}
 
 echo | Loading initial ramdisk ...
 

--- a/roles/core/pxe_stack/files/osdeploy/redhat_7.ipxe
+++ b/roles/core/pxe_stack/files/osdeploy/redhat_7.ipxe
@@ -18,7 +18,7 @@ echo | > Target kickstart: ${eq-equipment-profile}.kickstart.cfg
 echo |
 echo | Loading linux ...
 
-kernel ${images-root}/os/images/pxeboot/vmlinuz initrd=initrd.img inst.stage2=${images-root}/os/ inst.repo=${repository-root}/os/ ks=${kickstart-path} ${eq-console} ${eq-kernel-parameters} ${dedicated-kernel-parameters} ipxe_next_server=${next-server}
+kernel ${images-root}/os/images/pxeboot/vmlinuz initrd=initrd.img inst.stage2=${images-root}/os/ inst.repo=${repository-root}/os/ ks=${kickstart-path} ${eq-console} ${eq-kernel-parameters} ${dedicated-kernel-parameters} ipxe_next_server=${next-server} node_hostname=${hostname}
 
 echo | Loading initial ramdisk ...
 

--- a/roles/core/pxe_stack/files/osdeploy/redhat_8.ipxe
+++ b/roles/core/pxe_stack/files/osdeploy/redhat_8.ipxe
@@ -18,7 +18,7 @@ echo | > Target kickstart: ${eq-equipment-profile}.kickstart.cfg
 echo |
 echo | Loading linux ...
 
-kernel ${images-root}/os/images/pxeboot/vmlinuz initrd=initrd.img inst.stage2=${images-root}/os/ inst.repo=${repository-root}/os/BaseOS/ ks=${kickstart-path} ${eq-console} ${eq-kernel-parameters} ${dedicated-kernel-parameters} ipxe_next_server=${next-server}
+kernel ${images-root}/os/images/pxeboot/vmlinuz initrd=initrd.img inst.stage2=${images-root}/os/ inst.repo=${repository-root}/os/BaseOS/ ks=${kickstart-path} ${eq-console} ${eq-kernel-parameters} ${dedicated-kernel-parameters} ipxe_next_server=${next-server} node_hostname=${hostname}
 
 echo | Loading initial ramdisk ...
 

--- a/roles/core/pxe_stack/templates/kickstart.cfg.j2
+++ b/roles/core/pxe_stack/templates/kickstart.cfg.j2
@@ -121,9 +121,7 @@ set -- `cat /proc/cmdline`
 for I in $*; do case "$I" in *=*) eval $I;; esac; done
 
 echo "All went well, we can inform next-server we succeeded"
-dhclient
-sleep 4
-curl -s -k http://$ipxe_next_server/cgi-bin/bootswitch.cgi --data "node=$(hostname -s)&boot=disk"
+curl -s -k http://$ipxe_next_server/cgi-bin/bootswitch.cgi --data "node=$node_hostname&boot=disk"
 set +x
 %end
 


### PR DESCRIPTION
Prevent issues when using the curl feedback at the end of kickstart.
Had issues when upgrading to RHEL 8.3. Solves this, and no more dependencies to distribution.