### PR TITLE
Fix issues found when booting a diskless livenet image 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 #### Roles improvement or fix
 
+  - addons/diskless:
+    - fix issues preventing access to nodes booting a livenet image (#525)
   - addons/nic_nmcli:
     - add all ansible nmcli module capabilities (#444)
     - add routes handling on interfaces (#469)

--- a/roles/addons/diskless/files/livenet_module.py
+++ b/roles/addons/diskless/files/livenet_module.py
@@ -221,8 +221,8 @@ class LivenetImage(Image):
         os.system('mount -o loop ' + self.IMAGE_DIRECTORY + 'tosquash/LiveOS/rootfs.img ' + self.MOUNT_DIRECTORY)
 
         # Put the operating system inside rootfs.img
-        logging.debug('Executing \'cp -r ' + self.WORKING_DIRECTORY + 'generated_os/* ' + self.MOUNT_DIRECTORY + '\'')
-        os.system('cp -r ' + self.WORKING_DIRECTORY + 'generated_os/* ' + self.MOUNT_DIRECTORY)
+        logging.debug('Executing \'cp -a ' + self.WORKING_DIRECTORY + 'generated_os/* ' + self.MOUNT_DIRECTORY + '\'')
+        os.system('cp -a ' + self.WORKING_DIRECTORY + 'generated_os/* ' + self.MOUNT_DIRECTORY)
 
         # Unmount rootfs.img file
         logging.debug('Executing \'umount ' + self.MOUNT_DIRECTORY + '\'')

--- a/roles/addons/diskless/files/livenet_module.py
+++ b/roles/addons/diskless/files/livenet_module.py
@@ -368,6 +368,7 @@ class LivenetImage(Image):
         os.mkdir(self.WORKING_DIRECTORY + 'inventory')
 
         # Create the ansible connection
+        # Use of [:-1] to remove last '/' from the MOUNT_DIRECTORY path
         logging.debug('Executing \'echo \'' + self.MOUNT_DIRECTORY[:-1] + ' ansible_connection=chroot\' > ' + self.WORKING_DIRECTORY + 'inventory/host\'')
         os.system('echo \'' + self.MOUNT_DIRECTORY[:-1] + ' ansible_connection=chroot\' > ' + self.WORKING_DIRECTORY + 'inventory/host')
 

--- a/roles/addons/diskless/files/livenet_module.py
+++ b/roles/addons/diskless/files/livenet_module.py
@@ -368,8 +368,8 @@ class LivenetImage(Image):
         os.mkdir(self.WORKING_DIRECTORY + 'inventory')
 
         # Create the ansible connection
-        logging.debug('Executing \'echo \'' + self.MOUNT_DIRECTORY + ' ansible_connection=chroot\' > ' + self.WORKING_DIRECTORY + 'inventory/host\'')
-        os.system('echo \'' + self.MOUNT_DIRECTORY + ' ansible_connection=chroot\' > ' + self.WORKING_DIRECTORY + 'inventory/host')
+        logging.debug('Executing \'echo \'' + self.MOUNT_DIRECTORY[:-1] + ' ansible_connection=chroot\' > ' + self.WORKING_DIRECTORY + 'inventory/host\'')
+        os.system('echo \'' + self.MOUNT_DIRECTORY[:-1] + ' ansible_connection=chroot\' > ' + self.WORKING_DIRECTORY + 'inventory/host')
 
         # Change image mountage status
         self.is_mounted = True

--- a/roles/addons/diskless/files/livenet_module.py
+++ b/roles/addons/diskless/files/livenet_module.py
@@ -609,11 +609,14 @@ boot
         """Generate an ipxe boot file for the image."""
         logging.info('Creating image \'' + self.name + '\' IPXE boot file')
 
+        # selinux should be 0 (False) or 1 (True)
+        image_selinux = '1' if self.selinux else '0'
+
         # Format image ipxe boot file template with image attributes
         file_content = self.__class__.get_boot_file_template().format(image_name=self.name,
                                                                       image_initramfs=self.image,
                                                                       image_kernel=self.kernel,
-                                                                      image_selinux=self.selinux)
+                                                                      image_selinux=image_selinux)
 
         # Create ipxe boot file
         with open(self.IMAGE_DIRECTORY + '/boot.ipxe', "w") as ff:

--- a/roles/addons/diskless/files/livenet_module.py
+++ b/roles/addons/diskless/files/livenet_module.py
@@ -609,14 +609,11 @@ boot
         """Generate an ipxe boot file for the image."""
         logging.info('Creating image \'' + self.name + '\' IPXE boot file')
 
-        # selinux should be 0 (False) or 1 (True)
-        image_selinux = '1' if self.selinux else '0'
-
         # Format image ipxe boot file template with image attributes
         file_content = self.__class__.get_boot_file_template().format(image_name=self.name,
                                                                       image_initramfs=self.image,
                                                                       image_kernel=self.kernel,
-                                                                      image_selinux=image_selinux)
+                                                                      image_selinux=int(self.selinux))
 
         # Create ipxe boot file
         with open(self.IMAGE_DIRECTORY + '/boot.ipxe', "w") as ff:


### PR DESCRIPTION
This PR relates to the following issues regarding livenet images in the diskless role: #523 #521 #524

- For #523, using `cp -a` instead of `cp -r` will keep the setuid flag for /usr/bin/sudo.

- For #521, asking disklessset to disable SELinux would put `selinux=False` in the kernel command line, which would not disable SELinux during boot. The proposed fix will correctly write `selinux=0` in the kernel command line.

- For #524, the `self.MOUNT_DIRECTORY` variable is created with a `/` at the end and used in many places in the code. The proposed fix will keep the variable as-is but remove the `/` when writing the host file.   
