### PR TITLE
Fix ansible modules documentation URL

### DIFF
--- a/resources/documentation/learn_ansible.rst
+++ b/resources/documentation/learn_ansible.rst
@@ -624,7 +624,7 @@ Content is pretty simple:
 * Then Ansible ensure httpd service is started and enabled at boot
 
 You can find all Ansible modules here in the
-`official documentation <https://docs.ansible.com/ansible/latest/modules/modules_by_category.html>`_ .
+`official documentation <https://docs.ansible.com/ansible/latest/collections/index_module.html>`_.
 
 Template
 ^^^^^^^^
@@ -779,7 +779,7 @@ Task again
 ----------
 
 As discussed before, all task available modules can be found in the
-`Ansible modules documentation <https://docs.ansible.com/ansible/latest/modules/modules_by_category.html>`_ .
+`Ansible modules documentation <https://docs.ansible.com/ansible/latest/collections/index_module.html>`_ .
 
 Each of these modules can be combined with general tasks actions. But first,
 let's define the basic debug module and registers, that will allow us to play


### PR DESCRIPTION
Previous URL now gives a 404. The content at the new URL is slightly
different but roughly similar.