### PR TITLE
[Stable-1.4] backport PR #531

### DIFF
--- a/roles/core/ssh_master/templates/config.j2
+++ b/roles/core/ssh_master/templates/config.j2
@@ -35,7 +35,9 @@ Host {{ host }}
 {% endif %}
 
 {% for host in range %}
+  {% if hostvars[host]['network_interfaces'] is defined and hostvars[host]['network_interfaces'] is iterable %}
 {{ write_host(host,(node_main_network(hostvars[host]['network_interfaces'],j2_current_iceberg_network)| trim), None) }}
+  {% endif %}
 {% endfor %}
 
 {% if icebergs_system == true and ssh_master_enable_jump == true %}


### PR DESCRIPTION
Backport [#531](https://github.com/bluebanquise/bluebanquise/pull/531/commits/a7e0665d052ee6cb9379794b71325f8181545be7) of @btravouillon 
Role ssh_master should not fail when a host has no network_interfaces
defined. Ensure this parameter is defined when looping over all hosts.

```
TASK [ssh_master : template █ Generate /root/.ssh/config]
*****************************************************************************************
Friday 08 January 2021 15:52:50 +0100 (0:00:00.794) 0:00:05.886 ********
fatal: [mst3]: FAILED! => changed=false
msg: 'AnsibleUndefinedVariable: ''ansible.vars.hostvars.HostVarsVars object'' has no attribute ''network_interfaces'''
```