### PR TITLE
ci: fix ansible versions and failing tests

### DIFF
--- a/.github/workflows/molecule-actions-core-time.yml
+++ b/.github/workflows/molecule-actions-core-time.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   molecule_test:
     name: ${{ matrix.distro }} - molecule test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-python@v1
 
       - name: Install packages
-        run: pip install 'ansible<3.0.0' ansible-lint flake8 yamllint
+        run: pip install ansible ansible-lint flake8 yamllint
 
       - name: Check python code
         run: flake8 . --statistics --ignore E501,E226

--- a/roles/addons/nic_nmcli/tasks/main.yml
+++ b/roles/addons/nic_nmcli/tasks/main.yml
@@ -117,4 +117,5 @@
   tags:
     - identify
 
-- meta: flush_handlers
+- name: meta █ Run handler tasks to reload connections
+  meta: flush_handlers

--- a/roles/addons/powerman/tasks/main.yml
+++ b/roles/addons/powerman/tasks/main.yml
@@ -19,7 +19,8 @@
   tags:
     - template
 
-- meta: flush_handlers
+- name: meta █ Run handler tasks to restart powerman service
+  meta: flush_handlers
 
 - name: service █ Manage powerman state
   service:

--- a/roles/addons/prometheus_server/tasks/main.yml
+++ b/roles/addons/prometheus_server/tasks/main.yml
@@ -44,7 +44,8 @@
   tags:
     - firewall
 
-- meta: flush_handlers
+- name: meta █ Run handler tasks to restart firewall services
+  meta: flush_handlers
 
 - name: "firewalld █ Add services to firewall's {{ prometheus_server_firewall_zone | default('public') }} zone"
   firewalld:

--- a/roles/advanced-core/advanced_dns_server/tasks/main.yml
+++ b/roles/advanced-core/advanced_dns_server/tasks/main.yml
@@ -100,7 +100,8 @@
     - template
     - internal
 
-- meta: flush_handlers
+- name: meta █ Run handler tasks to restart dns services
+  meta: flush_handlers
 
 - name: "service █ Manage {{ advanced_dns_server_services_to_start | join(' ') }} state"
   service:

--- a/roles/core/conman/tasks/main.yml
+++ b/roles/core/conman/tasks/main.yml
@@ -102,7 +102,8 @@
   when:
     - ansible_facts.selinux.status == "enabled"
 
-- meta: flush_handlers
+- name: meta █ Run handler tasks to restart conman service
+  meta: flush_handlers
 
 - name: service █ Manage conman state
   service:

--- a/roles/core/dhcp_server/tasks/main.yml
+++ b/roles/core/dhcp_server/tasks/main.yml
@@ -82,7 +82,8 @@
   tags:
     - template
 
-- meta: flush_handlers
+- name: meta █ Run handler tasks to restart dhcp services
+  meta: flush_handlers
 
 - name: "service █ Manage {{ dhcp_server_services_to_start | join(' ') }} state"
   service:

--- a/roles/core/dns_server/tasks/main.yml
+++ b/roles/core/dns_server/tasks/main.yml
@@ -115,7 +115,8 @@
   tags:
     - template
 
-- meta: flush_handlers
+- name: meta █ Run handler tasks to restart dns services
+  meta: flush_handlers
 
 - name: "service █ Manage {{ dns_server_services_to_start | join(' ') }} state"
   service:

--- a/roles/core/firewall/tasks/RedHat.yml
+++ b/roles/core/firewall/tasks/RedHat.yml
@@ -19,7 +19,8 @@
   loop: "{{ (network_interfaces | map(attribute='network') | list) }}"
   notify: service █ Restart firewall services
 
-- meta: flush_handlers
+- name: meta █ Run handler tasks to restart firewall services
+  meta: flush_handlers
 
 - name: "firewalld █ Configure firewall zones"
   firewalld:

--- a/roles/core/log_client/tasks/main.yml
+++ b/roles/core/log_client/tasks/main.yml
@@ -72,7 +72,8 @@
     - udp
   notify: Restart rsyslog services
 
-- meta: flush_handlers
+- name: meta █ Run handler tasks to restart rsyslog services
+  meta: flush_handlers
 
 - name: Manage services state
   service:

--- a/roles/core/log_server/tasks/main.yml
+++ b/roles/core/log_server/tasks/main.yml
@@ -118,7 +118,8 @@
   tags:
     - template
 
-- meta: flush_handlers
+- name: meta █ Run handler tasks to restart rsyslog services
+  meta: flush_handlers
 
 - name: Manage services state
   service:

--- a/roles/core/nfs_server/tasks/main.yml
+++ b/roles/core/nfs_server/tasks/main.yml
@@ -56,7 +56,8 @@
   tags:
     - template
 
-- meta: flush_handlers
+- name: meta █ Run handler tasks to restart nfs server services
+  meta: flush_handlers
 
 - name: "service █ Manage {{ nfs_server_services_to_start | join(' ') }} state"
   service:

--- a/roles/core/pxe_stack/tasks/main.yml
+++ b/roles/core/pxe_stack/tasks/main.yml
@@ -265,7 +265,8 @@
     owner: "{{ pxe_stack_apache_user }}"
     group: "{{ pxe_stack_apache_user }}"
 
-- meta: flush_handlers
+- name: meta █ Run handler tasks to restart pxe services
+  meta: flush_handlers
 
 - name: "service █ Manage {{ (pxe_stack_services_to_start + [pxe_stack_tftp_service | default(pxe_stack_default_tftp_service)]) | join(' ') }} state"
   service:

--- a/roles/core/time/tasks/main.yml
+++ b/roles/core/time/tasks/main.yml
@@ -61,7 +61,8 @@
   timezone:
     name: "{{ time_zone }}"
 
-- meta: flush_handlers
+- name: meta █ Run handler tasks to restart time services
+  meta: flush_handlers
 
 - name: "service █ Manage {{ time_services_to_start | join(' ') }} services state"
   service:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,3}-ansible{28,29,210}
+envlist = py{27,3}-ansible{29,210,3}
 skipsdist = true
 
 [testenv]
@@ -11,9 +11,9 @@ passenv =
     PY_COLORS
     ANSIBLE_FORCE_COLOR
 deps =
-    ansible28: ansible==2.8
-    ansible29: ansible==2.9
-    ansible210: ansible==2.10
+    ansible29: ansible>=2.9.13,<2.10
+    ansible210: ansible>=2.10,<3.0
+    ansible3: ansible>=3.0
     ansible-lint
     flake8
     jmespath


### PR DESCRIPTION
1) Update tox file:

   - The stack requires >= 2.9.13.
   - Don't test with ansible 2.8 anymore.
   - Run tests with ansible 2.9, 2.10 and 3.

2) Revert ebfa28f since ansible-base 2.10.7 is released (resolve `firewalld` to the correct FQCN).

3) Pin molecule CI for role time to Ubuntu 18.04 runner.

4) Ansible-lint 5.0.3 enforce rule unnamed-task for Task/Handler: meta.

Fix the failures below with ansible-lint:
```
unnamed-task: All tasks should be named
roles/addons/nic_nmcli/tasks/main.yml:120 Task/Handler: meta  flush_handlers

unnamed-task: All tasks should be named
roles/addons/powerman/tasks/main.yml:22 Task/Handler: meta  flush_handlers

unnamed-task: All tasks should be named
roles/addons/prometheus_server/tasks/main.yml:47 Task/Handler: meta  flush_handlers

role-name: Role name advanced-core does not match ``^[a-z][a-z0-9_]+$`` pattern
roles/advanced-core:0

unnamed-task: All tasks should be named
roles/advanced-core/advanced_dns_server/tasks/main.yml:103 Task/Handler: meta  flush_handlers

unnamed-task: All tasks should be named
roles/core/conman/tasks/main.yml:105 Task/Handler: meta  flush_handlers

unnamed-task: All tasks should be named
roles/core/dhcp_server/tasks/main.yml:85 Task/Handler: meta  flush_handlers

unnamed-task: All tasks should be named
roles/core/dns_server/tasks/main.yml:118 Task/Handler: meta  flush_handlers

unnamed-task: All tasks should be named
roles/core/firewall/tasks/RedHat.yml:22 Task/Handler: meta  flush_handlers

unnamed-task: All tasks should be named
roles/core/log_client/tasks/main.yml:75 Task/Handler: meta  flush_handlers

unnamed-task: All tasks should be named
roles/core/log_server/tasks/main.yml:121 Task/Handler: meta  flush_handlers

unnamed-task: All tasks should be named
roles/core/nfs_server/tasks/main.yml:59 Task/Handler: meta  flush_handlers

unnamed-task: All tasks should be named
roles/core/pxe_stack/tasks/main.yml:268 Task/Handler: meta  flush_handlers

unnamed-task: All tasks should be named
roles/core/time/tasks/main.yml:64 Task/Handler: meta  flush_handlers

You can skip specific rules or tags by adding them to your configuration file:
# .ansible-lint
warn_list:  # or 'skip_list' to silence them completely
  - unnamed-task  # All tasks should be named
Finished with 13 failure(s), 1 warning(s) on 341 files.
```

