### PR TITLE
ci: update ansible deps in tox

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-python@v1
 
       - name: Install packages
-        run: pip install 'ansible<3.0.0' ansible-lint flake8 yamllint
+        run: pip install ansible ansible-lint flake8 yamllint
 
       - name: Check python code
         run: flake8 . --statistics --ignore E501,E226

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,3}-ansible{28,29,210}
+envlist = py{27,3}-ansible{29,210,3}
 skipsdist = true
 
 [testenv]
@@ -11,9 +11,9 @@ passenv =
     PY_COLORS
     ANSIBLE_FORCE_COLOR
 deps =
-    ansible28: ansible==2.8
-    ansible29: ansible==2.9
-    ansible210: ansible==2.10
+    ansible29: ansible>=2.9.13,<2.10
+    ansible210: ansible>=2.10,<3.0
+    ansible3: ansible>=3.0
     ansible-lint
     flake8
     jmespath


### PR DESCRIPTION
The stack requires >= 2.9.13.
Don't test with ansible 2.8 anymore.
Run tests with ansible 2.9, 2.10 and 3.

Also revert ebfa28f7 since ansible-base 2.10.7 released yesterday with the fix for the FQCN `firewalld`.