### PR TITLE
fix: add nodeset filter in powerman

### DIFF
--- a/roles/core/powerman/filter_plugins/nodeset.py
+++ b/roles/core/powerman/filter_plugins/nodeset.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleFilterError
+from ClusterShell.NodeSet import NodeSet
+
+def nodeset(nodes_list):
+    '''Convert a list of nodes to ClusterShell's NodeSet'''
+    nodeset = NodeSet(",".join(nodes_list))
+    return nodeset
+
+class FilterModule(object):
+    ''' NodeSet Jinja2 filter. '''
+
+    def filters(self):
+        return {
+            'nodeset': nodeset,
+        }

--- a/roles/core/powerman/templates/powerman.conf.j2
+++ b/roles/core/powerman/templates/powerman.conf.j2
@@ -26,8 +26,8 @@ include "/etc/powerman/ipmipower.dev"
     {% endif %}
   {% endfor %}
   {% if hosts | length > 0 %}
-device "{{ equipment }}" "ipmipower" "/usr/sbin/ipmipower --wait-until-on --wait-until-off -h {{ bmcs|join(',') }} -u {{ hostvars[hosts[0]]['ep_equipment_authentication']['user'] }} -p {{ hostvars[hosts[0]]['ep_equipment_authentication']['password'] }} |&"
-node "{{ hosts|join(',') }}" "{{ equipment }}" "{{ bmcs|join(',') }}"
+device "{{ equipment }}" "ipmipower" "/usr/sbin/ipmipower --wait-until-on --wait-until-off -h {{ bmcs|nodeset }} -u {{ hostvars[hosts[0]]['ep_equipment_authentication']['user'] }} -p {{ hostvars[hosts[0]]['ep_equipment_authentication']['password'] }} |&"
+node "{{ hosts|nodeset }}" "{{ equipment }}" "{{ bmcs|nodeset }}"
   {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
Add a new plugin filter to transform a list of nodes to a nodeset. Use
this filter in the powerman template.