### PR TITLE
fix: use tag package for package tasks

### DIFF
--- a/roles/core/clustershell/tasks/main.yml
+++ b/roles/core/clustershell/tasks/main.yml
@@ -3,7 +3,7 @@
     name: clustershell
     state: present
   tags:
-    - always
+    - package
 
 - name: template █ Generate /etc/clustershell/groups.d/local.cfg
   template:

--- a/roles/core/lvm/tasks/main.yml
+++ b/roles/core/lvm/tasks/main.yml
@@ -5,7 +5,7 @@
     name: "{{ lvm_packages_to_install }}"
     state: present
   tags:
-    - always
+    - package
 
 - name: lvg █ Creating volume groups
   lvg:

--- a/roles/core/powerman/tasks/main.yml
+++ b/roles/core/powerman/tasks/main.yml
@@ -6,7 +6,7 @@
       - powerman
     state: present
   tags:
-    - always
+    - package
 
 - name: template █ Generate /etc/powerman/powerman.conf
   template:


### PR DESCRIPTION
Was mistakenly replaced by always during move of the roles from addons
to core.