### PR TITLE
feat: set sysconfig OPTIONS for chronyd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     - fix issues preventing access to nodes booting a livenet image (#525)
   - pxe_stack: fix issues with hostname not set during kickstart on RHEL 8.3 (#522)
   - set_hostname: add fqdn capability (#543)
+  - time: allow to set sysconfig OPTIONS for chronyd (#552)
 
 ### Breaking changes
 

--- a/roles/core/time/molecule/default/converge.yml
+++ b/roles/core/time/molecule/default/converge.yml
@@ -1,11 +1,9 @@
 ---
 - name: Converge
   hosts: all
-  serial: 3
+  serial: 4
 
   vars:
-    # Start the services by default
-    start_services: true
     enable_services: true
     icebergs_system: false
     networks:

--- a/roles/core/time/molecule/default/molecule.yml
+++ b/roles/core/time/molecule/default/molecule.yml
@@ -70,13 +70,24 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
+  - name: client-no-start
+    image: "quay.io/actatux/ansible-${MOLECULE_DISTRO:-centos:8}"
+    override_command: false
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
 provisioner:
   name: ansible
   inventory:
     group_vars:
       server:
+        start_services: true
+        time_chronyd_options: "-x"
         time_profile: server
       client:
+        start_services: true
+        time_chronyd_options: "-x"
         time_profile: client
     host_vars:
       server-ext-pool:
@@ -115,5 +126,9 @@ provisioner:
         j2_node_main_network: ice1-1
       client-multi-sources:
         j2_node_main_network: ice2-1
+      client-no-start:
+        j2_node_main_network: ice1-1
+        start_services: false
+        time_profile: client
 verifier:
   name: ansible

--- a/roles/core/time/molecule/default/verify.yml
+++ b/roles/core/time/molecule/default/verify.yml
@@ -41,6 +41,15 @@
       debug:
         msg: "{{ chrony_conf['content'] | b64decode }}"
 
+    - name: Read /etc/sysconfig/chronyd
+      slurp:
+        src: /etc/sysconfig/chronyd
+      register: sysconfig
+
+    - name: Display /etc/sysconfig/chronyd
+      debug:
+        msg: "{{ sysconfig['content'] | b64decode }}"
+
 - name: Verify client with single source server
   hosts:
     - client-single-source
@@ -126,3 +135,13 @@
       assert:
         that: chrony_conf['content'] | b64decode |
                 regex_findall(("^local stratum"), multiline=True)
+
+- name: Verify /etc/sysconfig/chronyd
+  hosts:
+    - server
+    - client
+  tasks:
+    - name: Check presence of -x flag in OPTIONS
+      assert:
+        that: sysconfig['content'] | b64decode |
+                regex_findall(("^OPTIONS=\"-x\"$"), multiline=True)

--- a/roles/core/time/readme.rst
+++ b/roles/core/time/readme.rst
@@ -64,6 +64,7 @@ Optional inventory vars:
 
 * external_time
 * external_pool
+* time_chronyd_options
 
 Output
 ^^^^^^
@@ -80,6 +81,7 @@ Icebergs with stratum levels.
 Changelog
 ^^^^^^^^^
 
+* 1.1.0: Set sysconfig OPTIONS for chronyd. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.4: Add iburst to allow faster boot time recovery, update macro. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.3: Update to new network_interfaces syntax. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.2: Clean. johnnykeats <johnny.keats@outlook.com>

--- a/roles/core/time/tasks/main.yml
+++ b/roles/core/time/tasks/main.yml
@@ -53,6 +53,16 @@
   tags:
     - template
 
+- name: lineinfile █ Set sysconfig OPTIONS for chronyd
+  lineinfile:
+    path: /etc/sysconfig/chronyd
+    regexp: '^OPTIONS'
+    line: OPTIONS="{{ time_chronyd_options }}"
+  notify: service █ Restart time services
+  when: time_chronyd_options is defined
+  tags:
+    - template
+
 - name: "timezone █ Set system to {{ time_zone }} timezone"
   timezone:
     name: "{{ time_zone }}"

--- a/roles/core/time/vars/main.yml
+++ b/roles/core/time/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-time_role_version: 1.0.4
+time_role_version: 1.1.0


### PR DESCRIPTION
Add a new inventory variable time_chronyd_options to configure the value
of OPTIONS in /etc/sysconfig/chronyd. For full list of options, see
chronyd(8).

With this change, it is now possible to disable the control of the
system clock when running chronyd in containers, which is especially
useful when running CI in rootless containers.

Test this new feature with all previously defined hosts in molecule.
Create a new host 'client-no-start' which does not change the
/etc/sysconfig/chronyd and does not start the chronyd service.

Bump role time's version to 1.1.0 and update changelogs.