### PR TITLE
time: just a cosmetic for the generation of chrony conf

### DIFF
--- a/roles/core/time/tasks/main.yml
+++ b/roles/core/time/tasks/main.yml
@@ -42,7 +42,7 @@
   tags:
     - package
 
-- name: template █ Generate /etc/chrony.conf
+- name: "template █ Generate {{ time_chrony_conf_path }}"
   template:
     src: chrony.conf.j2
     dest: "{{ time_chrony_conf_path }}"


### PR DESCRIPTION
Hello,

This is not a real bug but mostly cosmetic.

In the generation of the /etc/chrony.conf file, in the case of a chrony-server.conf file, you do not change the title of the display. As I had to debug this part I was "disturbed" with this not being modified on the fly.

I believe it should be easy to validate.