### PR TITLE
time: add feature to have additional networks allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - pxe_stack: fix issues with hostname not set during kickstart on RHEL 8.3 (#522)
   - set_hostname: add fqdn capability (#543)
   - time: allow to set sysconfig OPTIONS for chronyd (#552)
+  - time: allow to additional networks for server to reply (#555)
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   - pxe_stack: fix issues with hostname not set during kickstart on RHEL 8.3 (#522)
   - set_hostname: add fqdn capability (#543)
   - time: allow to set sysconfig OPTIONS for chronyd (#552)
-  - time: allow to additional networks for server to reply (#555)
+  - time: allow to add additional networks for server to reply (#555)
 
 ### Breaking changes
 

--- a/roles/core/time/readme.rst
+++ b/roles/core/time/readme.rst
@@ -65,6 +65,7 @@ Optional inventory vars:
 * external_time
 * external_pool
 * time_chronyd_options
+* time_additional_networks_allowed
 
 Output
 ^^^^^^

--- a/roles/core/time/templates/chrony.conf.j2
+++ b/roles/core/time/templates/chrony.conf.j2
@@ -57,7 +57,7 @@ rtcsync
 allow {{ networks[nic.network]['subnet'] }}/{{ networks[nic.network]['prefix'] }}
     {% endif %}
   {% endfor %}
-  {% if time_additional_networks_allowed is defined and time_additional_networks_allowed is not none %}
+  {% if time_additional_networks_allowed is defined and time_additional_networks_allowed is iterable %}
     {% for addons in time_additional_networks_allowed %}
 allow {{ addons }}
     {% endfor %}

--- a/roles/core/time/templates/chrony.conf.j2
+++ b/roles/core/time/templates/chrony.conf.j2
@@ -57,6 +57,11 @@ rtcsync
 allow {{ networks[nic.network]['subnet'] }}/{{ networks[nic.network]['prefix'] }}
     {% endif %}
   {% endfor %}
+  {% if time_additional_networks_allowed is defined and time_additional_networks_allowed is not none %}
+    {% for addons in time_additional_networks_allowed %}
+allow {{ addons }}
+    {% endfor %}
+  {% endif %}
 
 # Serve time even if not synchronized to a time source.
 # Fairly unreliable time source


### PR DESCRIPTION
Hello,

Here is a little patch I had to setup. Maybe this is not the best way to write it but it works. In my case, I had to add some routed networks to my chrony-server which were allowed to get access to the time service.
Before this patch, the networks were all extracted from the NIC interfaces but this was not enough.

This solves this issue: https://github.com/bluebanquise/bluebanquise/issues/553

