### PR TITLE
nic: add ipv6_disable capability

### DIFF
--- a/roles/core/nic/readme.rst
+++ b/roles/core/nic/readme.rst
@@ -131,6 +131,13 @@ To assign a network interface to a firewall zone:
       network: bb
       zone: external
 
+To disable IPv6 on NIC
+  network_interfaces:
+    - interface: ens5
+      ip4: 192.168.121.124
+      ipv6_disable: true
+      network: bb
+
 MTU and/or Gateway can be set in the network file, and will be applied to NIC
 linked to this network.
 

--- a/roles/core/nic/templates/ifcfg.j2
+++ b/roles/core/nic/templates/ifcfg.j2
@@ -89,3 +89,9 @@ MASTER={{ item.master }}
 {% if item.zone is defined and item.zone is not none %}
 ZONE={{ item.zone }}
 {% endif %}
+
+{# 9. Check if IPv6 has to be disabled #}
+{% if ipv6_disable is defined %}
+IPV6INIT=no
+IPV6_DISABLED=yes
+{% endif %}


### PR DESCRIPTION
Hello,

In the case you need to disable IPv6, the nic role is not yet capable to do this. I have written a small patch to add this feature.