### PR TITLE
Fix: kernel_config - Prevent crash if variable is None

### DIFF
--- a/roles/core/kernel_config/tasks/main.yml
+++ b/roles/core/kernel_config/tasks/main.yml
@@ -6,7 +6,9 @@
 - name: command █ Update kernel parameters
   command: "grubby --args='{{ item }}' --update-kernel=DEFAULT"
   loop: "{{ ep_kernel_parameters.split(' ') | default([]) }}"
-  when: item not in current_kernel_parameters.stdout
+  when:
+    - ep_kernel_parameters is defined and ep_kernel_parameters is not none
+    - item not in current_kernel_parameters.stdout
 
 - name: sysctl █ Update sysctl parameters
   sysctl:


### PR DESCRIPTION
Crash if variable is None. Small fix to prevent that.