### PR TITLE
advanced_dhcp_server: fix issue with added spaces linked to spaces in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - pxe_stack: fix issues with hostname not set during kickstart on RHEL 8.3 (#522)
   - set_hostname: add fqdn capability (#543)
   - time: allow to set sysconfig OPTIONS for chronyd (#552)
+  - dhcp: fix issue with added spaces. Could prevent DHCP to start (#561)
 
 ### Breaking changes
 

--- a/roles/advanced_core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
+++ b/roles/advanced_core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
@@ -16,7 +16,7 @@
 ###############################################################################}
 {% macro write_host(macro_host, macro_nic, macro_filename) %}
 
-{% if macro_nic.dhcp_pattern is defined and macro_nic.dhcp_pattern is not none %}
+{%- if macro_nic.dhcp_pattern is defined and macro_nic.dhcp_pattern is not none %}
 {{ patterns[macro_nic.dhcp_pattern](macro_host, macro_nic, macro_filename) }}
 {% else %}
   {% if macro_nic.mac is defined %}
@@ -76,7 +76,7 @@
   }
 
   {%- endif %}
-{% endif %}
+{%- endif %}
 {%- endmacro %}
 
 {###############################################################################
@@ -108,24 +108,24 @@
   {% set current_hostvars = hostvars[host] %}{# buffer #}
   {% if current_hostvars['network_interfaces'] is defined and current_hostvars['network_interfaces'] is iterable %}
     {#- Define iPXE rom to use #}
-    {% if current_hostvars['ep_ipxe_driver'] == 'snponly' %} {# Select driver first #}
+    {% if current_hostvars['ep_ipxe_driver'] == 'snponly' %}{# Select driver first #}
       {% set ipxe_driver = 'snponly_' %}
     {% elif current_hostvars['ep_ipxe_driver'] == 'snp' %}
       {% set ipxe_driver = 'snp_' %}
     {% else %}{# Assume everything else is default driver #}
       {% set ipxe_driver = '' %}
     {% endif %}
-    {% if current_hostvars['ep_hardware']['cpu']['architecture'] == 'arm64' %} {# Now select architecture #}
+    {% if current_hostvars['ep_hardware']['cpu']['architecture'] == 'arm64' %}{# Now select architecture #}
       {% set ipxe_architecture = 'arm64' %}
     {% else %}{# Assume everything else is x86_64 #}
       {% set ipxe_architecture = 'x86_64' %}
     {% endif %}
-    {% if current_hostvars['ep_ipxe_embed'] == 'dhcpretry' %} {# Now select embed script #}
+    {% if current_hostvars['ep_ipxe_embed'] == 'dhcpretry' %}{# Now select embed script #}
       {% set ipxe_embed = 'dhcpretry' %}
     {% else %}
       {% set ipxe_embed = 'standard' %}
     {% endif %}
-    {% if current_hostvars['ep_ipxe_platform'] == 'efi' %} {# Finally, build file name depending of platform and previous parameters #}
+    {% if current_hostvars['ep_ipxe_platform'] == 'efi' %}{# Finally, build file name depending of platform and previous parameters #}
       {% set ipxe_rom_filename = (ipxe_architecture + '/' + ipxe_embed + '_' + ipxe_driver + 'ipxe.efi') %}
     {% else %}{# Assume everything else is pcbios #}
       {% set ipxe_rom_filename = (ipxe_architecture + '/' + ipxe_embed + '_undionly.kpxe') %}
@@ -134,7 +134,7 @@
     {%- for nic in current_hostvars['network_interfaces'] %}
       {% if (nic.network is defined and nic.network == item) and nic.ip4 is defined %}
 {{ write_host(host, nic, ipxe_rom_filename) }}
-      {% endif %}
+      {%- endif %}
     {% endfor -%}
 
     {%- if current_hostvars['bmc'] is defined %}


### PR DESCRIPTION
Hello,

In the extract of ```dhcpd.subnet.conf.j2``` in a configuration containing more than 2000 nodes, the previous version lead to a file where there was a line containing the number of nodes spaces. In this case DHCP does not want to start!

The fix only consists in removing all white spaces between comments and loop/tests sections.

I have also added a small fix removing a double blank line added while running the extract:
```diff
@@ -16,7 +16,7 @@
 ###############################################################################}
 {% macro write_host(macro_host, macro_nic, macro_filename) %}

-{% if macro_nic.dhcp_pattern is defined and macro_nic.dhcp_pattern is not none %}
+{%- if macro_nic.dhcp_pattern is defined and macro_nic.dhcp_pattern is not none %}
 {{ patterns[macro_nic.dhcp_pattern](macro_host, macro_nic, macro_filename) }}
 {% else %}
   {% if macro_nic.mac is defined %}
@@ -76,7 +76,7 @@
   }

   {%- endif %}
-{% endif %}
+{%- endif %}
 {%- endmacro %}
```

This is major issue for configuration where DHCP cannot start.