### PR TITLE
Docs: diskless - firewall doesn't work in chroot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   - diskless:
     - fix issues with dnf command in the livenet module (#528)
     - fix issues preventing access to nodes booting a livenet image (#525)
-    - notify in readme/page that firewall does not work in chroot (#?)
+    - notify in readme/page that firewall does not work in chroot (#569)
   - kernel_config: prevent crash if variable ep_kernel_parameters is undefined (#559)
   - pxe_stack: fix issues with hostname not set during kickstart on RHEL 8.3 (#522)
   - set_hostname: add fqdn capability (#543)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - diskless:
     - fix issues with dnf command in the livenet module (#528)
     - fix issues preventing access to nodes booting a livenet image (#525)
+    - notify in readme/page that firewall does not work in chroot (#?)
   - kernel_config: prevent crash if variable ep_kernel_parameters is undefined (#559)
   - pxe_stack: fix issues with hostname not set during kickstart on RHEL 8.3 (#522)
   - set_hostname: add fqdn capability (#543)

--- a/roles/core/diskless/readme.rst
+++ b/roles/core/diskless/readme.rst
@@ -406,7 +406,7 @@ Notes:
 * The multiple `-i` defines Ansible inventories to gather. By default, in BlueBanquise, the first two inventories are used. We simply add the third one, corresponding to the mounting point.
 * The `-e` (extra vars) are here to specify to the stack which iceberg and main network are to be used in the configuration of the node. (System cannot know on which nodes the image will be used).
 * The `--skip-tags identify` prevents hostname and static ip to be set, since the image should be generic for multiple hosts.
-* Firewall does not work properly in a chroot environment, so the variable **ep_firewall** should be set to **false**. If there are firewall related changes to be applied, change the variable and run the playbook with the image booted.
+* Firewall does not work properly in a chroot environment. Variable ep_firewall must be set to false when executing playbook in the chrooted image. If there are firewall related changes to be applied on the image, execute playbook with ep_firewall set to false in the playbook (but keep it true in the inventory) in the chrooted image. Once node is booted in diskless, execute again the playbook with ep_firewall to true (note: you can focus on firewall tasks only at this point using the firewall tag).
 
 Before closing, also remember to clean dnf cache into the image chroot to save space.
 

--- a/roles/core/diskless/readme.rst
+++ b/roles/core/diskless/readme.rst
@@ -371,6 +371,7 @@ with the following head:
       j2_node_main_network: ice1-1                #<<< UPDATE
       start_service: false
       image_equipment_profile: equipment_typeC    #<<< UPDATE
+      ep_firewall: false
   
     pre_tasks:
       - name: Add current host to defined equipment_profile
@@ -405,7 +406,7 @@ Notes:
 * The multiple `-i` defines Ansible inventories to gather. By default, in BlueBanquise, the first two inventories are used. We simply add the third one, corresponding to the mounting point.
 * The `-e` (extra vars) are here to specify to the stack which iceberg and main network are to be used in the configuration of the node. (System cannot know on which nodes the image will be used).
 * The `--skip-tags identify` prevents hostname and static ip to be set, since the image should be generic for multiple hosts.
-* By default, diskless images have the firewalld service enabled. Adding the **firewall** BlueBanquise role to this customization playbook will manage the firewalld service per the **ep_firewall** variable in the chosen **image_equipment_profile** (e.g. the default equipment_typeC profile will disable the firewalld service in the diskless image).
+* Firewall does not work properly in a chroot environment, so the variable **ep_firewall** should be set to **false**. If there are firewall related changes to be applied, change the variable and run the playbook with the image booted.
 
 Before closing, also remember to clean dnf cache into the image chroot to save space.
 


### PR DESCRIPTION
When customizing and image with disklessset tool, firewalld fails to start in the chroot environment.