### PR TITLE
backport/tools/1.0/PR#2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Major changes
 
+#### Backports
+
+  - Update initramfs in image_data and regenerate boot.ipxe when changing kernel (#571)
+
 #### New roles
 
   - addons/kernel_config: set or update kernel parameters and sysctl (#481)

--- a/roles/addons/diskless/files/kernel_manager.py
+++ b/roles/addons/diskless/files/kernel_manager.py
@@ -77,6 +77,10 @@ class KernelManager:
 
         # Use image method to set kernel
         image.kernel = kernel
+        # Update initramfs for selected kernel
+        image.image = 'initramfs-kernel-' + kernel.replace('vmlinuz-', '')
+        # Regenarate ipxe boot for the image
+        image.generate_ipxe_boot_file()
         # Register image with new kernel
         image.register_image()
 


### PR DESCRIPTION
Backport: disklessset - regenerate boot.ipxe when changing kernel

PR made against new branch 1.4.1 because changed code was moved to Tools project.