### PR TITLE
Fix: disklessset - string used as a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 #### Backports
 
+  - Fixed wrong variable type usage (#)
   - Added kernel-modules package to the standard livenet image type (#572)
   - Update initramfs in image_data and regenerate boot.ipxe when changing kernel (#571)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 #### Backports
 
-  - Fixed wrong variable type usage (#)
+  - Fixed wrong variable type usage (#577)
   - Added kernel-modules package to the standard livenet image type (#572)
   - Update initramfs in image_data and regenerate boot.ipxe when changing kernel (#571)
 

--- a/roles/addons/diskless/files/livenet_module.py
+++ b/roles/addons/diskless/files/livenet_module.py
@@ -155,7 +155,7 @@ class LivenetImage(Image):
         # Get appropriate packages for desired image file system
         if self.livenet_type == LivenetImage.Type.STANDARD:
             logging.debug('Standard image requested. Adding "@core kernel-modules" to packages list')
-            dnf_packages_list.append('@core kernel-modules')
+            dnf_packages = '@core kernel-modules'
         elif self.livenet_type == LivenetImage.Type.SMALL:
             logging.debug('Small image requested. Adding "dnf yum iproute procps-ng openssh-server NetworkManager" to packages list')
             dnf_packages = 'dnf yum iproute procps-ng openssh-server NetworkManager'


### PR DESCRIPTION
Hotfix: Somehow in the backport a string was treated as a list. This is a fatal error.