### PR TITLE
Fix: nfs_server - exprt name consistency in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Roles improvement or fix
 
+  - fix: nfs_export naming consistency between readme/tests/inventory (#578)
   - all: add compatibility with multiple RHEL like distributions (#560)
   - diskless:
     - fix issues with dnf command in the livenet module (#528)

--- a/roles/core/nfs_server/readme.rst
+++ b/roles/core/nfs_server/readme.rst
@@ -14,9 +14,9 @@ All configuration is done in *group_vars/all/general_settings/nfs.yml*:
 .. code-block:: yaml
 
   nfs:
-    softwares:                                    # Internal name of the nfs share
-      mount: /opt/softwares                       # What path server should export
-      export: /opt/softwares                      # Which path clients should mount this NFS (will be automatically created by client role)
+    software:                                     # Internal name of the nfs share
+      mount: /opt/software                        # What path server should export
+      export: /opt/software                       # Which path clients should mount this NFS (will be automatically created by client role)
       server: arngrim                             # The server that export this storage space
       clients_groups:                             # Group of hosts that will mount it. Can be an equipment group, or a main group (mg), or any other ansible group
         - mg_computes


### PR DESCRIPTION
The export /opt/software is used in mollecule tests and is also defined in resources/examples/simple_cluster/inventory/group_vars/all/general_settings/nfs.yml.

Change the nfs_server role readme to match that.