### PR TITLE
Backport/1.4.1/551 (conman: add conman user the authorization to write into /var/run/conman)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   - Added kernel-modules package to the standard livenet image type (#572)
   - Update initramfs in image_data and regenerate boot.ipxe when changing kernel (#571)
   - Notify in readme/page that firewall does not work in chroot (#575 (#569))
+  - conman: add conman user the authorization to write into /var/run/conman (#551)
 
 #### New roles
 

--- a/roles/core/conman/tasks/main.yml
+++ b/roles/core/conman/tasks/main.yml
@@ -36,6 +36,16 @@
     state: present
     system: yes
 
+- name: user █ Ensure user conman can use /var/run/conman
+  copy:
+    content: |
+      D /var/run/conman 0700 conman conman -
+    dest: /etc/tmpfiles.d/conman.conf
+    mode: 0644
+  notify: systemd █ Reload systemd configuration
+  when:
+    - ansible_facts.os_family == "RedHat"
+
 - name: user █ Ensure user conman exists
   user:
     name: conman


### PR DESCRIPTION
This is  a backport of #551 for 1.4.1 release.