### PR TITLE
Fix: pxe_stack - Force substitution from file to symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 #### Roles improvement or fix
 
+  - pxe_stack: force substitution of files by symlinks in case of an update (#587)
   - all: add compatibility with multiple RHEL like distributions (#560)
   - diskless:
     - fix issues with dnf command in the livenet module (#528)

--- a/roles/core/pxe_stack/tasks/main.yml
+++ b/roles/core/pxe_stack/tasks/main.yml
@@ -134,6 +134,7 @@
     owner: "{{ pxe_stack_apache_user }}"
     group: "{{ pxe_stack_apache_user }}"
     state: link
+    force: yes
   loop: "{{ pxe_stack_supported_os.redhat | subelements('distributions') }}"
   when: item.1 != 'redhat'
 


### PR DESCRIPTION
In the upgrade from BB v1.4 to v1.5, some files became links. Without the "force" attribute, Ansible refuses to do the replacement.

```
TASK [pxe_stack : file █ Generate links for all supported OS] ****************************************************************************************************************************************
Thursday 05 August 2021  16:10:34 -0300 (0:00:27.997)       0:01:47.544 *******
skipping: [mngt0-1] => (item=[{'major': 7, 'distributions': ['redhat', 'centos']}, 'redhat'])
failed: [mngt0-1] (item=[{'major': 7, 'distributions': ['redhat', 'centos']}, 'centos']) => changed=false
  ansible_loop_var: item
  gid: 48
  group: apache
  item:
  - distributions:
    - redhat
    - centos
    major: 7
  - centos
  mode: '0644'
  msg: refusing to convert from file to symlink for /var/www/html/preboot_execution_environment/osdeploy/centos_7.ipxe
  owner: apache
  path: /var/www/html/preboot_execution_environment/osdeploy/centos_7.ipxe
  secontext: unconfined_u:object_r:httpd_sys_content_t:s0
  size: 1367
  state: file
  uid: 48
skipping: [mngt0-1] => (item=[{'major': 8, 'distributions': ['redhat', 'centos', 'cloudlinux', 'oraclelinux', 'almalinux', 'rocky']}, 'redhat'])
failed: [mngt0-1] (item=[{'major': 8, 'distributions': ['redhat', 'centos', 'cloudlinux', 'oraclelinux', 'almalinux', 'rocky']}, 'centos']) => changed=false
  ansible_loop_var: item
  gid: 48
  group: apache
  item:
  - distributions:
    - redhat
    - centos
    - cloudlinux
    - oraclelinux
    - almalinux
    - rocky
    major: 8
  - centos
  mode: '0644'
  msg: refusing to convert from file to symlink for /var/www/html/preboot_execution_environment/osdeploy/centos_8.ipxe
  owner: apache
  path: /var/www/html/preboot_execution_environment/osdeploy/centos_8.ipxe
  secontext: unconfined_u:object_r:httpd_sys_content_t:s0
  size: 1374
  state: file
  uid: 48
```