### PR TITLE
Fix: diskless - Correct python path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     - fix issues with dnf command in the livenet module (#528)
     - fix issues preventing access to nodes booting a livenet image (#525)
     - notify in readme/page that firewall does not work in chroot (#569)
+    - fix python path of diskless files (#590)
   - kernel_config: prevent crash if variable ep_kernel_parameters is undefined (#559)
   - nic_nmcli:
     - add dns4 and dns4_search vars logic (#585)

--- a/roles/core/diskless/tasks/main.yml
+++ b/roles/core/diskless/tasks/main.yml
@@ -36,8 +36,8 @@
     - /diskless/images/nfsimages/golden
     - /diskless/images/nfsimages/staging
     # Create directories for python modules
-    - /lib/{{ diskless_python_version }}/site-packages/diskless
-    - /lib/{{ diskless_python_version }}/site-packages/diskless/modules
+    - /lib/python{{ diskless_python_version }}/site-packages/diskless
+    - /lib/python{{ diskless_python_version }}/site-packages/diskless/modules
     # Create directory for 'installations.yml' file
     - /var/lib/diskless
     # Create working directory for images
@@ -52,13 +52,13 @@
     dest: "{{ item.dest }}"
     mode: 0755
   with_items:
-    - { src: 'utils.py', dest: '/lib/{{ diskless_python_version }}/site-packages/diskless/utils.py' }
-    - { src: 'image_manager.py', dest: '/lib/{{ diskless_python_version }}/site-packages/diskless/image_manager.py' }
-    - { src: 'kernel_manager.py', dest: '/lib/{{ diskless_python_version }}/site-packages/diskless/kernel_manager.py' }
-    - { src: 'nfs_module.py', dest: '/lib/{{ diskless_python_version }}/site-packages/diskless/modules/nfs_module.py' }
-    - { src: 'base_module.py', dest: '/lib/{{ diskless_python_version }}/site-packages/diskless/modules/base_module.py' }
-    - { src: 'livenet_module.py', dest: '/lib/{{ diskless_python_version }}/site-packages/diskless/modules/livenet_module.py' }
-    - { src: 'demo_module.py', dest: '/lib/{{ diskless_python_version }}/site-packages/diskless/modules/demo_module.py' }
+    - { src: 'utils.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/utils.py' }
+    - { src: 'image_manager.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/image_manager.py' }
+    - { src: 'kernel_manager.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/kernel_manager.py' }
+    - { src: 'nfs_module.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/modules/nfs_module.py' }
+    - { src: 'base_module.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/modules/base_module.py' }
+    - { src: 'livenet_module.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/modules/livenet_module.py' }
+    - { src: 'demo_module.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/modules/demo_module.py' }
     - { src: 'disklessset.py', dest: '/usr/bin/disklessset' }
 
 - name: template █ Generate /etc/disklessset/diskless_parameters.yml


### PR DESCRIPTION
The path for diskless files was incorrect, for example:

```
    - /lib/{{ diskless_python_version }}/site-packages/diskless
```

with diskless_python_version being "3.6" (RedHat 8) or "3.9" (RedHat 9). The path should be "python3.6" or "python3.9":

```
    - /lib/python{{ diskless_python_version }}/site-packages/diskless
```