### PR TITLE
Fix for dns_server role for issue 608

### DIFF
--- a/roles/core/dns_server/readme.rst
+++ b/roles/core/dns_server/readme.rst
@@ -48,6 +48,17 @@ a relay.
     dns_server:  <<<<<<<<<<
       - 208.67.222.222
 
+To optionally override the IP addresses returned by certain host you define *group_vars/all/general_settings/dns_override.yml with the following content for example:
+
+.. code-block:: yaml
+
+  dns_overrides:
+    0.uk.pool.ntp.org: 10.11.0.1
+
+In this example, DNS look-ups for *0.uk.pool.ntp.org* will return *10.11.0.1*.
+
+This will cause */var/named/override* to be generated.
+
 Input
 ^^^^^
 
@@ -83,6 +94,8 @@ Optional inventory vars:
    * .mac
    * .name
 
+* dns_overrides
+
 Output
 ^^^^^^
 
@@ -96,11 +109,13 @@ Files generated:
 * /var/named/forward
 * /var/named/reverse
 * /var/named/forward.soa
+* /var/named/override
 * /var/named/reverse.soa
 
 Changelog
 ^^^^^^^^^
 
+* 1.1.0: Change role to use new layout and override feature for issue #608. Neil Munday <neil@mundayweb.com>
 * 1.0.2: Improve role performances. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.1: Added SOA. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/core/dns_server/tasks/RedHat/firewall.yml
+++ b/roles/core/dns_server/tasks/RedHat/firewall.yml
@@ -1,0 +1,14 @@
+---
+
+- name: firewalld █ "Add services to firewall's {{ dns_server_firewall_zone | default('public') }} zone"
+  firewalld:
+    zone: "{{ dns_server_firewall_zone | default('public') }}"
+    service: "{{ item }}"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ep_firewall | default(false) | bool
+  loop: "{{ dns_server_firewall_services_to_add }}"
+  tags:
+    - firewall

--- a/roles/core/dns_server/tasks/main.yml
+++ b/roles/core/dns_server/tasks/main.yml
@@ -24,7 +24,7 @@
     - always
 
 - name: "include_tasks ░ Use OS dedicated firewall task"
-  include_tasks: "{{ item }}"
+  include_tasks: "{{ outer_item }}"
   with_first_found:
     - files:
         - "{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_version }}/firewall.yml"
@@ -34,6 +34,8 @@
         - "{{ ansible_facts.distribution | replace(' ','_') }}/firewall.yml"
         - "{{ ansible_facts.os_family | replace(' ','_') }}/firewall.yml"
       skip: true
+  loop_control:
+    loop_var: outer_item
   tags:
     - internal
     - firewall

--- a/roles/core/dns_server/tasks/main.yml
+++ b/roles/core/dns_server/tasks/main.yml
@@ -13,7 +13,9 @@
   include_vars: "{{ item }}"
   with_first_found:
     - files:
+        - "vars/{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_version }}.yml"
         - "vars/{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_major_version }}.yml"
+        - "vars/{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_version }}.yml"
         - "vars/{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version }}.yml"
         - "vars/{{ ansible_facts.distribution | replace(' ','_') }}.yml"
         - "vars/{{ ansible_facts.os_family }}.yml"
@@ -21,18 +23,19 @@
   tags:
     - always
 
-- name: firewalld █ "Add services to firewall's {{ dns_server_firewall_zone | default('public') }} zone"
-  firewalld:
-    zone: "{{ dns_server_firewall_zone | default('public') }}"
-    service: "{{ item }}"
-    immediate: "yes"
-    permanent: "yes"
-    state: enabled
-  when:
-    - ansible_facts.os_family == "RedHat"
-    - ep_firewall | default(false) | bool
-  loop: "{{ dns_server_firewall_services_to_add }}"
+- name: "include_tasks ░ Use OS dedicated firewall task"
+  include_tasks: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_version }}/firewall.yml"
+        - "{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_major_version }}/firewall.yml"
+        - "{{ ansible_facts.os_family | replace(' ','_') }}_{{ ansible_facts.distribution_version }}/firewall.yml"
+        - "{{ ansible_facts.os_family | replace(' ','_') }}_{{ ansible_facts.distribution_major_version }}/firewall.yml"
+        - "{{ ansible_facts.distribution | replace(' ','_') }}/firewall.yml"
+        - "{{ ansible_facts.os_family | replace(' ','_') }}/firewall.yml"
+      skip: true
   tags:
+    - internal
     - firewall
 
 - name: "package █ Install {{ dns_server_packages_to_install | join(' ') }} packages"
@@ -109,6 +112,18 @@
     mode: 0644
   notify: service █ Restart dns services
   when: zoneconf.changed  # noqa 503
+  tags:
+    - template
+
+- name: template █ Generate override file
+  template:
+    src: override.j2
+    dest: /var/named/override
+    owner: root
+    group: root
+    mode: 0644
+  notify: service █ Restart dns services
+  when: dns_overrides is defined and  zoneconf.changed  # noqa 503
   tags:
     - template
 

--- a/roles/core/dns_server/templates/named.conf.j2
+++ b/roles/core/dns_server/templates/named.conf.j2
@@ -50,6 +50,10 @@ options {
 
   pid-file "/run/named/named.pid";
   session-keyfile "/run/named/session.key";
+
+{% if dns_overrides is defined %}
+  response-policy { zone "override"; };
+{% endif %}
 };
 
 logging {
@@ -75,6 +79,13 @@ zone "in-addr.arpa" IN {
   file "reverse";
   allow-update { none; };
 };
+
+{% if dns_overrides is defined %}
+zone "override" {
+  type master;
+  file "override";
+};
+{% endif %}
 
 include "/etc/named.rfc1912.zones";
 include "/etc/named.root.key";

--- a/roles/core/dns_server/templates/override.j2
+++ b/roles/core/dns_server/templates/override.j2
@@ -1,0 +1,17 @@
+$TTL 60
+@            IN    SOA  localhost. root.localhost.  (
+                          {{ serial }} ; serial
+                          1h           ; refresh
+                          30m          ; retry
+                          1w           ; expiry
+                          30m)         ; minimum
+                   IN     NS    localhost.
+
+localhost       A   127.0.0.1
+
+{% if dns_overrides is defined %}
+{% for site, ip in dns_overrides.items() %}
+{{ site }}    A        {{ ip }}
+{% endfor %}
+{% endif %}
+


### PR DESCRIPTION
This commit adds the ability to optionally define overrides for domain names to IPs. See the readme for the role for further details in the associated commits.