### PR TITLE
Re-worked reverse zone file generation for dns_role to fix issue #614

### DIFF
--- a/roles/core/dns_server/molecule/default/verify.yml
+++ b/roles/core/dns_server/molecule/default/verify.yml
@@ -10,7 +10,7 @@
       with_items:
         - /etc/named.conf
         - /var/named/forward.zone
-        - /var/named/reverse
+        - /var/named/ice1-1.rr.zone
 
     - name: assert files exist
       assert:

--- a/roles/core/dns_server/molecule/default/verify.yml
+++ b/roles/core/dns_server/molecule/default/verify.yml
@@ -9,7 +9,7 @@
       register: stat_results
       with_items:
         - /etc/named.conf
-        - /var/named/forward
+        - /var/named/forward.zone
         - /var/named/reverse
 
     - name: assert files exist

--- a/roles/core/dns_server/readme.rst
+++ b/roles/core/dns_server/readme.rst
@@ -115,6 +115,7 @@ Files generated:
 Changelog
 ^^^^^^^^^
 
+* 1.3.2: Re-worked reverse zone generation to fix issue #614. Neil Munday <neil@mundayweb.com>
 * 1.3.1: Adapt role to handle multiple distributions. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.3.0: Change role to use new layout and override feature for issue #608. Neil Munday <neil@mundayweb.com>
 * 1.2.0: Add Ubuntu support. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/core/dns_server/tasks/main.yml
+++ b/roles/core/dns_server/tasks/main.yml
@@ -64,10 +64,10 @@
   tags:
     - template
 
-- name: template █ Generate Forward zone file on Master DNS /var/named/forward
+- name: template █ Generate Forward zone file on Master DNS /var/named/forward.zone
   template:
     src: forward.j2
-    dest: /var/named/forward
+    dest: /var/named/forward.zone
     owner: root
     group: root
     mode: 0644
@@ -95,32 +95,35 @@
   tags:
     - template
 
-- name: template █ Generate Reverse zone file on Master DNS /var/named/reverse
+- name: "template █ Generate Reverse zone files for each network: /var/named/{{ item }}.rr.zone"
   template:
     src: reverse.j2
-    dest: /var/named/reverse
+    dest: "/var/named/{{ item }}.rr.zone"
     owner: root
     group: root
     mode: 0644
+  with_items: "{{ networks }}"
+  when: networks[item].is_in_dns
   tags:
     - template
 
-- name: template █ Generate SOA for reverse zone file /var/named/reverse.soa
+- name: "template █ Generate SOA for reverse zone files for each network: /var/named/{{ item }}.rr.soa"
   template:
     src: reverse.soa.j2
-    dest: /var/named/reverse.soa
+    dest: "/var/named/{{ item }}.rr.soa"
     owner: root
     group: root
     mode: 0644
   notify: service █ Restart dns services
-  when: zoneconf.changed  # noqa 503
+  with_items: "{{ networks }}"
+  when: zoneconf.changed and networks[item].is_in_dns  # noqa 503
   tags:
     - template
 
-- name: template █ Generate override file
+- name: "template █ Generate override zone file: /var/named/override.zone"
   template:
     src: override.j2
-    dest: /var/named/override
+    dest: /var/named/override.zone
     owner: root
     group: root
     mode: 0644

--- a/roles/core/dns_server/templates/named.conf.j2
+++ b/roles/core/dns_server/templates/named.conf.j2
@@ -83,17 +83,17 @@ zone "{{ octets }}.in-addr.arpa" IN {
 {%- endmacro %}
 
 {% for network, props in networks.items() %}
-{% if props['is_in_dns'] %}
-{% if props['prefix'] <= 8 %}
+  {% if props['is_in_dns'] %}
+    {% if props['prefix'] <= 8 %}
 {{ create_reverse_zone(network, props['subnet'].split('.')[0]) }}
-{% elif props['prefix'] <= 16 %}
+    {% elif props['prefix'] <= 16 %}
 {{ create_reverse_zone(network, props['subnet'].split('.')[0:2]|reverse|join('.')) }}
-{% elif props['prefix'] <= 24 %}
+    {% elif props['prefix'] <= 24 %}
 {{ create_reverse_zone(network, props['subnet'].split('.')[0:3]|reverse|join('.')) }}
-{% elif props['prefix'] < 32 %}
+    {% elif props['prefix'] < 32 %}
 {{ create_reverse_zone(network, props['subnet'].split('.')[0:4]|reverse|join('.')) }}
-{% endif %}
-{% endif %}
+    {% endif %}
+  {% endif %}
 {% endfor %}
 
 {% if dns_overrides is defined %}

--- a/roles/core/dns_server/templates/named.conf.j2
+++ b/roles/core/dns_server/templates/named.conf.j2
@@ -88,10 +88,8 @@ zone "{{ octets }}.in-addr.arpa" IN {
 {{ create_reverse_zone(network, props['subnet'].split('.')[0]) }}
     {% elif props['prefix'] <= 16 %}
 {{ create_reverse_zone(network, props['subnet'].split('.')[0:2]|reverse|join('.')) }}
-    {% elif props['prefix'] <= 24 %}
+    {% elif props['prefix'] <= 31 %}
 {{ create_reverse_zone(network, props['subnet'].split('.')[0:3]|reverse|join('.')) }}
-    {% elif props['prefix'] < 32 %}
-{{ create_reverse_zone(network, props['subnet'].split('.')[0:4]|reverse|join('.')) }}
     {% endif %}
   {% endif %}
 {% endfor %}

--- a/roles/core/dns_server/templates/named.conf.j2
+++ b/roles/core/dns_server/templates/named.conf.j2
@@ -70,20 +70,36 @@ zone "." IN {
 
 zone "{{ domain_name }}" IN {
   type master;
-  file "forward";
+  file "forward.zone";
   allow-update { none; };
 };
 
-zone "in-addr.arpa" IN {
-  type master;
-  file "reverse";
-  allow-update { none; };
+{% macro create_reverse_zone(network, octets) -%}
+zone "{{ octets }}.in-addr.arpa" IN {
+   type master;
+   file "{{ network }}.rr.zone";
+   allow-update { none; };
 };
+{%- endmacro %}
+
+{% for network, props in networks.items() %}
+{% if props['is_in_dns'] %}
+{% if props['prefix'] <= 8 %}
+{{ create_reverse_zone(network, props['subnet'].split('.')[0]) }}
+{% elif props['prefix'] <= 16 %}
+{{ create_reverse_zone(network, props['subnet'].split('.')[0:2]|reverse|join('.')) }}
+{% elif props['prefix'] <= 24 %}
+{{ create_reverse_zone(network, props['subnet'].split('.')[0:3]|reverse|join('.')) }}
+{% elif props['prefix'] < 32 %}
+{{ create_reverse_zone(network, props['subnet'].split('.')[0:4]|reverse|join('.')) }}
+{% endif %}
+{% endif %}
+{% endfor %}
 
 {% if dns_overrides is defined %}
 zone "override" {
   type master;
-  file "override";
+  file "override.zone";
 };
 {% endif %}
 

--- a/roles/core/dns_server/templates/reverse.j2
+++ b/roles/core/dns_server/templates/reverse.j2
@@ -23,19 +23,20 @@ $INCLUDE "{{ item }}.rr.soa"
   {% endif %}
 {%- endmacro %}
 
-{% for host in groups['all'] %}
-  {% if hostvars[host]['network_interfaces'] is defined and hostvars[host]['network_interfaces'] is iterable %}
-    {% for nic in hostvars[host]['network_interfaces'] %}
+{# Macro to write host in file #}
+{% macro write_host(host,host_dict,host_node_main_resolution_network) %}
+  {% if host_dict['network_interfaces'] is defined and host_dict['network_interfaces'] is iterable %}
+    {% for nic in host_dict['network_interfaces'] %}
       {% if nic.network is defined and nic.network == item and nic.ip4 is defined and nic.ip4 is not none and networks[item].prefix is defined %}
 {{ create_record(get_host_octets(nic.ip4, networks[item].prefix)|trim, [[host, item]|join('-'), domain_name]|join('.')) }}
-        {% if item == hostvars[host]['j2_node_main_resolution_network'] %}
+        {% if item == host_node_main_resolution_network %}
 {{ create_record(get_host_octets(nic.ip4, networks[item].prefix)|trim, [host, domain_name]|join('.')) }}
         {% endif %}
-        {% if hostvars[host].bmc is defined %}
-          {% set bmc_args = hostvars[host]['bmc'] %}
+        {% if host_dict['bmc'] is defined %}
+          {% set bmc_args = host_dict['bmc'] %}
           {% if bmc_args.name is defined and bmc_args.name is not none and bmc_args.ip4 is defined and bmc_args.ip4 is not none and bmc_args.network is defined and bmc_args.network is not none and bmc_args.network == item %}
 {{ create_record(get_host_octets(bmc_args.ip4, networks[bmc_args.network].prefix)|trim, [[bmc_args.name, bmc_args.network]|join('-'), domain_name]|join('.')) }}
-            {% if item == hostvars[host]['j2_node_main_resolution_network'] %}
+            {% if item == host_node_main_resolution_network %}
 {{ create_record(get_host_octets(bmc_args.ip4, networks[bmc_args.network].prefix)|trim, [bmc_args.name, domain_name]|join('.')) }}
             {% endif %}
           {% endif %}
@@ -43,4 +44,8 @@ $INCLUDE "{{ item }}.rr.soa"
       {% endif %}
     {% endfor %}
   {% endif %}
-{% endfor %}
+{% endmacro -%}
+
+{% for host in groups['all'] -%}
+{{ write_host(host,hostvars[host],hostvars[host]['j2_node_main_resolution_network']) }}
+{%- endfor %}

--- a/roles/core/dns_server/templates/reverse.j2
+++ b/roles/core/dns_server/templates/reverse.j2
@@ -1,37 +1,46 @@
 #jinja2: lstrip_blocks: True
 ;#### Blue Banquise file ####
-;## {{ ansible_managed }}
+;## {{ ansible_managed }} 
 
 $TTL 86400
-$ORIGIN in-addr.arpa.
-$INCLUDE "/var/named/reverse.soa"
+$ORIGIN {{ j2_dns_server_get_network | trim }}.in-addr.arpa.
+$INCLUDE "{{ item }}.rr.soa"
 @ IN NS {{ inventory_hostname }}.{{ domain_name }}.
 
-{# Macro to write host in file #}
-{% macro write_host(host,host_dict,host_node_main_resolution_network) %}
-  {% if host_dict['network_interfaces'] is defined and host_dict['network_interfaces'] is iterable %}
-    {% for nic in host_dict['network_interfaces'] %}
-      {% if nic.ip4 is defined and nic.ip4 is not none %}
-        {% if nic.network is defined and nic.network == host_node_main_resolution_network %}
-{{ nic.ip4.split('.')[3] }}.{{ nic.ip4.split('.')[2] }}.{{ nic.ip4.split('.')[1] }}.{{ nic.ip4.split('.')[0] }} IN PTR {{ host }}.{{ domain_name }}.
-{{ nic.ip4.split('.')[3] }}.{{ nic.ip4.split('.')[2] }}.{{ nic.ip4.split('.')[1] }}.{{ nic.ip4.split('.')[0] }} IN PTR {{ host }}-{{ nic.network }}.{{ domain_name }}.
-        {% elif nic.network is defined and nic.network is not none %}
-{{ nic.ip4.split('.')[3] }}.{{ nic.ip4.split('.')[2] }}.{{ nic.ip4.split('.')[1] }}.{{ nic.ip4.split('.')[0] }} IN PTR {{ host }}-{{ nic.network }}.{{ domain_name }}.
-        {% else %}
-{# Do nothing, not in registered network #}
-        {% endif %}
-      {% endif %}
-    {% endfor %}
-    {% if host_dict['bmc'] is defined %}
-      {% set bmc_args = host_dict['bmc'] %}
-      {% if (bmc_args.name is defined and bmc_args.name is not none) and (bmc_args.ip4 is defined and bmc_args.ip4 is not none) and (bmc_args.network is defined and bmc_args.network is not none) %}
-{{ bmc_args.ip4.split('.')[3] }}.{{ bmc_args.ip4.split('.')[2] }}.{{ bmc_args.ip4.split('.')[1] }}.{{ bmc_args.ip4.split('.')[0] }} IN PTR {{ bmc_args.name }}.{{ domain_name }}.
-{{ bmc_args.ip4.split('.')[3] }}.{{ bmc_args.ip4.split('.')[2] }}.{{ bmc_args.ip4.split('.')[1] }}.{{ bmc_args.ip4.split('.')[0] }} IN PTR {{ bmc_args.name }}-{{ bmc_args.network }}.{{ domain_name }}.
-      {% endif %}
-    {% endif %}
-  {% endif %}
-{% endmacro %}
+{% macro create_record(octets, name) -%}
+{{ octets }} IN PTR {{ name }}.
+{%- endmacro %}
 
-{% for host in groups['all'] -%}
-{{ write_host(host,hostvars[host],hostvars[host]['j2_node_main_resolution_network']) }}
-{%- endfor %}
+{% macro get_host_octets(ip, prefix) -%}
+{% if prefix <= 8 %}
+{{ ip.split('.')[3] }}
+{% elif prefix <= 16 %}
+{{ ip.split('.')[2:4]|reverse|join('.') }}
+{% elif prefix <= 24 %}
+{{ ip.split('.')[1:3]|reverse|join('.') }}
+{% elif prefix < 32 %}
+{{ ip.split('.')[0:4]|reverse|join('.') }}
+{% endif %}
+{%- endmacro %}
+
+{% for host in groups['all'] %}
+{% if hostvars[host]['network_interfaces'] is defined and hostvars[host]['network_interfaces'] is iterable %}
+{% for nic in hostvars[host]['network_interfaces'] %}
+{% if nic.network is defined and nic.network == item and nic.ip4 is defined and nic.ip4 is not none and networks[item].prefix is defined %}
+{{ create_record(get_host_octets(nic.ip4, networks[item].prefix)|trim, [[host, item]|join('-'), domain_name]|join('.')) }}
+{% if item == hostvars[host]['j2_node_main_resolution_network'] %}
+{{ create_record(get_host_octets(nic.ip4, networks[item].prefix)|trim, [host, domain_name]|join('.')) }}
+{% endif %}
+{% if hostvars[host].bmc is defined %}
+{% set bmc_args = hostvars[host]['bmc'] %}
+{% if bmc_args.name is defined and bmc_args.name is not none and bmc_args.ip4 is defined and bmc_args.ip4 is not none and bmc_args.network is defined and bmc_args.network is not none and bmc_args.network == item %}
+{{ create_record(get_host_octets(bmc_args.ip4, networks[bmc_args.network].prefix)|trim, [[bmc_args.name, bmc_args.network]|join('-'), domain_name]|join('.')) }}
+{% if item == hostvars[host]['j2_node_main_resolution_network'] %}
+{{ create_record(get_host_octets(bmc_args.ip4, networks[bmc_args.network].prefix)|trim, [bmc_args.name, domain_name]|join('.')) }}
+{% endif %}
+{% endif %}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}

--- a/roles/core/dns_server/templates/reverse.j2
+++ b/roles/core/dns_server/templates/reverse.j2
@@ -13,13 +13,11 @@ $INCLUDE "{{ item }}.rr.soa"
 
 {% macro get_host_octets(ip, prefix) -%}
   {% if prefix <= 8 %}
-{{ ip.split('.')[3] }}
+    {{ ip.split('.')[1:4]|reverse|join('.') }}
   {% elif prefix <= 16 %}
     {{ ip.split('.')[2:4]|reverse|join('.') }}
-  {% elif prefix <= 24 %}
-    {{ ip.split('.')[1:3]|reverse|join('.') }}
-  {% elif prefix < 32 %}
-    {{ ip.split('.')[0:4]|reverse|join('.') }}
+  {% elif prefix <= 31 %}
+    {{ ip.split('.')[3] }}
   {% endif %}
 {%- endmacro %}
 

--- a/roles/core/dns_server/templates/reverse.j2
+++ b/roles/core/dns_server/templates/reverse.j2
@@ -12,35 +12,35 @@ $INCLUDE "{{ item }}.rr.soa"
 {%- endmacro %}
 
 {% macro get_host_octets(ip, prefix) -%}
-{% if prefix <= 8 %}
+  {% if prefix <= 8 %}
 {{ ip.split('.')[3] }}
-{% elif prefix <= 16 %}
-{{ ip.split('.')[2:4]|reverse|join('.') }}
-{% elif prefix <= 24 %}
-{{ ip.split('.')[1:3]|reverse|join('.') }}
-{% elif prefix < 32 %}
-{{ ip.split('.')[0:4]|reverse|join('.') }}
-{% endif %}
+  {% elif prefix <= 16 %}
+    {{ ip.split('.')[2:4]|reverse|join('.') }}
+  {% elif prefix <= 24 %}
+    {{ ip.split('.')[1:3]|reverse|join('.') }}
+  {% elif prefix < 32 %}
+    {{ ip.split('.')[0:4]|reverse|join('.') }}
+  {% endif %}
 {%- endmacro %}
 
 {% for host in groups['all'] %}
-{% if hostvars[host]['network_interfaces'] is defined and hostvars[host]['network_interfaces'] is iterable %}
-{% for nic in hostvars[host]['network_interfaces'] %}
-{% if nic.network is defined and nic.network == item and nic.ip4 is defined and nic.ip4 is not none and networks[item].prefix is defined %}
+  {% if hostvars[host]['network_interfaces'] is defined and hostvars[host]['network_interfaces'] is iterable %}
+    {% for nic in hostvars[host]['network_interfaces'] %}
+      {% if nic.network is defined and nic.network == item and nic.ip4 is defined and nic.ip4 is not none and networks[item].prefix is defined %}
 {{ create_record(get_host_octets(nic.ip4, networks[item].prefix)|trim, [[host, item]|join('-'), domain_name]|join('.')) }}
-{% if item == hostvars[host]['j2_node_main_resolution_network'] %}
+        {% if item == hostvars[host]['j2_node_main_resolution_network'] %}
 {{ create_record(get_host_octets(nic.ip4, networks[item].prefix)|trim, [host, domain_name]|join('.')) }}
-{% endif %}
-{% if hostvars[host].bmc is defined %}
-{% set bmc_args = hostvars[host]['bmc'] %}
-{% if bmc_args.name is defined and bmc_args.name is not none and bmc_args.ip4 is defined and bmc_args.ip4 is not none and bmc_args.network is defined and bmc_args.network is not none and bmc_args.network == item %}
+        {% endif %}
+        {% if hostvars[host].bmc is defined %}
+          {% set bmc_args = hostvars[host]['bmc'] %}
+          {% if bmc_args.name is defined and bmc_args.name is not none and bmc_args.ip4 is defined and bmc_args.ip4 is not none and bmc_args.network is defined and bmc_args.network is not none and bmc_args.network == item %}
 {{ create_record(get_host_octets(bmc_args.ip4, networks[bmc_args.network].prefix)|trim, [[bmc_args.name, bmc_args.network]|join('-'), domain_name]|join('.')) }}
-{% if item == hostvars[host]['j2_node_main_resolution_network'] %}
+            {% if item == hostvars[host]['j2_node_main_resolution_network'] %}
 {{ create_record(get_host_octets(bmc_args.ip4, networks[bmc_args.network].prefix)|trim, [bmc_args.name, domain_name]|join('.')) }}
-{% endif %}
-{% endif %}
-{% endif %}
-{% endif %}
-{% endfor %}
-{% endif %}
+            {% endif %}
+          {% endif %}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
 {% endfor %}

--- a/roles/core/dns_server/vars/main.yml
+++ b/roles/core/dns_server/vars/main.yml
@@ -6,9 +6,7 @@ j2_dns_server_get_network: "
 {{ networks[item]['subnet'].split('.')[0] }}
 {% elif networks[item]['prefix'] <= 16 %}
 {{ networks[item]['subnet'].split('.')[0:2]|reverse|join('.') }}
-{% elif networks[item]['prefix'] <= 24 %}
+{% elif networks[item]['prefix'] <= 31 %}
 {{ networks[item]['subnet'].split('.')[0:3]|reverse|join('.') }}
-{% elif networks[item]['prefix'] < 32 %}
-{{ networks[item]['subnet'].split('.')[0:4]|reverse|join('.') }}
 {% endif %}
 "

--- a/roles/core/dns_server/vars/main.yml
+++ b/roles/core/dns_server/vars/main.yml
@@ -1,2 +1,14 @@
 ---
-dns_server_role_version: 1.1.1
+dns_server_role_version: 1.3.2
+
+j2_dns_server_get_network: "
+{% if networks[item]['prefix'] <= 8 %}
+{{ networks[item]['subnet'].split('.')[0] }}
+{% elif networks[item]['prefix'] <= 16 %}
+{{ networks[item]['subnet'].split('.')[0:2]|reverse|join('.') }}
+{% elif networks[item]['prefix'] <= 24 %}
+{{ networks[item]['subnet'].split('.')[0:3]|reverse|join('.') }}
+{% elif networks[item]['prefix'] < 32 %}
+{{ networks[item]['subnet'].split('.')[0:4]|reverse|join('.') }}
+{% endif %}
+"


### PR DESCRIPTION
Changed the generation of the reverse zone file to instead be one file per network that is defined to be in DNS. The network prefix is used to generate the corresponding `in-addr.arpa` entries.

Reverse zones are named: `{{ network }}.rr.zone` and SOA files are similarly named `{{ network }}.rr.soa`