### PR TITLE
Fix: Tox - Update envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,3}-ansible{29,210,3}
+envlist = py27-ansible29,py3-ansible{29,210,3}
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
I think we should restrain python 2.7 to Ansible 2.9 as Rhel7 is the only distrib we are supporting with python 2.7, and it is based on Ansible 2.9.
I see always too much issues with more recent Ansible, event if it should be supported by Ansible team.