### PR TITLE
Fix: diskless role - Task with missing scripts removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 #### Roles improvement or fix
 
+  - diskless
+    - Removed outdated copy scripts task
   - disklessset
     - Update to version 1.3.0 (#617)
   - pxe_stack: force substitution of files by symlinks in case of an update (#587)

--- a/roles/core/diskless/tasks/main.yml
+++ b/roles/core/diskless/tasks/main.yml
@@ -45,22 +45,6 @@
     # Create disklessset configuration directory
     - /etc/disklessset/
 
-# Copy script files with permission
-- name: "Add diskless scripts"
-  copy:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    mode: 0755
-  with_items:
-    - { src: 'utils.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/utils.py' }
-    - { src: 'image_manager.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/image_manager.py' }
-    - { src: 'kernel_manager.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/kernel_manager.py' }
-    - { src: 'nfs_module.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/modules/nfs_module.py' }
-    - { src: 'base_module.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/modules/base_module.py' }
-    - { src: 'livenet_module.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/modules/livenet_module.py' }
-    - { src: 'demo_module.py', dest: '/lib/python{{ diskless_python_version }}/site-packages/diskless/modules/demo_module.py' }
-    - { src: 'disklessset.py', dest: '/usr/bin/disklessset' }
-
 - name: template █ Generate /etc/disklessset/diskless_parameters.yml
   template:
     src: diskless_parameters.yml.j2


### PR DESCRIPTION
The scripts from task "Add diskless scripts" were moved to the tools project and are now installed with the disklessset rpm.