### PR TITLE
Fix: nic_nmcli - add missing register of nic_nmcli_apply variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
     - add ip4_manual entry (#618)
     - add dns4 and dns4_search vars logic (#585)
     - improve role capabilities (#558)
+    - add missing register of nic_nmcli_apply variable (#662)
   - powerman:
     - implement support for externaly defined BMC (#640)
   - pxe_stack:

--- a/roles/core/nic_nmcli/readme.rst
+++ b/roles/core/nic_nmcli/readme.rst
@@ -183,6 +183,7 @@ To achieve that, two variables are at disposal:
 Changelog
 ^^^^^^^^^
 
+* 1.5.1: Add missing register of nic_nmcli_apply variable. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.5.0: Add ip4_manual entry. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.4.1: Adapt role to handle multiple distributions. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.4.0: Add Ubuntu support. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/core/nic_nmcli/tasks/main.yml
+++ b/roles/core/nic_nmcli/tasks/main.yml
@@ -128,6 +128,7 @@
     method6: "{{ item.method6 | default(omit) }}"
   notify: command █ Reload connections
   loop: "{{ network_interfaces }}"
+  register: nic_nmcli_apply
   when: item.skip is not defined or (item.skip is defined and not item.skip)
   tags:
     - identify

--- a/roles/core/nic_nmcli/vars/main.yml
+++ b/roles/core/nic_nmcli/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-nic_nmcli_role_version: 1.5.0
+nic_nmcli_role_version: 1.5.1
 
 j2_nic_nmcli_ip4: "{{ j2_nic_nmcli_ip4_main | trim }}{% if item.ip4 is defined and item.ip4_manual is defined %},{% endif %}{{ j2_nic_nmcli_ip4_manual | trim }}"
 


### PR DESCRIPTION
The optional parameter of nic_nmcli role does not work, the role fails with this error message:

```
# ansible-playbook computes.yml --tags nic_nmcli -e nic_nmcli_force_nic_restart=true
...
TASK [nic_nmcli : shell █ Force apply nic settings] **********************************************************************
Tuesday 11 January 2022 16:31:38 +0100 (0:00:01.108) 0:00:08.516 *******
fatal: [management1]: FAILED! =>
msg: '''nic_nmcli_apply'' is undefined
```

This PR adds the missing variable definition, and the role works as expected.