### PR TITLE
Fix: pxe_stack force substitution from file to symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
     - Add bootset as package. (#649)
     - fix issues with hostname not set during kickstart on RHEL 8.3 (#522)
     - force substitution of files by symlinks in case of an update (#587)
+    - Reapply #587 (#666)
   - repositories_client: fix CentOS 8.4 repository compatibility (#534)
   - set_hostname: add fqdn capability (#543)
   - ssh_master:

--- a/roles/core/pxe_stack/tasks/client_os/RedHat.yml
+++ b/roles/core/pxe_stack/tasks/client_os/RedHat.yml
@@ -17,6 +17,7 @@
     owner: "{{ pxe_stack_apache_user }}"
     group: "{{ pxe_stack_apache_user }}"
     state: link
+    force: yes
   loop: "{{ pxe_stack_supported_os.redhat | subelements('distributions') }}"
   when: item.1 != 'redhat'
 

--- a/roles/core/pxe_stack/tasks/client_os/Ubuntu.yml
+++ b/roles/core/pxe_stack/tasks/client_os/Ubuntu.yml
@@ -19,6 +19,7 @@
     owner: "{{ pxe_stack_apache_user }}"
     group: "{{ pxe_stack_apache_user }}"
     state: link
+    force: yes
   loop: "{{ pxe_stack_supported_os.ubuntu | subelements('distributions') }}"
   when: item.1 != 'ubuntu'
 

--- a/roles/core/pxe_stack/vars/main.yml
+++ b/roles/core/pxe_stack/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pxe_stack_role_version: 1.3.4
+pxe_stack_role_version: 1.3.5
 
 pxe_stack_supported_os:
 #  centos:


### PR DESCRIPTION
Had the same problem as described in [#587](https://github.com/bluebanquise/bluebanquise/pull/587).
This time from bb-1.4 to 1.5.

Somehow the fix was removed during the update.