### PR TITLE
Fix: powerman - bluebanquise_filters is now bluebanquise-filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
     - add missing register of nic_nmcli_apply variable (#662)
   - powerman:
     - implement support for externaly defined BMC (#640)
+    - Fix reference to bluebanquise-filters (#669)
   - pxe_stack:
     - Fix missing efi bootorder management for Ubuntu (#656)
     - Add bootset as package. (#649)

--- a/roles/core/powerman/tasks/main.yml
+++ b/roles/core/powerman/tasks/main.yml
@@ -4,7 +4,7 @@
     name:
       - freeipmi
       - powerman
-      - bluebanquise_filters
+      - bluebanquise-filters
     state: present
   tags:
     - package

--- a/roles/core/powerman/vars/main.yml
+++ b/roles/core/powerman/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-powerman_role_version: 1.1.0
+powerman_role_version: 1.1.1


### PR DESCRIPTION
Powerman role still referencing old bluebanquise_filters package.