### PR TITLE
Fix for issue #682 in dns_server role

### DIFF
--- a/resources/documentation/conf.py
+++ b/resources/documentation/conf.py
@@ -86,7 +86,7 @@ pygments_style = None
 html_logo = "logo.png"
 html_theme = "sphinx_rtd_theme"
 html_theme_path = ["_themes", ]
-html_css_files = ["custom.css",]
+html_css_files = ["custom.css", ]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/roles/core/dns_server/defaults/main.yml
+++ b/roles/core/dns_server/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-dns_server_dnssec_enable: yes
-dns_server_dnssec_validation: yes
+dns_server_dnssec_enable: true
+dns_server_dnssec_validation: true
 dns_server_dnssec_lookaside: auto
 
 dns_server_forwarders: []  # list of custom forwarders ip.

--- a/roles/core/dns_server/readme.rst
+++ b/roles/core/dns_server/readme.rst
@@ -115,6 +115,7 @@ Files generated:
 Changelog
 ^^^^^^^^^
 
+* 1.4.1: Bug fix for issue #682. Neil Munday <neil@mundayweb.com>
 * 1.4.0: Re-worked role to work with Suse as well as existing distributions. Neil Munday <neil@mundayweb.com>
 * 1.3.3: Add missing vital parameters to allow binding to external DNS servers. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.3.2: Re-worked reverse zone generation to fix issue #614. Neil Munday <neil@mundayweb.com>

--- a/roles/core/dns_server/tasks/main.yml
+++ b/roles/core/dns_server/tasks/main.yml
@@ -97,30 +97,12 @@
   tags:
     - template
 
-- name: "template █ Generate Reverse zone file on Master DNS {{ dns_server_named_dir }}/{{ item }}.rr.zone"
-  template:
-    src: reverse.j2
-    dest: "{{ dns_server_named_dir }}/{{ item }}.rr.zone"
-    owner: root
-    group: root
-    mode: 0644
+- name: "include_tasks ░ Use reverse zone task"
+  include_tasks: reverse.yml
   with_items: "{{ networks }}"
-  when: networks[item].is_in_dns
-  tags:
-    - template
-
-- name: "template █ Generate SOA for reverse zone file {{ dns_server_named_dir }}/{{ item }}.rr.soa"
-  template:
-    src: reverse.soa.j2
-    dest: "{{ dns_server_named_dir }}/{{ item }}.rr.soa"
-    owner: root
-    group: root
-    mode: 0644
-  notify: service █ Restart dns services
-  with_items: "{{ networks }}"
-  when: zoneconf.changed and networks[item].is_in_dns  # noqa 503
-  tags:
-    - template
+  when: networks[outer_item].is_in_dns
+  loop_control:
+    loop_var: outer_item
 
 - name: "template █ Generate override file {{ dns_server_named_dir }}/override.zone"
   template:

--- a/roles/core/dns_server/tasks/reverse.yml
+++ b/roles/core/dns_server/tasks/reverse.yml
@@ -1,0 +1,26 @@
+---
+
+- name: "template █ Generate Reverse zone file on Master DNS {{ dns_server_named_dir }}/{{ item }}.rr.zone"
+  template:
+    src: reverse.j2
+    dest: "{{ dns_server_named_dir }}/{{ item|trim }}.rr.zone"
+    owner: root
+    group: root
+    mode: 0644
+  with_items: "{{ j2_dns_server_get_first_octets.split(',') }}"
+  tags:
+    - template
+
+- name: "template █ Generate SOA for reverse zone file {{ dns_server_named_dir }}/{{ item }}.rr.soa"
+  template:
+    src: reverse.soa.j2
+    dest: "{{ dns_server_named_dir }}/{{ item|trim }}.rr.soa"
+    owner: root
+    group: root
+    mode: 0644
+  notify: service █ Restart dns services
+  with_items: "{{ j2_dns_server_get_first_octets.split(',') }}"
+  when: zoneconf.changed  # noqa 503
+  tags:
+    - template
+

--- a/roles/core/dns_server/tasks/reverse.yml
+++ b/roles/core/dns_server/tasks/reverse.yml
@@ -23,4 +23,3 @@
   when: zoneconf.changed  # noqa 503
   tags:
     - template
-

--- a/roles/core/dns_server/templates/named.conf.j2
+++ b/roles/core/dns_server/templates/named.conf.j2
@@ -80,22 +80,36 @@ zone "{{ domain_name }}" IN {
   allow-update { none; };
 };
 
-{% macro create_reverse_zone(network, octets) -%}
-zone "{{ octets }}.in-addr.arpa" IN {
+{% macro create_reverse_zone(octets) -%}
+zone "{{ octets.split('.')|reverse|join('.') }}.in-addr.arpa" IN {
    type master;
-   file "{{ dns_server_named_dir }}/{{ network }}.rr.zone";
+   file "{{ dns_server_named_dir }}/{{ octets }}.rr.zone";
    allow-update { none; };
 };
 {%- endmacro %}
 
-{% for network, props in networks.items() %}
-  {% if props['is_in_dns'] %}
-    {% if props['prefix'] <= 8 %}
-{{ create_reverse_zone(network, props['subnet'].split('.')[0]) }}
-    {% elif props['prefix'] <= 16 %}
-{{ create_reverse_zone(network, props['subnet'].split('.')[0:2]|reverse|join('.')) }}
-    {% elif props['prefix'] <= 31 %}
-{{ create_reverse_zone(network, props['subnet'].split('.')[0:3]|reverse|join('.')) }}
+{% set ip_networks = [] %}
+
+{% for host in groups['all'] %}
+  {% if hostvars[host]['network_interfaces'] is defined %}
+    {% for interface in hostvars[host]['network_interfaces'] %}
+      {% if interface['ip4'] is defined and networks[interface['network']]['is_in_dns'] %}
+        {% set ip_prefix = interface['ip4'].split('.')[0:3]|join('.') %}
+        {% if ip_prefix not in ip_networks %}
+          {{ ip_networks.append(ip_prefix) }}
+{{ create_reverse_zone(ip_prefix) }}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+  {% if hostvars[host]['bmc'] is defined %}
+    {% set bmc_args = hostvars[host]['bmc'] %}
+    {% if bmc_args.ip4 is defined %}
+      {% set ip_prefix = bmc_args.ip4.split('.')[0:3]|join('.') %}
+      {% if ip_prefix not in ip_networks %}
+        {{ ip_networks.append(ip_prefix) }}
+{{ create_reverse_zone(ip_prefix) }}
+      {% endif %}
     {% endif %}
   {% endif %}
 {% endfor %}

--- a/roles/core/dns_server/templates/reverse.j2
+++ b/roles/core/dns_server/templates/reverse.j2
@@ -3,44 +3,34 @@
 ;## {{ ansible_managed }} 
 
 $TTL 86400
-$ORIGIN {{ j2_dns_server_get_network | trim }}.in-addr.arpa.
+$ORIGIN {{ item.split('.')|reverse|join('.') }}.in-addr.arpa.
 $INCLUDE "{{ dns_server_named_dir }}/{{ item }}.rr.soa"
 @ IN NS {{ inventory_hostname }}.{{ domain_name }}.
 
-{% macro create_record(octets, name) -%}
-{{ octets }} IN PTR {{ name }}.
-{%- endmacro %}
-
-{% macro get_host_octets(ip, prefix) -%}
-  {% if prefix <= 8 %}
-    {{ ip.split('.')[1:4]|reverse|join('.') }}
-  {% elif prefix <= 16 %}
-    {{ ip.split('.')[2:4]|reverse|join('.') }}
-  {% elif prefix <= 31 %}
-    {{ ip.split('.')[3] }}
-  {% endif %}
+{% macro create_record(ip, name) -%}
+{{ ip.split('.')[3] }} IN PTR {{ name }}.
 {%- endmacro %}
 
 {# Macro to write host in file #}
 {% macro write_host(host,host_dict,host_node_main_resolution_network) %}
   {% if host_dict['network_interfaces'] is defined and host_dict['network_interfaces'] is iterable %}
     {% for nic in host_dict['network_interfaces'] %}
-      {% if nic.network is defined and nic.network == item and nic.ip4 is defined and nic.ip4 is not none and networks[item].prefix is defined %}
-{{ create_record(get_host_octets(nic.ip4, networks[item].prefix)|trim, [[host, item]|join('-'), domain_name]|join('.')) }}
+      {% if nic.network is defined and nic.network == outer_item and nic.ip4 is defined and nic.ip4 is not none and nic.ip4.split('.')[0:3]|join('.') == item %}
+{{ create_record(nic.ip4, [[host, outer_item]|join('-'), domain_name]|join('.')) }}
         {% if item == host_node_main_resolution_network %}
-{{ create_record(get_host_octets(nic.ip4, networks[item].prefix)|trim, [host, domain_name]|join('.')) }}
-        {% endif %}
-        {% if host_dict['bmc'] is defined %}
-          {% set bmc_args = host_dict['bmc'] %}
-          {% if bmc_args.name is defined and bmc_args.name is not none and bmc_args.ip4 is defined and bmc_args.ip4 is not none and bmc_args.network is defined and bmc_args.network is not none and bmc_args.network == item %}
-{{ create_record(get_host_octets(bmc_args.ip4, networks[bmc_args.network].prefix)|trim, [[bmc_args.name, bmc_args.network]|join('-'), domain_name]|join('.')) }}
-            {% if item == host_node_main_resolution_network %}
-{{ create_record(get_host_octets(bmc_args.ip4, networks[bmc_args.network].prefix)|trim, [bmc_args.name, domain_name]|join('.')) }}
-            {% endif %}
-          {% endif %}
+{{ create_record(nic.ip4, [host, domain_name]|join('.')) }}
         {% endif %}
       {% endif %}
     {% endfor %}
+  {% endif %}
+  {% if host_dict['bmc'] is defined %}
+    {% set bmc_args = host_dict['bmc'] %}
+    {% if bmc_args.name is defined and bmc_args.name is not none and bmc_args.ip4 is defined and bmc_args.ip4 is not none and bmc_args.network is defined and bmc_args.network is not none and bmc_args.network == outer_item and bmc_args.ip4.split('.')[0:3]|join('.') == item  %}
+{{ create_record(bmc_args.ip4, [[bmc_args.name, bmc_args.network]|join('-'), domain_name]|join('.')) }}
+      {% if item == host_node_main_resolution_network %}
+{{ create_record(bmc_args.ip4, [bmc_args.name, domain_name]|join('.')) }}
+      {% endif %}
+    {% endif %}
   {% endif %}
 {% endmacro -%}
 

--- a/roles/core/dns_server/vars/main.yml
+++ b/roles/core/dns_server/vars/main.yml
@@ -15,7 +15,14 @@ j2_dns_server_get_first_octets: "
     {%- endfor -%}
     {%- if hostvars[host]['bmc'] is defined -%}
       {%- set bmc_args = hostvars[host]['bmc'] -%}
-      {%- if bmc_args.name is defined and bmc_args.name is not none and bmc_args.ip4 is defined and bmc_args.ip4 is not none and bmc_args.network is defined and bmc_args.network is not none and bmc_args.network == outer_item -%}
+      {%- if bmc_args.name is defined and \
+          bmc_args.name is not none and \
+          bmc_args.ip4 is defined and \
+          bmc_args.ip4 is not none and \
+          bmc_args.network is defined \
+          and bmc_args.network is not none and \
+          bmc_args.network == outer_item \
+      -%}
         {%- set ip_prefix = bmc_args.ip4.split('.')[0:3]|join('.') -%}
         {%- if ip_prefix not in ip_networks -%}
           {{ ip_networks.append(ip_prefix) }}

--- a/roles/core/dns_server/vars/main.yml
+++ b/roles/core/dns_server/vars/main.yml
@@ -1,12 +1,27 @@
 ---
-dns_server_role_version: 1.4.0
+dns_server_role_version: 1.4.1
 
-j2_dns_server_get_network: "
-{% if networks[item]['prefix'] <= 8 %}
-{{ networks[item]['subnet'].split('.')[0] }}
-{% elif networks[item]['prefix'] <= 16 %}
-{{ networks[item]['subnet'].split('.')[0:2]|reverse|join('.') }}
-{% elif networks[item]['prefix'] <= 31 %}
-{{ networks[item]['subnet'].split('.')[0:3]|reverse|join('.') }}
-{% endif %}
-"
+j2_dns_server_get_first_octets: "
+{%- set ip_networks = [] -%}
+{%- for host in groups['all'] -%}
+  {%- if hostvars[host]['network_interfaces'] is defined -%}
+    {%- for interface in hostvars[host]['network_interfaces'] -%}
+      {%- if interface['network'] == outer_item and  interface['ip4'] is defined and networks[interface['network']]['is_in_dns'] -%}
+        {%- set ip_prefix = interface['ip4'].split('.')[0:3]|join('.') -%}
+        {%- if ip_prefix not in ip_networks -%}
+          {{ ip_networks.append(ip_prefix) }}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- if hostvars[host]['bmc'] is defined -%}
+      {%- set bmc_args = hostvars[host]['bmc'] -%}
+      {%- if bmc_args.name is defined and bmc_args.name is not none and bmc_args.ip4 is defined and bmc_args.ip4 is not none and bmc_args.network is defined and bmc_args.network is not none and bmc_args.network == outer_item -%}
+        {%- set ip_prefix = bmc_args.ip4.split('.')[0:3]|join('.') -%}
+        {%- if ip_prefix not in ip_networks -%}
+          {{ ip_networks.append(ip_prefix) }}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endif -%}
+{%- endfor -%}
+{{ ip_networks|join(',') }}"


### PR DESCRIPTION
This mod changes the `dns_server` role so that reverse zone files are created in the form `xxx.yyy.zzz.rr.zone` for every host/BMC IP that matches.

If this is acceptable, the same mods can be made to to the `advanced_dns_server` role.