### PR TITLE
Feat: advanced_dhcp_server - allow time_ip list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
     - fix an idempotency problem of role clustershell (#675)
   - nfs_server:
     - Add auto directories creation capability. (#685)
+  - advanced_dhcp_server:
+    - Allows usage of a time_ip list. (#692)
 
 ## 1.5.0
 
@@ -47,7 +49,7 @@
   - bluebanquise:
     - Add missing bluebanquise_filter package (#648)
   - clustershell: prevent dummy host to be included (#619)
-  - conman: 
+  - conman:
     - Fix bluebanquise-filters package name (#665)
     - fix execpath for RHEL 8 (#584)
     - implement support for externaly defined BMC (#640)

--- a/roles/advanced_core/advanced_dhcp_server/readme.rst
+++ b/roles/advanced_core/advanced_dhcp_server/readme.rst
@@ -175,6 +175,7 @@ host {{ macro_host }} {
 Changelog
 ^^^^^^^^^
 
+* 1.1.1: Allows usage of time_ip list. Thiago Cardozo <thiago.cardozo@yahoo.com.br>
 * 1.1.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.6: Prevent unsorted ranges. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.5: Improve performances. Add dhcp_options and patterns features. Allow multiple entries per host. Benoit Leveugle <benoit.leveugle@atos.net>

--- a/roles/advanced_core/advanced_dhcp_server/templates/dhcpd.networks.conf.j2
+++ b/roles/advanced_core/advanced_dhcp_server/templates/dhcpd.networks.conf.j2
@@ -22,6 +22,7 @@ shared-network {{shared_network}} {
 {% for network in networks %}
 {% if (networks[network]['shared_network'] is defined and not none) and (networks[network]['shared_network'] == shared_network) and (networks[network]['is_in_dhcp'] == true) %}
   {% set nameservers = networks[network]['services_ip']['dns_ip'] | ipaddr %}
+  {% set timeservers = networks[network]['services_ip']['time_ip'] | ipaddr %}
 
 subnet {{networks[network]['subnet']}} netmask {{networks[network]['netmask']}} {
 
@@ -35,7 +36,11 @@ subnet {{networks[network]['subnet']}} netmask {{networks[network]['netmask']}} 
   option domain-name-servers {{nameservers | join(', ')}};
   {% endif %}
   option broadcast-address {{networks[network]['broadcast']}};
-  option ntp-servers {{networks[network]['services_ip']['time_ip']}};
+  {% if timeservers is string %}
+  option ntp-servers {{ timeservers }};
+  {% else %}
+  option ntp-servers {{ timeservers | join(', ') }};
+  {% endif %}
   {% if networks[network]['gateway'] is defined and not none %}
   option routers {{networks[network]['gateway']}};
   {% endif %}
@@ -68,6 +73,7 @@ subnet {{networks[network]['subnet']}} netmask {{networks[network]['netmask']}} 
 {% if j2_current_iceberg_network in network %}
 {% if (networks[network]['shared_network'] is not defined or none) and (networks[network]['is_in_dhcp'] == true) %}
   {% set nameservers = networks[network]['services_ip']['dns_ip'] | ipaddr %}
+  {% set timeservers = networks[network]['services_ip']['time_ip'] | ipaddr %}
 
 subnet {{networks[network]['subnet']}} netmask {{networks[network]['netmask']}} {
 
@@ -81,7 +87,11 @@ subnet {{networks[network]['subnet']}} netmask {{networks[network]['netmask']}} 
   option domain-name-servers {{nameservers | join(', ')}};
   {% endif %}
   option broadcast-address {{networks[network]['broadcast']}};
-  option ntp-servers {{networks[network]['services_ip']['time_ip']}};
+  {% if timeservers is string %}
+  option ntp-servers {{ timeservers }};
+  {% else %}
+  option ntp-servers {{ timeservers | join(', ') }};
+  {% endif %}
   {% if networks[network]['gateway'] is defined and not none %}
   option routers {{networks[network]['gateway']}};
   {% endif %}

--- a/roles/advanced_core/advanced_dhcp_server/vars/main.yml
+++ b/roles/advanced_core/advanced_dhcp_server/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-advanced_dhcp_server_role_version: 1.1.0
+advanced_dhcp_server_role_version: 1.1.1


### PR DESCRIPTION
Enables the usage of a time_ip list same way as is done with dns_ip.

Thanks to N. Capit.