### PR TITLE
Updated advanced_dhcp_server role for OpenSUSE/SLES for issue #696

### DIFF
--- a/roles/advanced_core/advanced_dhcp_server/readme.rst
+++ b/roles/advanced_core/advanced_dhcp_server/readme.rst
@@ -175,6 +175,7 @@ An example of macro would be, for the pattern *my_equipment_x* defined above:
 Changelog
 ^^^^^^^^^
 
+* 1.1.2: Updated to work with SLES/OpenSUSE. Neil Munday <neil@mundayweb.com>
 * 1.1.1: Allows usage of time_ip list. Thiago Cardozo <thiago.cardozo@yahoo.com.br>
 * 1.1.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.6: Prevent unsorted ranges. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/advanced_core/advanced_dhcp_server/tasks/Suse/firewall.yml
+++ b/roles/advanced_core/advanced_dhcp_server/tasks/Suse/firewall.yml
@@ -1,0 +1,12 @@
+- name: "firewalld █ Add services to firewall's {{ advanced_dhcp_server_firewall_zone | default('public') }} zone"
+  ansible.posix.firewalld:
+    zone: "{{ advanced_dhcp_server_firewall_zone | default('public') }}"
+    service: "{{ item }}"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ep_firewall | default(false) | bool
+  loop: "{{ advanced_dhcp_server_firewall_services_to_add }}"
+  tags:
+    - firewall

--- a/roles/advanced_core/advanced_dhcp_server/tasks/Suse/main.yml
+++ b/roles/advanced_core/advanced_dhcp_server/tasks/Suse/main.yml
@@ -1,0 +1,10 @@
+- name: template █ Generate /etc/sysconfig/dhcpd for SuSE based systems
+  template:
+    src: Suse/sysconfig.j2
+    dest: /etc/sysconfig/dhcpd
+    owner: root
+    group: root
+    mode: 0644
+  notify: service █ Restart dhcp server
+  tags:
+    - template

--- a/roles/advanced_core/advanced_dhcp_server/tasks/main.yml
+++ b/roles/advanced_core/advanced_dhcp_server/tasks/main.yml
@@ -46,10 +46,17 @@
   tags:
     - package
 
-- name: Template >> /etc/dhcp/dhcpd.conf
+- name: "file █ Create {{ advanced_dhcp_server_conf_dir }}"
+  ansible.builtin.file:
+    path: "{{ dhcp_server_conf_dir }}"
+    owner: root
+    mode: "0755"
+    state: directory
+
+- name: "Template >> {{ advanced_dhcp_server_conf_file }}"
   ansible.builtin.template:
     src: dhcpd.conf.j2
-    dest: /etc/dhcp/dhcpd.conf
+    dest: "{{ advanced_dhcp_server_conf_file }}"
     owner: root
     group: root
     mode: 0644
@@ -57,10 +64,10 @@
   tags:
     - template
 
-- name: Template >> /etc/dhcp/dhcpd.networks.conf
+- name: "Template >> {{ advanced_dhcp_server_conf_dir }}/dhcpd.networks.conf"
   ansible.builtin.template:
     src: dhcpd.networks.conf.j2
-    dest: /etc/dhcp/dhcpd.networks.conf
+    dest: "{{ advanced_dhcp_server_conf_dir }}/dhcpd.networks.conf"
     owner: root
     group: root
     mode: 0644
@@ -68,10 +75,10 @@
   tags:
     - template
 
-- name: Template >> /etc/dhcp/dhcpd.{{ item }}.conf
+- name: "Template >> {{ advanced_dhcp_server_conf_dir }}/dhcpd.{{ item }}.conf"
   ansible.builtin.template:
     src: dhcpd.subnet.conf.j2
-    dest: /etc/dhcp/dhcpd.{{ item }}.conf
+    dest: "{{ advanced_dhcp_server_conf_dir }}/dhcpd.{{ item }}.conf"
     owner: root
     group: root
     mode: 0644

--- a/roles/advanced_core/advanced_dhcp_server/templates/Suse/sysconfig.j2
+++ b/roles/advanced_core/advanced_dhcp_server/templates/Suse/sysconfig.j2
@@ -1,0 +1,185 @@
+# {{ ansible_managed }}
+
+## Path: 	Network/DHCP/DHCP server
+## Description: DHCPv4 server settings
+## Type:	string
+## Default:	""
+## ServiceRestart: dhcpd
+#
+# Interface(s) for the DHCPv4 server to listen on.
+# 
+# A special keyword is ANY, it will cause dhcpd to autodetect available
+# interfaces.
+#
+# Examples: DHCPD_INTERFACE="eth0 eth1 eth2"
+#           DHCPD_INTERFACE="ANY"
+#
+DHCPD_INTERFACE="{%- for v in hostvars[inventory_hostname]['network_interfaces'] | selectattr('network','defined') | selectattr('network','match','^'+j2_current_iceberg_network+'-[a-zA-Z0-9]+') %}
+ {{ v['interface'] }} 
+{%- endfor -%}"
+
+## Path: 	Network/DHCP/DHCP server
+## Description: DHCPv6 server settings
+## Type:	string
+## Default:	""
+## ServiceRestart: dhcpd6
+#
+# Interface(s) for the DHCPv6 server to listen on.
+# 
+# A special keyword is ANY, it will cause dhcpd to autodetect available
+# interfaces.
+#
+# Examples: DHCPD6_INTERFACE="eth0 eth1 eth2"
+#           DHCPD6_INTERFACE="ANY"
+#
+DHCPD6_INTERFACE=""
+## Description: Restart dhcpv4 server when interface goes up (again)
+## Type:        list(yes,no,auto,)
+## Default:     
+#
+# When the dhcp server is listening on a virtual interface, e.g. bridge,
+# bonding or vlan, and this interface gets deleted and recreated during
+# a network restart, dhcpd will stop answering requests on this interface
+# and needs a restart as well.
+# Begining with SLE-10 SP3, we install an if-up.d post script (see ifup(8)
+# and also ifservices(5)), enabled in auto mode by default. This variable
+# can be used to force or avoid the dhcp server restart:
+#
+#   no:   do not restart dhcpd
+#  yes:   force a dhcp server restart
+# auto:   (default) restart for virtual interfaces (bond,bridge,vlan) when
+#         all interfaces used in DHCPD_INTERFACE variable are up as well.
+#
+# Except of this global setting, the variable can be specified per interface
+# in the interface configurations (/etc/sysconfig/network/ifcfg-$name).
+#
+DHCPD_IFUP_RESTART=""
+## Description: Restart dhcpv6 server when interface goes up (again)
+## Type:        list(yes,no,auto,)
+## Default:     
+#
+# When the dhcp server is listening on a virtual interface, e.g. bridge,
+# bonding or vlan, and this interface gets deleted and recreated during
+# a network restart, dhcpd will stop answering requests on this interface
+# and needs a restart as well.
+# Begining with SLE-10 SP3, we install an if-up.d post script (see ifup(8)
+# and also ifservices(5)), enabled in auto mode by default. This variable
+# can be used to force or avoid the dhcp server restart:
+#
+#   no:   do not restart dhcpd
+#  yes:   force a dhcp server restart
+# auto:   (default) restart for virtual interfaces (bond,bridge,vlan) when
+#         all interfaces used in DHCPD_INTERFACE variable are up as well.
+#
+# Except of this global setting, the variable can be specified per interface
+# in the interface configurations (/etc/sysconfig/network/ifcfg-$name).
+#
+DHCPD6_IFUP_RESTART=""
+
+## Type:	yesno
+## Default:	yes
+## ServiceRestart: dhcpd
+#
+# Shall the DHCP server dhcpd run in a chroot jail (/var/lib/dhcp)?
+#
+# Each time you start dhcpd with the init script, /etc/dhcpd.conf
+# will be copied to /var/lib/dhcp/etc/.
+# 
+# Some files that are important for hostname to IP address resolution
+# (/etc/{gai.conf,nsswitch.conf,resolv.conf,host.conf,hosts,localtime},
+# /lib/lib{resolv.so.*,libnss_*.so.*,libpthread.so.0,libdl.so.2}) will
+# also be copied to the chroot jail by the init script when you start
+# it (less than 1MB altogether).
+# 
+# The pid file will be in /var/lib/dhcp/var/run/dhcpd.pid. 
+#
+DHCPD_RUN_CHROOTED="yes"
+
+## Type:	yesno
+## Default:	yes
+## ServiceRestart: dhcpd6
+#
+# Shall the DHCP server dhcpd run in a chroot jail (/var/lib/dhcp6)?
+#
+# Each time you start dhcpd with the init script, /etc/dhcpd6.conf
+# will be copied to /var/lib/dhcp6/etc/.
+# 
+# Some files that are important for hostname to IP address resolution
+# (/etc/{gai.conf,nsswitch.conf,resolv.conf,host.conf,hosts,localtime},
+# /lib/lib{resolv.so.*,libnss_*.so.*,libpthread.so.0,libdl.so.2}) will
+# also be copied to the chroot jail by the init script when you start
+# it (less than 1MB altogether).
+# 
+# The pid file will be in /var/lib/dhcp6/var/run/dhcpd.pid. 
+#
+DHCPD6_RUN_CHROOTED="yes"
+
+## Type:	string
+## Default:	"/etc/dhcpd.d"
+## ServiceRestart: dhcpd
+#
+# Since version 3, dhcpd.conf can contain include statements. 
+# If you enter the names of any include files here, _all_ conf
+# files will be copied to $chroot/etc/, when dhcpd is started in the 
+# chroot jail. (/etc/dhcpd.conf is always copied.)
+#
+# For your convenience, you can also specify entire directories,
+# that will be copied inclusive subdirectories. The /etc/dhcpd.d
+# directory will be copied by default when it exists.
+#
+# Example: "/etc/foo.bar.conf /etc/dhcpd.bootp-clients.conf"
+#
+DHCPD_CONF_INCLUDE_FILES="{{ dhcp_server_conf_dir }}"
+
+## Type:	string
+## Default:	"/etc/dhcpd.d"
+## ServiceRestart: dhcpd6
+#
+# Since version 3, dhcpd.conf can contain include statements. 
+# If you enter the names of any include files here, _all_ conf
+# files will be copied to $chroot/etc/, when dhcpd is started in
+# the chroot jail. (/etc/dhcpd6.conf is always copied.)
+#
+# For your convenience, you can also specify entire directories,
+# that will be copied inclusive subdirectories. The /etc/dhcpd6.d
+# directory will be copied by default when it exists.
+#
+# Example: "/etc/foo.bar.conf /etc/dhcpd6.bootp-clients.conf"
+#
+DHCPD6_CONF_INCLUDE_FILES="/etc/dhcpd6.d"
+
+## Type:	string
+## Default:	"dhcpd"
+## ServiceRestart: dhcpd
+#
+# Leave empty or enter "root" to let dhcpd run as root. 
+# Enter "dhcpd" to run dhcpd as user 'dhcpd'.
+#
+DHCPD_RUN_AS="dhcpd"
+
+## Type:	string
+## Default:	"dhcpd"
+## ServiceRestart: dhcpd6
+#
+# Leave empty or enter "root" to let dhcpd run as root. 
+# Enter "dhcpd" to run dhcpd as user 'dhcpd'.
+#
+DHCPD6_RUN_AS="dhcpd"
+
+## Type:	string
+## Default:	""
+## ServiceRestart: dhcpd
+#
+# Other arguments that you want dhcpd to be started with
+# (e.g. "-p 1234" for a non-standard port to listen on)
+#
+DHCPD_OTHER_ARGS=""
+
+## Type:	string
+## Default:	""
+## ServiceRestart: dhcpd6
+#
+# Other arguments that you want dhcpd to be started with
+# (e.g. "-p 1234" for a non-standard port to listen on)
+#
+DHCPD6_OTHER_ARGS=""

--- a/roles/advanced_core/advanced_dhcp_server/templates/dhcpd.conf.j2
+++ b/roles/advanced_core/advanced_dhcp_server/templates/dhcpd.conf.j2
@@ -40,4 +40,4 @@
 
 ## NETWORKS AND NODES
 
-include "/etc/dhcp/dhcpd.networks.conf";
+include "{{ advanced_dhcp_server_conf_dir }}/dhcpd.networks.conf";

--- a/roles/advanced_core/advanced_dhcp_server/templates/dhcpd.networks.conf.j2
+++ b/roles/advanced_core/advanced_dhcp_server/templates/dhcpd.networks.conf.j2
@@ -59,7 +59,7 @@ subnet {{networks[network]['subnet']}} netmask {{networks[network]['netmask']}} 
     {% endif %}
   {% endif %}
 
-  include "/etc/dhcp/dhcpd.{{network}}.conf";
+  include "{{ advanced_dhcp_server_conf_dir }}/dhcpd.{{network}}.conf";
 
 }
 {% endif %}
@@ -110,7 +110,7 @@ subnet {{networks[network]['subnet']}} netmask {{networks[network]['netmask']}} 
     {% endif %}
   {% endif %}
 
-  include "/etc/dhcp/dhcpd.{{network}}.conf";
+  include "{{ advanced_dhcp_server_conf_dir }}/dhcpd.{{network}}.conf";
 
 }
 {% endif %}

--- a/roles/advanced_core/advanced_dhcp_server/vars/RedHat_7.yml
+++ b/roles/advanced_core/advanced_dhcp_server/vars/RedHat_7.yml
@@ -5,3 +5,5 @@ advanced_dhcp_server_services_to_start:
   - dhcpd
 advanced_dhcp_server_firewall_services_to_add:
   - dhcp
+advanced_dhcp_server_conf_file: /etc/dhcp/dhcpd.conf
+advanced_dhcp_server_conf_dir: /etc/dhcp

--- a/roles/advanced_core/advanced_dhcp_server/vars/Suse.yml
+++ b/roles/advanced_core/advanced_dhcp_server/vars/Suse.yml
@@ -1,9 +1,10 @@
 ---
 advanced_dhcp_server_packages_to_install:
   - dhcp-server
+  - python3-netaddr
 advanced_dhcp_server_services_to_start:
   - dhcpd
 advanced_dhcp_server_firewall_services_to_add:
   - dhcp
-advanced_dhcp_server_conf_file: /etc/dhcp/dhcpd.conf
-advanced_dhcp_server_conf_dir: /etc/dhcp
+advanced_dhcp_server_conf_file: /etc/dhcpd.conf
+advanced_dhcp_server_conf_dir: /etc/dhcpd.d

--- a/roles/advanced_core/advanced_dhcp_server/vars/Suse_12.yml
+++ b/roles/advanced_core/advanced_dhcp_server/vars/Suse_12.yml
@@ -5,5 +5,5 @@ advanced_dhcp_server_services_to_start:
   - dhcpd
 advanced_dhcp_server_firewall_services_to_add:
   - dhcp
-advanced_dhcp_server_conf_file: /etc/dhcp/dhcpd.conf
-advanced_dhcp_server_conf_dir: /etc/dhcp
+advanced_dhcp_server_conf_file: /etc/dhcpd.conf
+advanced_dhcp_server_conf_dir: /etc/dhcpd.d

--- a/roles/advanced_core/advanced_dhcp_server/vars/Ubuntu.yml
+++ b/roles/advanced_core/advanced_dhcp_server/vars/Ubuntu.yml
@@ -3,3 +3,5 @@ advanced_dhcp_server_packages_to_install:
   - isc-dhcp-server
 advanced_dhcp_server_services_to_start:
   - isc-dhcp-server
+advanced_dhcp_server_conf_file: /etc/dhcp/dhcpd.conf
+advanced_dhcp_server_conf_dir: /etc/dhcp

--- a/roles/advanced_core/advanced_dhcp_server/vars/main.yml
+++ b/roles/advanced_core/advanced_dhcp_server/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-advanced_dhcp_server_role_version: 1.1.1
+advanced_dhcp_server_role_version: 1.1.2


### PR DESCRIPTION
Updated the `advanced_dhcp_server` role to work with OpenSUSE/SLES for issue #696 