### PR TITLE
Feat: dhcp_server - Add capability to choose ipxe ROM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
     - Allow to choose between root or sudo user. (#687)
   - clushershell:
     - fix an idempotency problem of role clustershell (#675)
+  - dhcp_server:
+    - Add capability to choose ipxe ROM. (#698)
   - nfs_server:
     - Add auto directories creation capability. (#685)
   - nic:

--- a/roles/core/dhcp_server/defaults/main.yml
+++ b/roles/core/dhcp_server/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 dhcp_server_default_lease_time: 600  # Consider to increase once in production
 dhcp_server_max_lease_time: 7200  # Same
+
+dhcp_server_ipxe_driver: snponly
+dhcp_server_ipxe_embed: standard

--- a/roles/core/dhcp_server/readme.rst
+++ b/roles/core/dhcp_server/readme.rst
@@ -54,10 +54,12 @@ Resulting example network could be:
 Finally, note that the following parameters can be set in the inventory, to
 override default ones:
 
-* dhcp_server_default_lease_time (default to 600)
-* dhcp_server_max_lease_time (default to 7200)
+* dhcp_server_default_lease_time (default to 600) to set default lease time
+* dhcp_server_max_lease_time (default to 7200) to set max lease time
+* dhcp_server_ipxe_driver to set ipxe default EFI driver (see main BlueBanquise documentation, equipment profiles variables)
+* dhcp_server_ipxe_embed to set ipxe default embed script (see main BlueBanquise documentation, equipment profiles variables)
 
-Consider increasing the default values once your network is production ready.
+Consider increasing the default leases values once your network is production ready.
 
 Input
 ^^^^^
@@ -89,6 +91,8 @@ Optional inventory vars:
 
 * dhcp_server_default_lease_time
 * dhcp_server_max_lease_time
+* dhcp_server_ipxe_driver
+* dhcp_server_ipxe_embed
 
 * network[item]
    * .dhcp_unknown_range
@@ -117,6 +121,7 @@ Files generated:
 Changelog
 ^^^^^^^^^
 
+* 1.4.0: Add capability to choose ipxe ROM. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.3.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.2.0: Update role to work with OpenSuSE. Neil Munday <neil@mundayweb.com>
 * 1.1.2: Prevent unsorted ranges. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/core/dhcp_server/templates/dhcpd.conf.j2
+++ b/roles/core/dhcp_server/templates/dhcpd.conf.j2
@@ -25,22 +25,38 @@
  # 11 64-bit ARM EFI
  # https://ipxe.org/cfg/platform
 
+{% if dhcp_server_ipxe_driver == 'snponly' %}
+  {% set ipxe_driver = 'snponly_' %}
+{% elif dhcp_server_ipxe_driver == 'snp' %}
+  {% set ipxe_driver = 'snp_' %}
+{% else %}{# Assume everything else is default driver #}
+  {% set ipxe_driver = '' %}
+{% endif %}
+
+{% if dhcp_server_ipxe_embed == 'dhcpretry' %}
+  {% set ipxe_embed = 'dhcpretry' %}
+{% elif dhcp_server_ipxe_embed == 'noshell' %}
+  {% set ipxe_embed = 'noshell' %}
+{% else %}{# Assume everything else is standard script #}
+  {% set ipxe_embed = 'standard' %}
+{% endif %}
+
  option client-arch code 93 = unsigned integer 16;
  if exists client-arch {
    if option client-arch = 00:00 {
-     filename "x86_64/standard_undionly.kpxe";
+     filename "x86_64/{{ ipxe_embed }}_undionly.kpxe";
    } elsif option client-arch = 00:06 {
-     filename "x86/standard_ipxe.efi";
+     filename "x86/{{ ipxe_embed }}_{{ ipxe_driver }}ipxe.efi";
    } elsif option client-arch = 00:07 {
-     filename "x86_64/standard_ipxe.efi";
+     filename "x86_64/{{ ipxe_embed }}_{{ ipxe_driver }}ipxe.efi";
    } elsif option client-arch = 00:08 {
-     filename "x86_64/standard_ipxe.efi";
+     filename "x86_64/{{ ipxe_embed }}_{{ ipxe_driver }}ipxe.efi";
    } elsif option client-arch = 00:09 {
-     filename "x86_64/standard_ipxe.efi";
+     filename "x86_64/{{ ipxe_embed }}_{{ ipxe_driver }}ipxe.efi";
    } elsif option client-arch = 00:0a {
-     filename "arm32/standard_ipxe.efi";
+     filename "arm32/{{ ipxe_embed }}_{{ ipxe_driver }}ipxe.efi";
    } elsif option client-arch = 00:0b {
-     filename "arm64/standard_ipxe.efi";
+     filename "arm64/{{ ipxe_embed }}_{{ ipxe_driver }}ipxe.efi";
    }
  }
 


### PR DESCRIPTION
Allows to switch between ipxe roms with default simple dhcp server. Some hardware need snponly roms, and you may not want to use advanced dhcp server.