### PR TITLE
OpenSUSE / SLES fixes

### DIFF
--- a/roles/core/pxe_stack/readme.rst
+++ b/roles/core/pxe_stack/readme.rst
@@ -173,6 +173,7 @@ To be done
 Changelog
 ^^^^^^^^^
 
+* 1.6.1: Updated to work with both SLES and OpenSUSE and install sudo package if sudo use is enabled. Neil Munday <neil@mundayweb.com>
 * 1.6.0: Allow to choose between root or sudo user. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.5.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.4.1: Extend bootset support for custom htdocs path. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/core/pxe_stack/templates/Suse/autoyast.xml.j2
+++ b/roles/core/pxe_stack/templates/Suse/autoyast.xml.j2
@@ -3,6 +3,7 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
+{% if ep_operating_system['distribution'] == "SLES" %} 
   <add-on>
     <add_on_products config:type="list">
 {% for repo in repositories %}
@@ -18,6 +19,7 @@
 {% endfor %}
     </add_on_products>
   </add-on>
+{% endif %}
 
   <keyboard>
     <keymap>{{hostvars[groups[item][0]]['ep_configuration']['keyboard_layout']|lower}}</keymap>
@@ -39,15 +41,20 @@
   </networking>
 
   <software>
+{% if ep_operating_system['distribution'] == "SLES" %} 
     <products config:type="list">
       <product>SLES</product>
     </products>
+{% endif %}
     <install_recommended config:type="boolean">true</install_recommended>
     <patterns config:type="list">
       <pattern>base</pattern>
     </patterns>
     <packages config:type="list">
       <package>openssh-server</package>
+    {% if pxe_stack_enable_root %}
+      <package>sudo</package>
+    {% endif %}
     </packages>
   </software> 
 

--- a/roles/core/pxe_stack/vars/main.yml
+++ b/roles/core/pxe_stack/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pxe_stack_role_version: 1.6.0
+pxe_stack_role_version: 1.6.1
 
 pxe_stack_supported_os:
 #  centos:

--- a/roles/core/repositories_client/readme.rst
+++ b/roles/core/repositories_client/readme.rst
@@ -130,6 +130,7 @@ sources.list file.
 Changelog
 ^^^^^^^^^
 
+* 1.3.1: Updated SUSE subtask to handle missing repo definition when repo is a dictionary. Neil Munday <neil@mundayweb.com>
 * 1.3.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.2.0: Add OpenSuSE support and correct ansible warning for included tasks loop. Neil Munday <neil@mundayweb.com>
 * 1.1.3: Improve Ubuntu support. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/roles/core/repositories_client/tasks/Suse/main.yml
+++ b/roles/core/repositories_client/tasks/Suse/main.yml
@@ -15,7 +15,7 @@
   community.general.zypper_repository:
     name: "{{ item.name | default(item) }}"
     description: "{{ item.name | default(item) }} gen by Ansible"
-    repo: "{{ item.repo | default(baseurl_prefix + item.repo | default(item)) }}"
+    repo: "{{ item.repo | default(baseurl_prefix + item.repo | default(item.name | default(item))) }}"
     disable_gpg_check: "{{ item.disable_gpg_check | default(omit) }}"
     auto_import_keys: "{{ item.disable_gpg_check | default(omit) }}"
     autorefresh: "{{ item.autorefresh | default(omit) }}"

--- a/roles/core/repositories_client/vars/main.yml
+++ b/roles/core/repositories_client/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-repositories_client_role_version: 1.3.0
+repositories_client_role_version: 1.3.1


### PR DESCRIPTION
**pxe_stack**

- Handle installation of `sudo` package if sudo usage has been chosen
- Only set product and add on repositories if using SLES - not applicable to OpenSUSE

**repositories_client**

- Update SUSE sub task to better handle a repository definition where a dictionary is use. For example:

```
repositories:
  - name: oss
    disable_gpg_check: true
```

With the current code, this definition causes an error. With my modification this is no longer the case.