### PR TITLE
Fix: powerman - error when ep_host_authentication does not contain IPMI credentials

### DIFF
--- a/roles/core/powerman/templates/powerman.conf.j2
+++ b/roles/core/powerman/templates/powerman.conf.j2
@@ -29,25 +29,36 @@ include "/etc/powerman/ipmipower.dev"
       {% else %}{# BMC is defined outside host #}
         {% set credentials_host = hostvars[host]['bmc']['name'] %}{# Define external bmc as credentials source #}
       {% endif %}
-      {# Gather BMC credentials settings #}
-      {% if hostvars[credentials_host]['ep_host_authentication'] is defined %}{# Check if host_authentication is defined #}
-        {% set host_bmc_user = (hostvars[credentials_host]['ep_host_authentication'] | selectattr('protocol','match','IPMI') | map(attribute='user') | list | first) %}
-        {% set host_bmc_password = (hostvars[credentials_host]['ep_host_authentication'] | selectattr('protocol','match','IPMI') | map(attribute='password') | list | first) %}
+      {# Look for BMC credentials #}
+      {% if hostvars[credentials_host]['ep_host_authentication'] is defined %}
+        {# Found ep_host_authentication settings, use them #}
+        {% set ipmi_credentials = (hostvars[credentials_host]['ep_host_authentication'] | selectattr('protocol','match','IPMI')) %}
+        {% if ipmi_credentials | length > 0 %}
+          {# Found IPMI credentials from ep_host_authentication, save first entry #}
+          {% set host_bmc_user = (ipmi_credentials | map(attribute='user') | list | first) %}
+          {% set host_bmc_password = (ipmi_credentials | map(attribute='password') | list | first) %}
+        {% else %}
+          {# Did not find IPMI credentials, will not add this BMC #}
+          {% set host_bmc_user = '' %}
+          {% set host_bmc_password = '' %}
+        {% endif %}
       {% else %}{# Fall back to equipment_authentication | DATAMODEL 2.0 DEPRECATION #}
         {% set host_bmc_user = hostvars[credentials_host]['ep_equipment_authentication']['user'] %}
         {% set host_bmc_password = hostvars[credentials_host]['ep_equipment_authentication']['password'] %}
       {% endif %}
       {# Check if this set of credentials have been used before in a previous host #}
-      {% if host_bmc_user not in credentials_dict -%}
+      {% if host_bmc_user and host_bmc_user not in credentials_dict -%}
         {# new user credential, create a dictionary entry for it #}
         {{ credentials_dict.update({host_bmc_user: {}}) }}
       {%- endif %}
-      {% if host_bmc_password not in credentials_dict[host_bmc_user] -%}
+      {% if host_bmc_password and host_bmc_password not in credentials_dict[host_bmc_user] -%}
         {# new password credential, create an inner dictionary entry for it #}
         {{ credentials_dict[host_bmc_user].update({host_bmc_password: []}) }}
       {%- endif %}
       {# Add this host to the set of hosts with the same credentials #}
-      {{ credentials_dict[host_bmc_user][host_bmc_password].append(host) }}
+      {% if host_bmc_user and host_bmc_password -%}
+        {{ credentials_dict[host_bmc_user][host_bmc_password].append(host) }}
+      {%- endif %}
     {%- endif %}
   {% endfor %}
   {# Render entries for each set of nodes with the same credentials #}


### PR DESCRIPTION
We had an issue with our customized inventory that provides ep_host_authentication. The automatically generated inventory may contain devices that are considered MC of BMCs, and these devices connect via SNMP. In that case, the list of credentials in ep_host_authentication does not contain any IPMI credentials.

This inventory created an error in powerman role: the "first" filter failed when trying to match the IPMI protocol in the entries.

The proposed fix checks if there are any IPMI credentials in ep_host_authentication before adding credentials to credentials_dict dictionary. It also makes sure not to add the BMC device if there are no IPMI credentials for it (this avoids a "more plugs than nodes" error that happens if the number of devices does not match the number of nodes).

This fix should not affect behavior of inventories that only use the IPMI protocol for credentials.

There are other ways that we could deal with this inventory, e.g. we could use ep_equipment_authentication anyway (not necessary for our use case), or configure powerman role to support SNMP (this would be a new feature).