### PR TITLE
Fix: all - Remove netaddr packages in roles

### DIFF
--- a/.github/workflows/global_centos_7.yml
+++ b/.github/workflows/global_centos_7.yml
@@ -44,7 +44,7 @@ jobs:
         run: sudo modprobe -v dummy numdummies=2; sudo ip addr add 10.10.0.1/16 dev dummy0; ip a;
 
       - name: Install packages
-        run: pip3 install ansible netaddr clustershell jmespath
+        run: pip3 install -r requirements.txt
 
       - name: Install collections
         run: ansible-galaxy collection install community.general

--- a/.github/workflows/global_opensuseleap_15.yml
+++ b/.github/workflows/global_opensuseleap_15.yml
@@ -44,7 +44,7 @@ jobs:
         run: sudo modprobe -v dummy numdummies=2; sudo ip addr add 10.10.0.1/16 dev dummy0; ip a;
 
       - name: Install packages
-        run: pip3 install ansible netaddr clustershell jmespath
+        run: pip3 install -r requirements.txt
 
       - name: Install collections
         run: ansible-galaxy collection install community.general

--- a/.github/workflows/global_rocky_8.yml
+++ b/.github/workflows/global_rocky_8.yml
@@ -44,7 +44,7 @@ jobs:
         run: sudo modprobe -v dummy numdummies=2; sudo ip addr add 10.10.0.1/16 dev dummy0; ip a;
 
       - name: Install packages
-        run: pip3 install ansible netaddr clustershell jmespath
+        run: pip3 install -r requirements.txt
 
       - name: Install collections
         run: ansible-galaxy collection install community.general

--- a/.github/workflows/global_ubuntu_20.04.yml
+++ b/.github/workflows/global_ubuntu_20.04.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-python@v1
 
       - name: Install packages
-        run: pip3 install ansible netaddr clustershell jmespath
+        run: pip3 install -r requirements.txt
 
       - name: Install collections
         run: ansible-galaxy collection install community.general

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 #### Roles improvement or fix
 
+  - all:
+    - Remove netaddr packages in roles (#713)
   - pxe_stack:
     - Extend bootset support for custom htdocs path (#676)
     - Allow to choose between root or sudo user. (#687)

--- a/roles/advanced_core/advanced_dhcp_server/vars/Suse.yml
+++ b/roles/advanced_core/advanced_dhcp_server/vars/Suse.yml
@@ -1,7 +1,6 @@
 ---
 advanced_dhcp_server_packages_to_install:
   - dhcp-server
-  - python3-netaddr
 advanced_dhcp_server_services_to_start:
   - dhcpd
 advanced_dhcp_server_firewall_services_to_add:

--- a/roles/advanced_core/advanced_dns_server/vars/Ubuntu.yml
+++ b/roles/advanced_core/advanced_dns_server/vars/Ubuntu.yml
@@ -1,6 +1,5 @@
 ---
 advanced_dns_server_packages_to_install:
   - bind9
-  - python-netaddr
 advanced_dns_server_services_to_start:
   - bind9

--- a/roles/core/dhcp_server/vars/Suse.yml
+++ b/roles/core/dhcp_server/vars/Suse.yml
@@ -1,7 +1,6 @@
 ---
 dhcp_server_packages_to_install:
   - dhcp-server
-  - python3-netaddr
 dhcp_server_services_to_start:
   - dhcpd
 dhcp_server_firewall_services_to_add:

--- a/roles/core/dhcp_server/vars/Ubuntu.yml
+++ b/roles/core/dhcp_server/vars/Ubuntu.yml
@@ -1,7 +1,6 @@
 ---
 dhcp_server_packages_to_install:
   - isc-dhcp-server
-  - python-netaddr
 dhcp_server_services_to_start:
   - isc-dhcp-server
 dhcp_server_conf_file: /etc/dhcp/dhcpd.conf

--- a/roles/core/dns_server/vars/Ubuntu.yml
+++ b/roles/core/dns_server/vars/Ubuntu.yml
@@ -1,7 +1,6 @@
 ---
 dns_server_packages_to_install:
   - bind9
-  - python-netaddr
 dns_server_services_to_start:
   - bind9
 dns_server_dump_file: /var/named/data/cache_dump.db


### PR DESCRIPTION
Fix packages installation that should no more occur since all deps comes from pip (requirements.txt).

This is last PR before 1.6 release as no more blocking bug were reported.