### PR TITLE
Fix: flush handlers at the end of role repositories_client

### DIFF
--- a/roles/core/repositories_client/tasks/main.yml
+++ b/roles/core/repositories_client/tasks/main.yml
@@ -14,3 +14,6 @@
     loop_var: outer_item
   tags:
     - internal
+
+- name: meta ░ Run handler tasks to update the package manager's cache
+  ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
Hi,

To allow subsequent roles to install packages.

Thanks!
