### PR TITLE
Improve idempotency of role pxe_stack

### DIFF
--- a/roles/core/pxe_stack/tasks/client_os/Ubuntu.yml
+++ b/roles/core/pxe_stack/tasks/client_os/Ubuntu.yml
@@ -73,9 +73,9 @@
     - file
 
 - name: file █ Create cloud-init empty meta-data
-  ansible.builtin.file:
-    path: "{{ pxe_stack_htdocs_path }}/preboot_execution_environment/equipment_profiles/{{ item | replace(equipment_naming+'_','') | trim }}.cloud-init/meta-data"
-    state: touch
+  ansible.builtin.copy:
+    dest: "{{ pxe_stack_htdocs_path }}/preboot_execution_environment/equipment_profiles/{{ item | replace(equipment_naming+'_','') | trim }}.cloud-init/meta-data"
+    content: ""
     mode: 0644
     owner: "{{ pxe_stack_apache_user }}"
     group: "{{ pxe_stack_apache_group }}"


### PR DESCRIPTION
Hi!

This is only while creating the Ubuntu cloud-init empty "meta-data" file.  The Ansible module "file" 'touch'es the "meta-data" file every time the role is played (modifying the access time of the "meta-data" file).  Suggesting to replace with the Ansible module "copy" with an empty content.

Thanks!
