### PR TITLE
fix: in role dns_server, check if network is defined

### DIFF
--- a/roles/core/dns_server/readme.rst
+++ b/roles/core/dns_server/readme.rst
@@ -115,6 +115,7 @@ Files generated:
 Changelog
 ^^^^^^^^^
 
+* 1.5.2: Bug fix for bond interfaces with no network defined.
 * 1.5.1: Add recursion management. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.5.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.4.1: Bug fix for issue #682. Neil Munday <neil@mundayweb.com>

--- a/roles/core/dns_server/templates/named.conf.j2
+++ b/roles/core/dns_server/templates/named.conf.j2
@@ -97,7 +97,7 @@ zone "{{ octets.split('.')|reverse|join('.') }}.in-addr.arpa" IN {
 {% for host in groups['all'] %}
   {% if hostvars[host]['network_interfaces'] is defined %}
     {% for interface in hostvars[host]['network_interfaces'] %}
-      {% if interface['ip4'] is defined and networks[interface['network']]['is_in_dns'] %}
+      {% if interface['network'] is defined and interface['ip4'] is defined and networks[interface['network']]['is_in_dns'] %}
         {% set ip_prefix = interface['ip4'].split('.')[0:3]|join('.') %}
         {% if ip_prefix not in ip_networks %}
           {{ ip_networks.append(ip_prefix) }}

--- a/roles/core/dns_server/vars/main.yml
+++ b/roles/core/dns_server/vars/main.yml
@@ -6,7 +6,7 @@ j2_dns_server_get_first_octets: "
 {%- for host in groups['all'] -%}
   {%- if hostvars[host]['network_interfaces'] is defined -%}
     {%- for interface in hostvars[host]['network_interfaces'] -%}
-      {%- if interface['network'] == outer_item and  interface['ip4'] is defined and networks[interface['network']]['is_in_dns'] -%}
+      {%- if interface['network'] is defined and interface['network'] == outer_item and  interface['ip4'] is defined and networks[interface['network']]['is_in_dns'] -%}
         {%- set ip_prefix = interface['ip4'].split('.')[0:3]|join('.') -%}
         {%- if ip_prefix not in ip_networks -%}
           {{ ip_networks.append(ip_prefix) }}

--- a/roles/core/dns_server/vars/main.yml
+++ b/roles/core/dns_server/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-dns_server_role_version: 1.5.1
+dns_server_role_version: 1.5.2
 
 j2_dns_server_get_first_octets: "
 {%- set ip_networks = [] -%}


### PR DESCRIPTION
Hi!

For network interfaces which are bond slaves, the `network` parameter may not be defined (since it is defined in the bond master interface), which leads the `dns_server` role to fail.
Suggesting to check whether `network` is defined.  Might be useful to additionally check `if network is not none`?

Thanks!
