### PR TITLE
fix: to prepare bootswitch, retrieve from kernel cmd line only the necessary variables

### DIFF
--- a/roles/core/pxe_stack/tasks/client_os/DGX.yml
+++ b/roles/core/pxe_stack/tasks/client_os/DGX.yml
@@ -94,7 +94,7 @@
       {% endfor %}
         4_bb: ["curtin", "in-target", "--", "sh", "-c", "sed -i 's/^#PermitRootLogin.*$/PermitRootLogin yes/g' /etc/ssh/sshd_config"]
         5_bb: ["curtin", "in-target", "--", "sh", "-c", "sed -i 's|^root:.:|root:{{ hostvars[groups[item][0]]['authentication_root_password_sha512'] }}:|' /etc/shadow"]
-        6_bb: ["curtin", "in-target", "--", "sh", "-c", 'set -- `cat /proc/cmdline`; for I in $*; do case "$I" in *=*) eval $I;; esac; done; curl -s -k http://$ipxe_next_server/cgi-bin/bootswitch.cgi --data "node=$node_hostname&boot=next";']
+        6_bb: ["curtin", "in-target", "--", "sh", "-c", 'for I in `cat /proc/cmdline | tr " " "\n" | grep -E "^(node_hostname|ipxe_next_server)="` ; do eval $I; done; curl -s -k http://$ipxe_next_server/cgi-bin/bootswitch.cgi --data "node=$node_hostname&boot=disk"']
         7_bb: ["curtin", "in-target", "--", "sh", "-c", '/bin/echo -e "network:\n  version: 2\n  ethernets:"> /etc/netplan/01-netcfg.yaml; for i in $(ip link show | grep ':\ en' | awk -F ' ' '{print $2}' | sed 's/://'); do /bin/echo -e "\n    $i:\n      dhcp4: true" >> /etc/netplan/01-netcfg.yaml; done;']
         # 8_bb: ["curtin", "in-target", "--", "sh", "-c", 'efibootmgr -o $(efibootmgr | grep BootCurrent | cut -d" " -f2),$(efibootmgr | grep BootOrder | sed "s/BootOrder:\ //" | sed "s/$(efibootmgr | grep BootCurrent | cut -d" " -f2),//")']
         9_bb: ["curtin", "in-target", "--", "sh", "-c", "apt-get remove -y nvidia-oem-config-eula"]

--- a/roles/core/pxe_stack/templates/RedHat/kickstart.cfg.j2
+++ b/roles/core/pxe_stack/templates/RedHat/kickstart.cfg.j2
@@ -146,8 +146,7 @@ echo '{{ pxe_stack_sudo_user }} ALL=(ALL:ALL) ALL' >> /etc/sudoers.d/{{ pxe_stac
 
 # Turn the kernel parameters into variables
 # We are looking for next_server value
-set -- `cat /proc/cmdline`
-for I in $*; do case "$I" in *=*) eval $I;; esac; done
+for I in `cat /proc/cmdline | tr " " "\n" | grep -E "^(node_hostname|ipxe_next_server)="` ; do eval $I; done
 
 echo "All went well, we can inform next-server we succeeded"
 curl -s -k http://$ipxe_next_server/cgi-bin/bootswitch.cgi --data "node=$node_hostname&boot=disk"

--- a/roles/core/pxe_stack/templates/Suse/autoyast.xml.j2
+++ b/roles/core/pxe_stack/templates/Suse/autoyast.xml.j2
@@ -193,8 +193,7 @@ fi
 
 # Turn the kernel parameters into variables
 # We are looking for next_server value
-set -- `cat /proc/cmdline`
-for I in $*; do case "$I" in *=*) eval $I;; esac; done
+for I in `cat /proc/cmdline | tr " " "\n" | grep -E "^ipxe_next_server="` ; do eval $I; done
 
 echo "All went well, we can inform next-server we succeeded"
 curl -s -k http://$ipxe_next_server/cgi-bin/bootswitch.cgi --data "node=$(hostname -s)&boot=disk"

--- a/roles/core/pxe_stack/templates/Suse/autoyast_sles12.xml.j2
+++ b/roles/core/pxe_stack/templates/Suse/autoyast_sles12.xml.j2
@@ -152,8 +152,7 @@ fi
 
 # Turn the kernel parameters into variables
 # We are looking for next_server value
-set -- `cat /proc/cmdline`
-for I in $*; do case "$I" in *=*) eval $I;; esac; done
+for I in `cat /proc/cmdline | tr " " "\n" | grep -E "^ipxe_next_server="` ; do eval $I; done
 
 echo "All went well, we can inform next-server we succeeded"
 curl -s -k http://$ipxe_next_server/cgi-bin/bootswitch.cgi --data "node=$(hostname -s)&boot=disk"

--- a/roles/core/pxe_stack/templates/Ubuntu/preseed.cfg.j2
+++ b/roles/core/pxe_stack/templates/Ubuntu/preseed.cfg.j2
@@ -125,7 +125,7 @@ d-i preseed/late_command string \
 {% if hostvars[groups[item][0]]['ep_preserve_efi_first_boot_device'] == true %}
   in-target sh -c '[ -d /sys/firmware/efi ] && efibootmgr -o $(efibootmgr | grep BootCurrent | cut -d" " -f2),$(efibootmgr | grep BootOrder | sed "s/BootOrder:\ //" | sed "s/$(efibootmgr | grep BootCurrent | cut -d" " -f2),//") || echo "Not an EFI system, skipping"'
 {% endif %}
-  in-target set -- `cat /proc/cmdline`; for I in $*; do case "$I" in *=*) eval $I;; esac; done; \
+  in-target for I in `cat /proc/cmdline | tr " " "\n" | grep -E "^(node_hostname|ipxe_next_server)="` ; do eval $I; done; \
   in-target echo Next server is $ipxe_next_server; \
   in-target curl -s -k http://$ipxe_next_server/cgi-bin/bootswitch.cgi --data "node=$node_hostname&boot=disk";
 

--- a/roles/core/pxe_stack/templates/Ubuntu/user-data.j2
+++ b/roles/core/pxe_stack/templates/Ubuntu/user-data.j2
@@ -48,5 +48,5 @@ autoinstall:
 {% if hostvars[groups[item][0]]['ep_preserve_efi_first_boot_device'] == true %}
     - sh -c '[ -d /sys/firmware/efi ] && efibootmgr -o $(efibootmgr | grep BootCurrent | cut -d" " -f2),$(efibootmgr | grep BootOrder | sed "s/BootOrder:\ //" | sed "s/$(efibootmgr | grep BootCurrent | cut -d" " -f2),//") || echo "Not an EFI system, skipping"'
 {% endif %}
-    - curtin in-target --target=/target -- sh -c 'set -- `cat /proc/cmdline`; for I in $*; do case "$I" in *=*) eval $I;; esac; done; curl -s -k http://$ipxe_next_server/cgi-bin/bootswitch.cgi --data "node=$node_hostname&boot=disk";'
+    - curtin in-target --target=/target -- sh -c 'for I in `cat /proc/cmdline | tr " " "\n" | grep -E "^(node_hostname|ipxe_next_server)="` ; do eval $I; done; curl -s -k http://$ipxe_next_server/cgi-bin/bootswitch.cgi --data "node=$node_hostname&boot=disk"'
 


### PR DESCRIPTION
Hi!

Some kernel options may contain dots (like `modprobe.blacklist=`, `rd.driver.blacklist=`, `pciehp.pciehp_debug=`, etc.), so we can't evaluate those options as shell variables when preparing the bootswitch.
The idea here is to only retrieve the necessary kernel cmd line options to evaluate them as shell vars, before curl'ing the bootswitch.

Thanks!