### PR TITLE
fix: pxe_stack role — rationalize single and double quote nested usage

### DIFF
--- a/roles/core/pxe_stack/tasks/client_os/DGX.yml
+++ b/roles/core/pxe_stack/tasks/client_os/DGX.yml
@@ -95,7 +95,7 @@
         4_bb: ["curtin", "in-target", "--", "sh", "-c", "sed -i 's/^#PermitRootLogin.*$/PermitRootLogin yes/g' /etc/ssh/sshd_config"]
         5_bb: ["curtin", "in-target", "--", "sh", "-c", "sed -i 's|^root:.:|root:{{ hostvars[groups[item][0]]['authentication_root_password_sha512'] }}:|' /etc/shadow"]
         6_bb: ["curtin", "in-target", "--", "sh", "-c", 'set -- `cat /proc/cmdline`; for I in $*; do case "$I" in *=*) eval $I;; esac; done; curl -s -k http://$ipxe_next_server/cgi-bin/bootswitch.cgi --data "node=$node_hostname&boot=next";']
-        7_bb: ["curtin", "in-target", "--", "sh", "-c", '/bin/echo -e "network:\n  version: 2\n  ethernets:"> /etc/netplan/01-netcfg.yaml; for i in $(ip link show | grep ':\ en' | awk -F ' ' '{print $2}' | sed 's/://'); do /bin/echo -e "\n    $i:\n      dhcp4: true" >> /etc/netplan/01-netcfg.yaml; done;']
+        7_bb: ["curtin", "in-target", "--", "sh", "-c", '/bin/echo -e "network:\n  version: 2\n  ethernets:"> /etc/netplan/01-netcfg.yaml; for i in $(ip -br l | grep "^en" | cut -d" " -f1); do /bin/echo -e "\n    $i:\n      dhcp4: true" >> /etc/netplan/01-netcfg.yaml; done']
         # 8_bb: ["curtin", "in-target", "--", "sh", "-c", 'efibootmgr -o $(efibootmgr | grep BootCurrent | cut -d" " -f2),$(efibootmgr | grep BootOrder | sed "s/BootOrder:\ //" | sed "s/$(efibootmgr | grep BootCurrent | cut -d" " -f2),//")']
         9_bb: ["curtin", "in-target", "--", "sh", "-c", "apt-get remove -y nvidia-oem-config-eula"]
   with_items: "{{ j2_equipment_groups_list }}"


### PR DESCRIPTION
Hi!

When tweaking the DGX-OS curtin file to configure all network interfaces in DHCP after 1st reboot in the so-called "late commands", fix improper use of single & double quotes (don't use single quotes for both inner quotes and outer quotes).
Here: using single quotes as outer, and double quotes as inner because when need shell variable expansion.
Also simplifying the code a little.

Thanks!