### PR TITLE
Fix bootstrap.sh iso copy [rhel-like]

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -89,7 +89,7 @@ if $GATHER_PACKAGES; then
       else
         if $OFFLINE_MODE; then
           cp -a "$CURRENT_DIR/offline_bootstrap/iso/$REDHAT_8_ISO"\
-          "{REPO_PATH}"
+          "${REPO_PATH}"
         else
           wget -P "{REPO_PATH}" "${REDHAT_8_ISO_URL}"
         fi


### PR DESCRIPTION
fix a wrong variable call for ${REPO_PATH} on the copy iso step for el8 platform.