### PR TITLE
Fix: issue 731

### DIFF
--- a/roles/core/powerman/tasks/main.yml
+++ b/roles/core/powerman/tasks/main.yml
@@ -4,7 +4,6 @@
     name:
       - freeipmi
       - powerman
-      - bluebanquise-filters
     state: present
   tags:
     - package


### PR DESCRIPTION
Fix issue #731
Filter package is no more needed since file is embed into role at https://github.com/bluebanquise/bluebanquise/blob/master/roles/core/powerman/filter_plugins/nodeset.py