### PR TITLE
Update the "diskless_usr_lib_dir" var to /usr/lib

### DIFF
--- a/roles/core/diskless/vars/RedHat_8.yml
+++ b/roles/core/diskless/vars/RedHat_8.yml
@@ -1,6 +1,6 @@
 ---
 diskless_htdocs_path: /var/www/html/preboot_execution_environment
-diskless_usr_lib_dir: /usr/lib64
+diskless_usr_lib_dir: /usr/lib
 diskless_apache_user: apache
 diskless_python_version: 3.6
 diskless_packages_to_install:


### PR DESCRIPTION
The real files provided by the tool on the latest version is under /usr/lib:  ( at least for the el8 version)

$ rpm -qa bluebanquise-disklessset
bluebanquise-disklessset-1.3.7-1.el8.noarch

$ rpm -ql bluebanquise-disklessset
/usr/bin/bluebanquise-disklessset
/usr/bin/disklessset
/usr/lib/python3.6/site-packages/diskless/__pycache__
/usr/lib/python3.6/site-packages/diskless/__pycache__/image_manager.cpython-36.opt-1.pyc
/usr/lib/python3.6/site-packages/diskless/__pycache__/image_manager.cpython-36.pyc
/usr/lib/python3.6/site-packages/diskless/__pycache__/kernel_manager.cpython-36.opt-1.pyc
/usr/lib/python3.6/site-packages/diskless/__pycache__/kernel_manager.cpython-36.pyc
/usr/lib/python3.6/site-packages/diskless/__pycache__/utils.cpython-36.opt-1.pyc
/usr/lib/python3.6/site-packages/diskless/__pycache__/utils.cpython-36.pyc
/usr/lib/python3.6/site-packages/diskless/image_manager.py
/usr/lib/python3.6/site-packages/diskless/kernel_manager.py
/usr/lib/python3.6/site-packages/diskless/modules
/usr/lib/python3.6/site-packages/diskless/modules/__pycache__
/usr/lib/python3.6/site-packages/diskless/modules/__pycache__/base_module.cpython-36.opt-1.pyc
/usr/lib/python3.6/site-packages/diskless/modules/__pycache__/base_module.cpython-36.pyc
/usr/lib/python3.6/site-packages/diskless/modules/__pycache__/demo_module.cpython-36.opt-1.pyc
/usr/lib/python3.6/site-packages/diskless/modules/__pycache__/demo_module.cpython-36.pyc
/usr/lib/python3.6/site-packages/diskless/modules/__pycache__/livenet_module.cpython-36.opt-1.pyc
/usr/lib/python3.6/site-packages/diskless/modules/__pycache__/livenet_module.cpython-36.pyc
/usr/lib/python3.6/site-packages/diskless/modules/__pycache__/nfs_module.cpython-36.opt-1.pyc
/usr/lib/python3.6/site-packages/diskless/modules/__pycache__/nfs_module.cpython-36.pyc
/usr/lib/python3.6/site-packages/diskless/modules/base_module.py
/usr/lib/python3.6/site-packages/diskless/modules/demo_module.py
/usr/lib/python3.6/site-packages/diskless/modules/livenet_module.py
/usr/lib/python3.6/site-packages/diskless/modules/nfs_module.py
/usr/lib/python3.6/site-packages/diskless/utils.py
