### PR TITLE
added pip updating for offline bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -147,6 +147,7 @@ fi
 if $INSTALL_PIP_REQUIREMENTS; then
   message_output "Installing python needed dependencies via pip3..."
   if $OFFLINE_MODE; then
+    sudo pip3 install --upgrade pip --no-index --find-links "${CURRENT_DIR}/offline_bootstrap/pip3/"
     pip3 install --no-index\
                  --find-links "${CURRENT_DIR}/offline_bootstrap/pip3/"\
                  -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ ansible>=4.10.0
 netaddr>=0.7.19
 clustershell
 jmespath>=0.9.5
+# Only to support offline bootstrap
+pip


### PR DESCRIPTION
To solve this:

Collecting ansible>=4.10.0 (from -r requirements.txt (line 1))
Collecting netaddr>=0.7.19 (from -r requirements.txt (line 2))
Collecting clustershell (from -r requirements.txt (line 3))
Collecting jmespath>=0.9.5 (from -r requirements.txt (line 4))
Collecting Cython (from -r requirements.txt (line 6))
Collecting ansible-core~=2.11.7 (from ansible>=4.10.0->-r requirements.txt (line 1))
Collecting importlib-resources; python_version < "3.7" (from netaddr>=0.7.19->-r requirements.txt (line 2))
Collecting PyYAML (from clustershell->-r requirements.txt (line 3))
Collecting jinja2 (from ansible-core~=2.11.7->ansible>=4.10.0->-r requirements.txt (line 1))
Collecting cryptography (from ansible-core~=2.11.7->ansible>=4.10.0->-r requirements.txt (line 1))
    Complete output from command python setup.py egg_info:
    
            =============================DEBUG ASSISTANCE==========================
            If you are seeing an error here please try the following to
            successfully install cryptography:
    
            Upgrade to the latest pip and try again. This will fix errors for most
            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
            =============================DEBUG ASSISTANCE==========================
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-5zdk9g4u/cryptography/setup.py", line 14, in <module>
        from setuptools_rust import RustExtension
    ModuleNotFoundError: No module named 'setuptools_rust'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-5zdk9g4u/cryptography/
