### PR TITLE
ci: update to ansible-lint v6.5

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,3 +4,5 @@ warn_list:
 verbosity: 1
 skip_list:
   - fqcn-builtins
+  - jinja[spacing]
+  - name[casing]

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-python@v1
 
       - name: Install packages
-        run: pip install ansible ansible-lint flake8 yamllint
+        run: pip install ansible 'ansible-lint<6.6' flake8 yamllint
 
       - name: Check python code
         run: flake8 . --statistics --ignore E501,E226

--- a/roles/advanced_core/advanced_dns_server/tasks/master.yml
+++ b/roles/advanced_core/advanced_dns_server/tasks/master.yml
@@ -13,7 +13,7 @@
 - name: set_fact ░ Set SOA Serial for forward zone
   set_fact:
     serial: "{{ lookup('pipe', 'date +%s') }}"
-  when: zoneconf.changed  # noqa 503
+  when: zoneconf.changed  # noqa no-handler
   tags:
     - template
     - internal
@@ -26,7 +26,7 @@
     group: root
     mode: 0644
   notify: service █ Restart dns services
-  when: zoneconf.changed  # noqa 503
+  when: zoneconf.changed  # noqa no-handler
   tags:
     - template
 
@@ -44,7 +44,7 @@
 - name: set_fact ░ Set SOA Serial for reverse zone
   set_fact:
     serial: "{{ lookup('pipe', 'date +%s') }}"
-  when: zoneconf.changed  # noqa 503
+  when: zoneconf.changed  # noqa no-handler
   tags:
     - template
     - internal
@@ -57,6 +57,6 @@
     group: root
     mode: 0644
   notify: service █ Restart dns services
-  when: zoneconf.changed  # noqa 503
+  when: zoneconf.changed  # noqa no-handler
   tags:
     - template

--- a/roles/core/conman/tasks/main.yml
+++ b/roles/core/conman/tasks/main.yml
@@ -57,7 +57,7 @@
     - ansible_facts.os_family == "RedHat"
 
 - name: file █ Create /var/log/conman directory
-  ansible.builtin.file:  # noqa 208
+  ansible.builtin.file:  # noqa risky-file-permissions
     path: /var/log/conman
     setype: "{{ (ansible_facts.selinux.status == 'enabled') | ternary('conman_log_t', omit) }}"
     state: directory

--- a/roles/core/dns_server/tasks/main.yml
+++ b/roles/core/dns_server/tasks/main.yml
@@ -80,7 +80,7 @@
 - name: set_fact ░ Set SOA Serial for reverse zone
   ansible.builtin.set_fact:
     serial: "{{ lookup('pipe', 'date +%s') }}"
-  when: zoneconf.changed  # noqa 503
+  when: zoneconf.changed  # noqa no-handler
   tags:
     - template
     - internal
@@ -93,7 +93,7 @@
     group: root
     mode: 0644
   notify: service █ Restart dns services
-  when: zoneconf.changed  # noqa 503
+  when: zoneconf.changed  # noqa no-handler
   tags:
     - template
 
@@ -117,7 +117,7 @@
     mode: 0644
   notify: service █ Restart dns services
   with_items: "{{ j2_dns_server_get_first_octets.split(',') }}"
-  when: zoneconf.changed  # noqa 503
+  when: zoneconf.changed  # noqa no-handler
   tags:
     - template
 
@@ -129,7 +129,7 @@
     group: root
     mode: 0644
   notify: service █ Restart dns services
-  when: dns_overrides is defined and zoneconf.changed  # noqa 503
+  when: dns_overrides is defined and zoneconf.changed  # noqa no-handler
   tags:
     - template
 

--- a/roles/core/log_server/tasks/main.yml
+++ b/roles/core/log_server/tasks/main.yml
@@ -46,7 +46,7 @@
     - package
 
 - name: file █ Create /var/log/rsyslog directory
-  ansible.builtin.file:  # noqa 208
+  ansible.builtin.file:  # noqa risky-file-permissions
     path: /var/log/rsyslog
     setype: var_log_t
     state: directory

--- a/roles/core/nfs_client/tasks/main.yml
+++ b/roles/core/nfs_client/tasks/main.yml
@@ -29,7 +29,7 @@
     - package
 
 - name: file █ Create NFS directories
-  ansible.builtin.file:  # noqa 208
+  ansible.builtin.file:  # noqa risky-file-permissions
     path: "{{ item.0.mount }}"
     state: directory
   with_subelements:


### PR DESCRIPTION
The recent release of ansible-lint v6.5 brings some breaking changes.
Pin the version to 6.5.x, so any future update won't break the CI out of
the blue.

Disable jinja[spacing]: there might be an interest to run it later.

Disable name[casing]: this is not compatible with the task naming
convention of this project.