### PR TITLE
Fix override.j2

### DIFF
--- a/roles/core/dns_server/templates/override.j2
+++ b/roles/core/dns_server/templates/override.j2
@@ -1,5 +1,5 @@
 $TTL 60
-@            IN    SOA  localhost. root.localhost.  (
+@            IN    SOA  {{ inventory_hostname }}.{{ domain_name }}. root.{{ domain_name }}.  (
                           {{ serial }} ; serial
                           1h           ; refresh
                           30m          ; retry


### PR DESCRIPTION
Fix override configuration file to use same zone as cluster, otherwise de domain will not be searched correctly