### PR TITLE
feat: nic - Add support for MTU in Ubuntu

### DIFF
--- a/collections/infrastructure/plugins/modules/networkd.py
+++ b/collections/infrastructure/plugins/modules/networkd.py
@@ -48,6 +48,7 @@ class Networkd(object):
         self.dns4 = module.params['dns4']
         self.method4 = module.params['method4']
         self.mode = module.params['mode']
+        self.mtu = module.params['mtu']
         self.vlanid = module.params['vlanid']
         self.vlandev = module.params['vlandev']
 
@@ -92,6 +93,11 @@ class Networkd(object):
                 network.append("Gateway=" + route4.split(' ')[1])
                 if len(route4.split(' ')) > 2:
                     network.append("Metric=" + route4.split(' ')[2])
+
+        # LINK
+        if self.mtu is not None:
+            network.append("[Link]")
+            network.append("MTUBytes=" + self.mtu)
 
         return network
 
@@ -145,6 +151,7 @@ def main():
             method4=dict(type='str', choices=['auto', 'link-local', 'manual', 'shared', 'disabled']),
             mode=dict(type='str', default='balance-rr',
                       choices=['802.3ad', 'active-backup', 'balance-alb', 'balance-rr', 'balance-tlb', 'balance-xor', 'broadcast']),
+            mtu=dict(type='str'),
             vlanid=dict(type='int'),
             vlandev=dict(type='str'),
         ),

--- a/collections/infrastructure/roles/nic/tasks/Ubuntu/main.yml
+++ b/collections/infrastructure/roles/nic/tasks/Ubuntu/main.yml
@@ -27,12 +27,12 @@
     gw4: "{{ j2_nic_gw4 | trim | default(omit,true) }}"
     routes4: "{{ j2_nic_routes4 | trim | default(omit,true) }}"
     dns4: "{{ j2_nic_dns4 | trim | default(omit,true) }}"
+    mtu: "{{ item.mtu | default(omit) }}"
     type: "{{ item.type | default('ethernet') }}"  # Even if in the documentation type is optional, it is in fact mandatory. Default to ethernet.
     # Standard
     state: "{{ item.state | default('present') }}"
     master: "{{ item.master | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
-    mtu: "{{ item.mtu | default(omit) }}"
     method4: "{{ item.method4 | default(omit) }}"
     vlanid: "{{ item.vlanid | default(omit) }}"
     vlandev: "{{ item.vlandev | default(omit) }}"

--- a/collections/infrastructure/roles/nic/tasks/Ubuntu/main.yml
+++ b/collections/infrastructure/roles/nic/tasks/Ubuntu/main.yml
@@ -32,6 +32,7 @@
     state: "{{ item.state | default('present') }}"
     master: "{{ item.master | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
+    mtu: "{{ item.mtu | default(omit) }}"
     method4: "{{ item.method4 | default(omit) }}"
     vlanid: "{{ item.vlanid | default(omit) }}"
     vlandev: "{{ item.vlandev | default(omit) }}"


### PR DESCRIPTION
Add MTUBytes in [Link] section if mtu is provided for an interface.

Test input:
```
          network_interfaces:
            - interface: eth_ips_mtu
              ip4: 10.10.0.1/16,10.10.0.2/16  # Multiple ip possible
              gw4: 10.10.0.254
              mtu: 8000
              network: ice1-1
```

Correct output: 
```
[Match]
Name=eth_ips_mtu
[Network]
DNS=10.10.0.1
[Address]
Address=10.10.0.1/16
Address=10.10.0.2/16
[Route]
Gateway=10.10.0.254
[Link]
MTUBytes=8000
```