### PR TITLE
Feat nic bond options

### DIFF
--- a/collections/infrastructure/plugins/modules/networkd.py
+++ b/collections/infrastructure/plugins/modules/networkd.py
@@ -33,6 +33,14 @@ def write_list_to_file(list1, filepath):
         f.write(it + "\n")
     f.close()
 
+
+def check_milliseconds_field_is_digit(networkd,  name):
+    networkd_field = getattr(networkd, name)
+    if networkd_field is not None and not networkd_field.isdigit():
+        msg = name + " should only contain numbers representing milliseconds"
+        networkd.module.fail_json(msg=msg)
+
+
 class Networkd(object):
 
     def __init__(self, module):
@@ -126,13 +134,13 @@ class Networkd(object):
             else:
                 netdev.append("Mode=802.3ad")
             if self.miimon is not None:
-                netdev.append("MIIMonitorSec=" + self.miimon)
+                netdev.append("MIIMonitorSec=" + self.miimon + "ms")
             if self.updelay is not None:
-                netdev.append("UpDelaySec=" + self.updelay)
+                netdev.append("UpDelaySec=" + self.updelay + "ms")
             if self.downdelay is not None:
-                netdev.append("DownDelaySec=" + self.downdelay)
+                netdev.append("DownDelaySec=" + self.downdelay + "ms")
             if self.arp_interval is not None:
-                netdev.append("ARPIntervalSec=" + self.arp_interval)
+                netdev.append("ARPIntervalSec=" + self.arp_interval + "ms")
             if self.arp_ip_target is not None:
                 netdev.append("ARPIPTargets=" + self.arp_ip_target)
 
@@ -191,6 +199,10 @@ def main():
     # check for issues
     if networkd.conn_name is None:
         networkd.module.fail_json(msg="Please specify a name for the connection")
+    check_milliseconds_field_is_digit(networkd, "miimon")
+    check_milliseconds_field_is_digit(networkd, "updelay")
+    check_milliseconds_field_is_digit(networkd, "downdelay")
+    check_milliseconds_field_is_digit(networkd, "arp_interval")
 
     try:
         if networkd.state == 'absent':

--- a/collections/infrastructure/plugins/modules/networkd.py
+++ b/collections/infrastructure/plugins/modules/networkd.py
@@ -40,6 +40,9 @@ class Networkd(object):
         self.conn_name = module.params['conn_name']
         self.master = module.params['master']
         self.state = module.params['state']
+        self.arp_interval = module.params['arp_interval']
+        self.arp_ip_target = module.params['arp_ip_target']
+        self.downdelay = module.params['downdelay']
         self.ifname = module.params['ifname']
         self.type = module.params['type']
         self.ip4 = module.params['ip4']
@@ -47,8 +50,10 @@ class Networkd(object):
         self.routes4 = module.params['routes4']
         self.dns4 = module.params['dns4']
         self.method4 = module.params['method4']
+        self.miimon = module.params['miimon']
         self.mode = module.params['mode']
         self.mtu = module.params['mtu']
+        self.updelay = module.params['updelay']
         self.vlanid = module.params['vlanid']
         self.vlandev = module.params['vlandev']
 
@@ -120,6 +125,16 @@ class Networkd(object):
                 netdev.append("Mode=" + self.mode)
             else:
                 netdev.append("Mode=802.3ad")
+            if self.miimon is not None:
+                netdev.append("MIIMonitorSec=" + self.miimon)
+            if self.updelay is not None:
+                netdev.append("UpDelaySec=" + self.updelay)
+            if self.downdelay is not None:
+                netdev.append("DownDelaySec=" + self.downdelay)
+            if self.arp_interval is not None:
+                netdev.append("ARPIntervalSec=" + self.arp_interval)
+            if self.arp_ip_target is not None:
+                netdev.append("ARPIPTargets=" + self.arp_ip_target)
 
         # VLAN
         if self.type == "vlan":
@@ -135,6 +150,9 @@ def main():
             state=dict(type='str', required=True, choices=['absent', 'present']),
             conn_name=dict(type='str', required=True),
             master=dict(type='str'),
+            arp_interval=dict(type='str'),
+            arp_ip_target=dict(type='str'),
+            downdelay=dict(type='str'),
             ifname=dict(type='str'),
             type=dict(type='str',
                       choices=[
@@ -151,7 +169,9 @@ def main():
             method4=dict(type='str', choices=['auto', 'link-local', 'manual', 'shared', 'disabled']),
             mode=dict(type='str', default='balance-rr',
                       choices=['802.3ad', 'active-backup', 'balance-alb', 'balance-rr', 'balance-tlb', 'balance-xor', 'broadcast']),
+            miimon=dict(type='str'),
             mtu=dict(type='str'),
+            updelay=dict(type='str'),
             vlanid=dict(type='int'),
             vlandev=dict(type='str'),
         ),

--- a/collections/infrastructure/roles/nic/tasks/Ubuntu/main.yml
+++ b/collections/infrastructure/roles/nic/tasks/Ubuntu/main.yml
@@ -31,9 +31,14 @@
     type: "{{ item.type | default('ethernet') }}"  # Even if in the documentation type is optional, it is in fact mandatory. Default to ethernet.
     # Standard
     state: "{{ item.state | default('present') }}"
+    arp_interval: "{{ item.arp_interval | default(omit) }}"
+    arp_ip_target: "{{ item.arp_ip_target | default(omit) }}"
+    downdelay: "{{ item.downdelay | default(omit) }}"
     master: "{{ item.master | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
+    miimon: "{{ item.miimon | default(omit) }}"
     method4: "{{ item.method4 | default(omit) }}"
+    updelay: "{{ item.updelay | default(omit) }}"
     vlanid: "{{ item.vlanid | default(omit) }}"
     vlandev: "{{ item.vlandev | default(omit) }}"
   notify: command <|> networkctl reload


### PR DESCRIPTION
Adding options for bond interfaces on Ubuntu + systemd-networkd.
Checking that the input does not contain any "s", or "ms" for time intervals, since we are following nmcli convention and it assumes a number representing milliseconds.

Example input:
```
            - interface: bond0
              ip4: 10.10.0.1
              network: ice1-1
              type: bond
              mode: 802.3ad
              miimon: 900
```

Output for bond0.netdev:
```
[NetDev]
Name=bond0
Kind=bond
[Bond]
Mode=802.3ad
MIIMonitorSec=900ms
```
Note: had to look around for the acceptance of "900ms", since it is not documented. See here https://bugs.launchpad.net/netplan/+bug/1745597

