### PR TITLE
fix: nic - Create one [Address] section for each IP address in Ubuntu

### DIFF
--- a/collections/infrastructure/plugins/modules/networkd.py
+++ b/collections/infrastructure/plugins/modules/networkd.py
@@ -90,9 +90,9 @@ class Networkd(object):
 
         # ADDRESS
         if self.method4 == "manual" or self.method4 is None:
-            network.append("[Address]")
             if self.ip4 is not None:
                 for ip4 in self.ip4:
+                    network.append("[Address]")
                     network.append("Address=" + ip4)
 
         # ADDRESS


### PR DESCRIPTION
Multiple IPs were being rendered like this:

```
[Match]
Name=eth_ips_mtu
[Network]
DNS=10.10.0.1
[Address]
Address=10.10.0.1/16
Address=10.10.0.2/16
[Route]
Gateway=10.10.0.254
```

systemd-networkd does not like that, fixing so that each address gets its own [Address] field:

```
[Match]
Name=eth_ips_mtu
[Network]
DNS=10.10.0.1
[Address]
Address=10.10.0.1/16
[Address]
Address=10.10.0.2/16
[Route]
Gateway=10.10.0.254
```