### PR TITLE
feat: repositories_client - Support gpgkey for Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
     - Bug fix for bond interfaces with no network defined (#722)
   - pxe_stack:
     - Add force main NIC and fix gateway (#723)
+  - repositories:
+    - Support gpgkey for Ubuntu (#762)
 
 ## 1.6.0
 

--- a/collections/infrastructure/roles/repositories/readme.rst
+++ b/collections/infrastructure/roles/repositories/readme.rst
@@ -130,6 +130,7 @@ sources.list file.
 Changelog
 ^^^^^^^^^
 
+* 1.3.3: Support gpgkey for Ubuntu. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.3.2: Flush handlers at the end of role repositories_client. #sla31
 * 1.3.1: Updated SUSE subtask to handle missing repo definition when repo is a dictionary. Neil Munday <neil@mundayweb.com>
 * 1.3.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/repositories/tasks/Ubuntu/main.yml
+++ b/collections/infrastructure/roles/repositories/tasks/Ubuntu/main.yml
@@ -17,6 +17,15 @@
     - ep_operating_system['distribution'] is defined and ep_operating_system['distribution'] is not none
     - (ep_operating_system['distribution_version'] is defined and ep_operating_system['distribution_version'] is not none) or (ep_operating_system['distribution_major_version'] is defined and ep_operating_system['distribution_major_version'] is not none)
 
+- name: set_fact <|> Initialize trust_option_by_repo
+  ansible.builtin.set_fact:
+    trust_option_by_repo: >-
+      {{ trust_option_by_repo | default([]) | combine(
+        {item.name: 'signed-by=' + item.gpgkey}
+        if ((item.gpgcheck is defined and item.gpgcheck | bool) and (item.gpgkey is defined and item.gpgkey | length > 0 )) else
+        {item.name: 'trusted=yes'}) }}
+  with_items: "{{ bb_repositories }}"
+
 - name: file <|+> Disable sources.list repositories
   ansible.builtin.replace:
     path: /etc/apt/sources.list
@@ -43,7 +52,7 @@
 
 - name: apt_repository <|+> Setting custom repositories
   ansible.builtin.apt_repository:
-    repo: "{{ item.repo | default('deb [trusted=yes] ' + (repositories_client_baseurl_prefix | default('', true)) + ( item.name | default(item, true) | string ) + ' ' + ( item.distribution | default('./', true) )) }}"
+    repo: "{{ item.repo | default('deb [' + trust_option_by_repo[item.name] + '] ' + (repositories_client_baseurl_prefix | default('', true)) + ( item.name | default(item, true) | string ) + ' ' + ( item.distribution | default('./', true) )) }}"
     state: "{{ item.state | default('present') }}"
     codename: "{{ item.codename | default(omit) }}"
     filename: "{{ item.filename | default(omit) }}"

--- a/collections/infrastructure/roles/repositories/vars/main.yml
+++ b/collections/infrastructure/roles/repositories/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-repositories_client_role_version: 1.3.2
+repositories_client_role_version: 1.3.3


### PR DESCRIPTION
Support gpgkey/gpgcheck options for Ubuntu in repositories_client role.

Given the input:

```
repositories:
  - name: repo-no-gpg
  - name: repo-with-gpg
    gpgcheck: 1
    gpgkey: /usr/share/keyrings/gpgkey-12345678-keyring.gpg
    distribution: jammy main
```

The following output is produced at /etc/apt/sources.list.d 
```
deb [trusted=yes] http://10.10.0.1/repositories//ubuntu/20.04/x86_64/repo-no-gpg ./
```  
```
deb [signed-by=/usr/share/keyrings/gpgkey-12345678-keyring.gpg] http://10.10.0.1/repositories//ubuntu/20.04/x86_64/repo-with-gpg jammy main
```

Note: `apt update` command requires the key in `signed-by` option to be present, otherwise the command will fail.