### PR TITLE
monitoring/roles/grafana: allow to run as non-root

### DIFF
--- a/collections/monitoring/roles/grafana/tasks/dashboards.yml
+++ b/collections/monitoring/roles/grafana/tasks/dashboards.yml
@@ -2,6 +2,7 @@
 - name: dashboards █ Download Opensource Grafana dashboards
   delegate_to: localhost
   run_once: true
+  become: false
   block:
     - name: dashboards █ Create local grafana dashboard directory
       ansible.builtin.tempfile:


### PR DESCRIPTION
When running role grafana as non-root user within a playbook that uses `become: true`, the download of dashboards is performed by root.

However, following tasks that loop over `with_fileglob` cannot find downloaded files because the fileglob is performed by non-root playbook caller and cannot read download directory.

Adding `become: false` in the download part allows to correctly find the files.
