### PR TITLE
Conman - add logrotate configuration

### DIFF
--- a/collections/infrastructure/roles/conman/README.md
+++ b/collections/infrastructure/roles/conman/README.md
@@ -74,6 +74,7 @@ Once these pam_limits parameter pushed, restart conman daemon.
 
 ## Changelog
 
+* 1.4.1: Add logrotate file. Matthieu Isoard <indigoping4cgmi@gmail.com>
 * 1.4.0: Update to BB 2.0 format. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.3.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.2.0: Add OpenSuSE support. Neil Munday <neil@mundayweb.com>

--- a/collections/infrastructure/roles/conman/tasks/main.yml
+++ b/collections/infrastructure/roles/conman/tasks/main.yml
@@ -104,6 +104,22 @@
   tags:
     - template
 
+- name: logrotate <|> Check if /etc/logrotated.d/conman file exists
+  ansible.builtin.stat: 
+    path: /etc/logrotated.d/conman
+  register: logrotate_conman
+
+- name: logrotate <|> Generate /etc/logrotated.d/conman
+  ansible.builtin.template:
+    src: conman.logrotate.j2
+    dest: /etc/logrotated.d/conman
+    owner: conman
+    group: conman
+    mode: 0600
+  when: not logrotate_conman.stat.exists
+  tags:
+    - template
+
 - name: seboolean <|> Allow all daemons the ability to use unallocated ttys
   ansible.posix.seboolean:
     name: daemons_use_tty

--- a/collections/infrastructure/roles/conman/templates/conman.logrotate.j2
+++ b/collections/infrastructure/roles/conman/templates/conman.logrotate.j2
@@ -1,0 +1,19 @@
+#jinja2: lstrip_blocks: "True"
+#### Blue Banquise file ####
+## {{ ansible_managed }}
+
+/var/log/conman/*.log {
+  compress
+  dateext
+  missingok
+  nocopytruncate
+  nocreate
+  nodelaycompress
+  nomail
+  rotate 4
+  sharedscripts
+  weekly
+  postrotate
+    /usr/bin/killall -HUP conmand
+  endscript
+}

--- a/collections/infrastructure/roles/conman/vars/main.yml
+++ b/collections/infrastructure/roles/conman/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-conman_role_version: 1.4.0
+conman_role_version: 1.4.1
 
 conman_execpath: "/usr/lib/conman/exec"
 


### PR DESCRIPTION
Implementing Issue #754.

Conman role:

- Add a new template file in conman for logrotate
- Update tasks to deploy it
- Update READMe and vars for this new release of the conman role.