### PR TITLE
fix: advanced_dhcp_server : file Create /etc/dhcp

### DIFF
--- a/resources/legacy/roles/advanced_core/advanced_dhcp_server/tasks/main.yml
+++ b/resources/legacy/roles/advanced_core/advanced_dhcp_server/tasks/main.yml
@@ -48,7 +48,7 @@
 
 - name: "file █ Create {{ advanced_dhcp_server_conf_dir }}"
   ansible.builtin.file:
-    path: "{{ dhcp_server_conf_dir }}"
+    path: "{{ advanced_dhcp_server_conf_dir }}"
     owner: root
     mode: "0755"
     state: directory


### PR DESCRIPTION
Hello,

during the installation of the advanced DHCP role, I encountered this error:

```
TASK [advanced_dhcp_server : file █ Create /etc/dhcp] ***********************************************************************************************************************************************************************************
Monday 30 January 2023  10:04:43 +0100 (0:00:01.636)       0:00:04.166 ********
fatal: [mngt-01]: FAILED! =>
  msg: |-
    The task includes an option with an undefined variable. The error was: 'dhcp_server_conf_dir' is undefined

    The error appears to be in '/root/bluebanquise/roles/advanced_core/advanced_dhcp_server/tasks/main.yml': line 49, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:

    - name: "file █ Create {{ advanced_dhcp_server_conf_dir }}"
      ^ here
    We could be wrong, but this one looks like it might be an issue with
    missing quotes. Always quote template expression brackets when they
    start a value. For instance:

        with_items:
          - {{ foo }}

    Should be written as:

        with_items:
          - "{{ foo }}"
```

Here is my suggested fix.

best regards,