### PR TITLE
fix: rsyslog - 768 bug rsyslog server not writing locally apps logs not being fowarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
     - Add force main NIC and fix gateway (#723)
   - repositories:
     - Support gpgkey for Ubuntu (#762)
+  - rsyslog:
+    - More precise rules for logroation;write log server local messages also in /var/log/;write app messages in /var/log/rsyslog/ (#771)
 
 ## 1.6.0
 

--- a/collections/logging/roles/rsyslog/README.md
+++ b/collections/logging/roles/rsyslog/README.md
@@ -1,4 +1,4 @@
-# Log 
+# Log
 
 ## Description
 
@@ -80,6 +80,7 @@ log_client_configuration_files:
 
 ## Changelog
 
+* 1.4.1: Register server local apps locally;more precise logrotate wildcards. <boubee.thiago@gmail.com>
 * 1.4.0: Merge both client and server. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.3.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.2.1: Add OpenSuSE support. Neil Munday <neil@mundayweb.com>

--- a/collections/logging/roles/rsyslog/templates/rsyslog_logrotate.j2
+++ b/collections/logging/roles/rsyslog/templates/rsyslog_logrotate.j2
@@ -1,7 +1,18 @@
 #### Blue Banquise file ####
 ## {{ansible_managed}}
 
-/var/log/rsyslog/*/* {
+/var/log/rsyslog/*/*.log
+/var/log/rsyslog/*/messages
+/var/log/rsyslog/*/cron
+/var/log/rsyslog/*/secure
+/var/log/rsyslog/*/maillog
+/var/log/rsyslog/*/spooler
+{
     daily
+    missingok
     rotate 5
-}
+    sharedscripts
+    postrotate
+        /usr/bin/systemctl try-restart rsyslog-server.service > /dev/null 2>/dev/null || true
+    endscript
+ }

--- a/resources/legacy/roles/core/rsyslog/templates/server.conf.j2
+++ b/resources/legacy/roles/core/rsyslog/templates/server.conf.j2
@@ -38,3 +38,17 @@ uucp,news.crit ?Spooler
 # Save boot messages also to boot.log
 $template Boot,"/var/log/rsyslog/%HOSTNAME%/boot.log"
 local7.* ?Boot
+
+# Rules for processing remote app logs
+$template RemoteLogs,"/var/log/rsyslog/%HOSTNAME%/%PROGRAMNAME%.log"
+*.* ?RemoteLogs
+
+# Also save logs of log_server locally
+if $fromhost-ip == '127.0.0.1' then {
+  *.info;mail.none;authpriv.none;cron.none                /var/log/messages
+  authpriv.*                                              /var/log/secure
+  mail.*                                                  -/var/log/maillog
+  cron.*                                                  /var/log/cron
+  uucp,news.crit                                          /var/log/spooler
+  local7.*                                                /var/log/boot.log
+}


### PR DESCRIPTION
The rule
```
$template RemoteLogs,"/var/log/rsyslog/%HOSTNAME%/%PROGRAMNAME%.log"
*.* ?RemoteLogs
```
was present before and was wrongly removed. It allows app messages to be stored at rsyslog subfolder, otherwise they are lost in the log server.

The block
```
if $fromhost-ip == '127.0.0.1' then {
  *.info;mail.none;authpriv.none;cron.none                /var/log/messages
  authpriv.*                                              /var/log/secure
  mail.*                                                  -/var/log/maillog
  cron.*                                                  /var/log/cron
  uucp,news.crit                                          /var/log/spooler
  local7.*                                                /var/log/boot.log
}
```
makes so that in a HA scenario those logs are also written in /var/log of the running server. Otherwise they are only present in /var/rsyslog/$HOSTNAME, which usually is a shared/remote disk.

This part
```
/var/log/rsyslog/*/*.log
/var/log/rsyslog/*/messages
/var/log/rsyslog/*/cron
/var/log/rsyslog/*/secure
/var/log/rsyslog/*/maillog
/var/log/rsyslog/*/spooler
{
    daily
    missingok
    rotate 5
    sharedscripts
    postrotate
        /usr/bin/systemctl try-restart rsyslog-server.service > /dev/null 2>/dev/null || true
    endscript
 }
```
contains more specific wildcards instead of /var/log/rsyslog/\*/\* because this make logrotate try to rotate already rotated files, including possibly compressed ones.
"missingok" is to not give errors on missing files.
The lines after sharedscripts are, including it, are to run the command to try to restart the server once after rotating all logs.
It was taken from examples at [logrotate manual](https://www.unix.com/man-page/redhat/8/logrotate/).
It seems to be a good practice to restart the log server and the logging applications after changing the log files.