### PR TITLE
clustershell upgrade: 1.2.1

### DIFF
--- a/collections/infrastructure/roles/clustershell/README.md
+++ b/collections/infrastructure/roles/clustershell/README.md
@@ -7,11 +7,11 @@ It can be used in combinaison with other BlueBanquise stack tools, like `blueban
 
 ## Instructions
 
-By default, role will not install Clustershell, since Clustershell is already a base 
+By default, role will not install Clustershell, since Clustershell is already a base
 requirement for the BlueBanquise stack. However, if for any reasons you wish the role to install it,
 set either variables `clustershell_install_from_pip` or `clustershell_install_from_package` to true.
 
-`clustershell_install_from_pip` will uses pip to install Clustershell, while `clustershell_install_from_package` 
+`clustershell_install_from_pip` will uses pip to install Clustershell, while `clustershell_install_from_package`
 will rely on system native packages manager to install it.
 
 Once role has been deployed, check groups using:
@@ -20,14 +20,101 @@ Once role has been deployed, check groups using:
 nodeset -LL
 ```
 
+## Custom nodeset Map
+
+By default, the role generates ClusterShell groups based on the Ansible inventory.
+
+However, you can generate custom groups with other names and also clusters (see man 5 groups.conf) using the role.
+
+If you want to customize, you must configure as below:
+
+1. Change the ``clustershell_custom_map`` variable to true inside the ``defaults`` folder.
+2. Create an inventory called ``clush.yml`` inside ``inventory/group_vars/all/addons`` with the following structure:
+
+```yaml
+---
+clush:
+  all:
+    all:
+     - '@adm'
+     - '@io'
+     - '@computes'
+  adm:
+    mngt:
+      - mngt0-1
+      - mngt0-2
+  io:
+    oss:
+      - oss[1-2]
+    mds:
+      - mds[1-2]
+  computes:
+    cpu:
+      - cpu[1-10]
+    gpu:
+      - gpu[1-10]
+```
+
+**Comments:**
+
+The first keys (which in the example are *all, adm, io and computes*) will be used to generate the name of the groups in ***local.cfg*** and the name of the roles in ***cluster.yaml***:
+
+The second keys (which in the example are *mngt, oss, mds, cpu, gpu*) will be used to generate the name of the groups inside the ***cluster.yaml***.
+
+You can use groups from the file itself. See below how we used the *adm*, *io* and *computes* keys to generate the group.
+
+The above configuration would generate the following nodeset:
+
+```shell
+@adm mngt0-[1-2]
+@all cpu[1-10],gpu[1-10],mds[1-2],mngt0-[1-2],oss[1-2]
+@computes cpu[1-10],gpu[1-10]
+@io mds[1-2],oss[1-2]
+@all:all cpu[1-10],gpu,mds,mngt0-[1-2],oss[1-2]
+@adm:mngt mngt0-[1-2]
+@io:mds mds[1-2]
+@io:oss oss[1-2]
+@computes:cpu cpu[1-10]
+@computes:gpu gpu[1-10]
+```
+
+With this configuration, you will be able to take advantage of customized names for your nodesets and also the Cluster functionality, which allows you to use ClusterShell in two different ways:
+
+1. *Simple nodeset*:
+
+```shell
+[root@mngt0-1 ~]# clush -bw @io echo ok
+---------------
+mds[1-2],oss[1-2] (4)
+---------------
+ok
+```
+
+2. *Cluster nodeset*:
+
+```shell
+[root@mngt0-1 ~]# clush -bw @io:mds echo ok
+---------------
+mds[1-2] (2)
+---------------
+ok
+
+[root@mngt0-1 ~]# clush -bw @io:oss echo ok
+---------------
+oss[1-2] (2)
+---------------
+ok
+```
+
 ## To be done
 
 Tree execution mode is missing.
 
 ## Changelog
 
+* 1.2.1: Added cluster feature and custom nodeset mapping. Leonardo Araujo <lmagdanello40@gmail.com>
 * 1.2.0: Update to BB 2.0 format. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.1.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.2: Prevent dummy user to be included. Documentation. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.1: Fixed bad template. Documentation. johnnykeats <johnny.keats@outlook.com>
-* 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com> 
+* 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/clustershell/defaults/main.yml
+++ b/collections/infrastructure/roles/clustershell/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 clustershell_install_from_package: false
 clustershell_install_from_pip: false
+clustershell_custom_map: false

--- a/collections/infrastructure/roles/clustershell/tasks/main.yml
+++ b/collections/infrastructure/roles/clustershell/tasks/main.yml
@@ -33,3 +33,26 @@
     mode: 0644
   tags:
     - template
+  when: clustershell_custom_map == false
+
+- name: cluster <|> Create clusters.yaml if clush inventory exists
+  ansible.builtin.template:
+    src: cluster.yaml.j2
+    dest: /etc/clustershell/groups.d/cluster.yaml
+    owner: root
+    group: root
+    mode: 0644
+  tags:
+    - template
+  when: clush is defined and clustershell_custom_map
+
+- name: cluster <|> Create local.cfg with mapping names
+  ansible.builtin.template:
+    src: local.cfg.mapping.j2
+    dest: /etc/clustershell/groups.d/local.cfg
+    owner: root
+    group: root
+    mode: 0644
+  tags:
+    - template
+  when: clush is defined and clustershell_custom_map

--- a/collections/infrastructure/roles/clustershell/templates/cluster.yaml.j2
+++ b/collections/infrastructure/roles/clustershell/templates/cluster.yaml.j2
@@ -1,0 +1,15 @@
+{% if clush is defined %}
+#### Blue Banquise file ####
+## {{ansible_managed}}
+
+{% for roles, groups in clush.items() %}
+{{ roles }}:
+{% for group, node in groups.items() %}
+{% if '@' in node|string %}
+  {{ group }}: '{% for item in node %}{{ item }}:{{ clush[item | replace("@", "")].keys()|join(",") }}{% if not loop.last %},{% endif %}{% endfor %}'
+{% else %}
+  {{ group }}: '{{ node|join(',')|trim }}'
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endif %}

--- a/collections/infrastructure/roles/clustershell/templates/local.cfg.j2
+++ b/collections/infrastructure/roles/clustershell/templates/local.cfg.j2
@@ -1,9 +1,9 @@
 #### Blue Banquise file ####
 ## {{ansible_managed}}
 
-{% for gr, nodes in groups.items() %}
-{% if (gr | string) != 'ungrouped' %}
-{{ gr }}: {% for node in nodes | sort %}{% if loop.first %}{{ node }}{% else %},{{ node }}{% endif %}{% endfor %}
+{% for gr, gr_vars in groups.items() %}
+{% if (gr|string) != 'ungrouped' %}
+{{ gr }}: {% set gr_vars_without_dummy = gr_vars | reject("equalto", "dummy") %}{% for node in gr_vars_without_dummy | sort %}{{ node }}{% if not loop.last %},{% endif %}{% endfor %}
 
 {% endif %}
 {% endfor %}

--- a/collections/infrastructure/roles/clustershell/templates/local.cfg.mapping.j2
+++ b/collections/infrastructure/roles/clustershell/templates/local.cfg.mapping.j2
@@ -1,0 +1,10 @@
+{% if clush is defined %}
+#### Blue Banquise file ####
+## {{ansible_managed}}
+
+{% for roles, groups in clush.items() %}
+{% for group, node in groups.items() %}
+{{ roles }}: {{ node|join(',')|trim }}
+{% endfor %}
+{% endfor %}
+{% endif %}

--- a/collections/infrastructure/roles/clustershell/vars/main.yml
+++ b/collections/infrastructure/roles/clustershell/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-clustershell_role_version: 1.2.0
+clustershell_role_version: 1.2.1


### PR DESCRIPTION
(fix): Configured local.cfg template to ignore the node called dummy, which was impacting generation of the @all nodeset. Fix bug #741

(feat): added feature so that the user can configure a set of custom mapping nodes and use the Clusters functionality (@nodeset:groups).

(docs): added tutorial on how to configure a custom mapping nodeset and how to use Clusters functionality with ClusterShell.

## Describe your changes

I created three new tasks for the role: 

- 1: Generate the default local.cfg, based on the Ansible inventory, if the custom_map variable is false. 
- 2 and 3: Generate local.cfg and cluster.yaml based on the created clush.yml inventory, which creates a custom nodeset and adds clustering functionality.

## Issue ticket number and link if any
#741 

## Checklist before requesting a review
- [x] Document introduced changes / variables in role README.md if any
- [x] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [x] Update changelog inside role README.md
- [x] If not present, please also add your name in the related collection authors list in galaxy.yml