### PR TITLE
(backport for BB 1.6) fix: advanced_dhcp_server : file Create /etc/dhcp

### DIFF
--- a/roles/advanced_core/advanced_dhcp_server/tasks/main.yml
+++ b/roles/advanced_core/advanced_dhcp_server/tasks/main.yml
@@ -48,7 +48,7 @@
 
 - name: "file █ Create {{ advanced_dhcp_server_conf_dir }}"
   ansible.builtin.file:
-    path: "{{ dhcp_server_conf_dir }}"
+    path: "{{ advanced_dhcp_server_conf_dir }}"
     owner: root
     mode: "0755"
     state: directory


### PR DESCRIPTION
Backport for PR #770 into stable-1.6
(cherry picked from commit d8832d86c6e75ac69bfe86607e0372f67d8de8ce)