### PR TITLE
infrastructure/dns_server: find correct default resolution network in reverse zone

### DIFF
--- a/collections/infrastructure/roles/dns_server/README.md
+++ b/collections/infrastructure/roles/dns_server/README.md
@@ -52,6 +52,7 @@ This will cause `/var/named/override` to be generated.
 
 ## Changelog
 
+* 1.7.1: Find correct default resolution network in reverse zone. Alexandra Darrieutort <alexandra.darrieutort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.7.0: Add optional alias to every interface. Matthieu Isoard <indigoping4cgmi@gmail.com>
 * 1.6.0: Update to BB 2.0 format. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.5.3: Bug fix for issue #724. Neil Munday <neil@mundayweb.com>

--- a/collections/infrastructure/roles/dns_server/templates/reverse.j2
+++ b/collections/infrastructure/roles/dns_server/templates/reverse.j2
@@ -17,7 +17,7 @@ $INCLUDE "{{ dns_server_named_dir }}/{{ item }}.rr.soa"
     {% for nic in host_dict['network_interfaces'] %}
       {% if nic.network is defined and nic.ip4 is defined and (networks[nic.network].is_in_dns | default(true)) and nic.ip4 is not none and (nic.ip4 | ansible.utils.ipaddr) and nic.ip4.split('.')[0:3]|join('.') == item %}
 {{ create_record(nic.ip4, [[host, nic.network]|join('-'), bb_domain_name | default(dns_server_domaine_name)] | join('.')) }}
-        {% if item == host_j2_node_main_resolution_network %}
+        {% if host_j2_node_main_resolution_address.split('.')[0:3]|join('.') == item %}
 {{ create_record(nic.ip4, [host, bb_domain_name | default(dns_server_domaine_name)] | join('.')) }}
         {% endif %}
       {% endif %}

--- a/collections/infrastructure/roles/dns_server/vars/main.yml
+++ b/collections/infrastructure/roles/dns_server/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-dns_server_role_version: 1.7.0
+dns_server_role_version: 1.7.1
 
 j2_dns_server_get_first_octets: "
 {%- set ip_networks = [] -%}


### PR DESCRIPTION
## Describe your changes

Reverse zone definition templates used j2_node_main_resolution_network to select main interface and write short name, but variable `item` is a network address and not a name.

We propose to check against host_j2_node_main_resolution_address prefix address instead


## Issue ticket number and link if any

## Checklist before requesting a review
- [X] Document introduced changes / variables in role README.md if any
- [X] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [X] Update changelog inside role README.md
- [X] If not present, please also add your name in the related collection authors list in galaxy.yml
