### PR TITLE
infrastructure/firewall: enforce firewalld AllowZoneDrifting

### DIFF
--- a/collections/infrastructure/roles/firewall/README.md
+++ b/collections/infrastructure/roles/firewall/README.md
@@ -111,14 +111,22 @@ Optional inventory vars:
     * icmp_block_inversion (bool)
     * masquerade           (bool)
 
+Optional role vars:
+
+* firewalld_allow_zone_drifting: Enforce the state of Firewalld AllowZoneDrifting configuration
+option (default: `false`)
+
 ## Output
 
 Package installed:
 
 * firewall
 
+
+
 ## Changelog
 
+* 1.3.0: Add firewalld_allow_zone_drifting variable. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.2.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.1.3: Add OpenSuSE support. Neil Munday <neil@mundayweb.com>
 * 1.1.2: Adapt role to handle multiple distributions. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/firewall/README.md
+++ b/collections/infrastructure/roles/firewall/README.md
@@ -113,8 +113,8 @@ Optional inventory vars:
 
 Optional role vars:
 
-* firewalld_allow_zone_drifting: Enforce the state of Firewalld AllowZoneDrifting configuration
-option (default: `false`)
+* firewall_firewalld_allow_zone_drifting: Enforce the state of Firewalld
+AllowZoneDrifting configuration option (default: `false`)
 
 ## Output
 

--- a/collections/infrastructure/roles/firewall/defaults/main.yml
+++ b/collections/infrastructure/roles/firewall/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 
-firewalld_allow_zone_drifting: false
+firewall_firewalld_allow_zone_drifting: false

--- a/collections/infrastructure/roles/firewall/defaults/main.yml
+++ b/collections/infrastructure/roles/firewall/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+firewalld_allow_zone_drifting: false

--- a/collections/infrastructure/roles/firewall/tasks/RedHat/main.yml
+++ b/collections/infrastructure/roles/firewall/tasks/RedHat/main.yml
@@ -1,4 +1,12 @@
 ---
+
+- name: "lineinfile <|> Ensure firewalld config AllowZoneDrifting={{ firewalld_allow_zone_drifting | ternary('yes', 'no') }}"
+  ansible.builtin.lineinfile:
+    path: /etc/firewalld/firewalld.conf
+    regexp: "^AllowZoneDrifting=.*$"
+    line: "AllowZoneDrifting={{ firewalld_allow_zone_drifting | ternary('yes', 'no') }}"
+  notify: service <|> Restart firewall services
+
 - name: fail <|> Check presence of required parameters
   ansible.builtin.fail:
     msg: "Bailing out.

--- a/collections/infrastructure/roles/firewall/tasks/RedHat/main.yml
+++ b/collections/infrastructure/roles/firewall/tasks/RedHat/main.yml
@@ -1,10 +1,10 @@
 ---
 
-- name: "lineinfile <|> Ensure firewalld config AllowZoneDrifting={{ firewalld_allow_zone_drifting | ternary('yes', 'no') }}"
+- name: "lineinfile <|> Ensure firewalld config AllowZoneDrifting={{ firewall_firewalld_allow_zone_drifting | ternary('yes', 'no') }}"
   ansible.builtin.lineinfile:
     path: /etc/firewalld/firewalld.conf
     regexp: "^AllowZoneDrifting=.*$"
-    line: "AllowZoneDrifting={{ firewalld_allow_zone_drifting | ternary('yes', 'no') }}"
+    line: "AllowZoneDrifting={{ firewall_firewalld_allow_zone_drifting | ternary('yes', 'no') }}"
   notify: service <|> Restart firewall services
 
 - name: fail <|> Check presence of required parameters

--- a/collections/infrastructure/roles/firewall/vars/main.yml
+++ b/collections/infrastructure/roles/firewall/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-firewall_role_version: 1.2.0
+firewall_role_version: 1.3.0


### PR DESCRIPTION
## Describe your changes

Firewalld is configured with `AllowZoneDrifting=yes` by default on RedHat systems, which seems to be a security risk.

We propose to enforce configuration to `no` by default (based on an ansible variable to allow configuratbility)

## Issue ticket number and link if any

## Checklist before requesting a review
- [X] Document introduced changes / variables in role README.md if any
- [X] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [X] Update changelog inside role README.md
- [X] If not present, please also add your name in the related collection authors list in galaxy.yml
