### PR TITLE
hpc/slurm: allow submitters to contact accounting host

### DIFF
--- a/collections/hpc/roles/slurm/README.md
+++ b/collections/hpc/roles/slurm/README.md
@@ -234,6 +234,7 @@ To enable it on the slurm configuration its required to define `slurm_selecttype
 
 ## Changelog
 
+* 1.2.4: Set accounting host name in `slurm.conf` in order to allow submitters to connect. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.2.3: Fix old CamelCase variables. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.2.2: Improve partition definition readability in slurm.conf. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.2.1: Update to BB 2.0 format. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>

--- a/collections/hpc/roles/slurm/tasks/accounting.yml
+++ b/collections/hpc/roles/slurm/tasks/accounting.yml
@@ -65,3 +65,16 @@
     state: "{{ (start_services | bool) | ternary('started', omit) }}"
   tags:
     - service
+
+- name: "firewalld <|> Add Slurmdbd ports to firewall's {{ slurm_firewall_zone | default('public') }} zone"
+  ansible.posix.firewalld:
+    zone: "{{ slurm_firewall_zone | default('public') }}"
+    port: "{{ slurm_slurmdbd_port }}/tcp"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - ep_firewall | default(false) | bool
+  tags:
+    - firewall

--- a/collections/hpc/roles/slurm/templates/slurm.conf.j2
+++ b/collections/hpc/roles/slurm/templates/slurm.conf.j2
@@ -60,7 +60,7 @@ SelectTypeParameters=CR_Core_Memory,CR_CORE_DEFAULT_DIST_BLOCK,CR_ONE_TASK_PER_C
 {% endif %}
 {% if slurm_enable_accounting %}
 ## Accounting
-AccountingStorageHost=localhost
+AccountingStorageHost={{ slurm_control_machine }}
 AccountingStorageType=accounting_storage/slurmdbd
 JobAcctGatherType=jobacct_gather/linux
 {% endif %}

--- a/collections/hpc/roles/slurm/vars/main.yml
+++ b/collections/hpc/roles/slurm/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-slurm_role_version: 1.2.3
+slurm_role_version: 1.2.4


### PR DESCRIPTION
## Describe your changes

When submitters are not the controller node, they need to be able to connect to slurmdbd for commands like sacct.

This PR sets the AccountingStorageHost variable to the controller host name and opens the corresponding port in the firewall.

## Issue ticket number and link if any

## Checklist before requesting a review
- [X] Document introduced changes / variables in role README.md if any
- [X] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [X] Update changelog inside role README.md
- [X] If not present, please also add your name in the related collection authors list in galaxy.yml
