### PR TITLE
infrastructure/pxe_stack

### DIFF
--- a/collections/infrastructure/roles/pxe_stack/README.md
+++ b/collections/infrastructure/roles/pxe_stack/README.md
@@ -147,6 +147,7 @@ for a group of hosts or even at hostvars level.
 
 ## Changelog
 
+* 1.8.2: RedHat missing rpm. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.8.1: Update to BB 2.0 format again. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.8.0: Update to BB 2.0 format. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.7.0: Add force main NIC and fix gateway. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/pxe_stack/vars/RedHat_8.yml
+++ b/collections/infrastructure/roles/pxe_stack/vars/RedHat_8.yml
@@ -9,6 +9,7 @@ pxe_stack_packages_to_install:
   - bluebanquise-ipxe-arm64
   - httpd
   - python3-policycoreutils
+  - python3-pyyaml
   - policycoreutils
 pxe_stack_default_tftp_package: atftp
 pxe_stack_services_to_start:

--- a/collections/infrastructure/roles/pxe_stack/vars/RedHat_9.yml
+++ b/collections/infrastructure/roles/pxe_stack/vars/RedHat_9.yml
@@ -9,6 +9,7 @@ pxe_stack_packages_to_install:
   - bluebanquise-ipxe-arm64
   - httpd
   - python3-policycoreutils
+  - python3-pyyaml
   - policycoreutils
 pxe_stack_default_tftp_package: atftp
 pxe_stack_services_to_start:

--- a/collections/infrastructure/roles/pxe_stack/vars/main.yml
+++ b/collections/infrastructure/roles/pxe_stack/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pxe_stack_role_version: 1.8.1
+pxe_stack_role_version: 1.8.2
 
 pxe_stack_supported_os:
   redhat:


### PR DESCRIPTION
## Describe your changes

When installed with online-bootstrap, pyyaml package is not available at root level (only in `~bluebanquise/ansible_venv`). It must be available when running pxe_stack role with `become: true`

## Issue ticket number and link if any

## Checklist before requesting a review
- [x] Document introduced changes / variables in role README.md if any
- [x] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [x] Update changelog inside role README.md
- [x] If not present, please also add your name in the related collection authors list in galaxy.yml
