### PR TITLE
infrastructure/firewall: ensure nics are in the correct fw zone

### DIFF
--- a/collections/infrastructure/roles/firewall/README.md
+++ b/collections/infrastructure/roles/firewall/README.md
@@ -126,6 +126,7 @@ Package installed:
 
 ## Changelog
 
+* 1.3.1: Firewalld: enforce interfaces to their relevant zone. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.3.0: Add firewalld_allow_zone_drifting variable. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.2.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.1.3: Add OpenSuSE support. Neil Munday <neil@mundayweb.com>

--- a/collections/infrastructure/roles/firewall/tasks/RedHat/main.yml
+++ b/collections/infrastructure/roles/firewall/tasks/RedHat/main.yml
@@ -21,11 +21,25 @@
 - name: "firewalld <|> Ensure firewall zones exist"
   ansible.posix.firewalld:
     zone: "{{ networks[item]['firewall']['zone'] }}"
-    permanent: yes
+    permanent: true
     state: present
   when: networks[item]['firewall']['zone'] is defined
   loop: "{{ (network_interfaces | map(attribute='network') | list) }}"
   notify: service <|> Restart firewall services
+
+- name: "firewalld <|> Ensure interfaces are in the correct firewall zone"
+  ansible.posix.firewalld:
+    interface: "{{ item.interface }}"
+    zone: "{{ networks[item.network]['firewall']['zone'] }}"
+    permanent: true
+    immediate: true
+    state: enabled
+  when: networks[item.network]['firewall']['zone'] is defined
+  loop: "{{ network_interfaces }}"
+  loop_control:
+    label: "{{ item.interface }} -> {{ networks[item.network]['firewall']['zone'] }}"
+  notify: service <|> Restart firewall services
+
 
 - name: meta <|> Run handler tasks to restart firewall services
   ansible.builtin.meta: flush_handlers

--- a/collections/infrastructure/roles/firewall/vars/main.yml
+++ b/collections/infrastructure/roles/firewall/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-firewall_role_version: 1.3.0
+firewall_role_version: 1.3.1


### PR DESCRIPTION
## Describe your changes

For nodes with multiple NICs, firewalld role didn't set each one in its own firewall zone.

## Issue ticket number and link if any

## Checklist before requesting a review
- [x] Document introduced changes / variables in role README.md if any
- [x] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [x] Update changelog inside role README.md
- [x] If not present, please also add your name in the related collection authors list in galaxy.yml
