### PR TITLE
hpc/slurm: RH9 packages

### DIFF
--- a/collections/hpc/roles/slurm/README.md
+++ b/collections/hpc/roles/slurm/README.md
@@ -234,6 +234,7 @@ To enable it on the slurm configuration its required to define `slurm_selecttype
 
 ## Changelog
 
+* 1.2.5: RedHat 9 packages file. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.2.4: Set accounting host name in `slurm.conf` in order to allow submitters to connect. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.2.3: Fix old CamelCase variables. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.2.2: Improve partition definition readability in slurm.conf. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>

--- a/collections/hpc/roles/slurm/vars/RedHat_9.yml
+++ b/collections/hpc/roles/slurm/vars/RedHat_9.yml
@@ -1,0 +1,25 @@
+---
+slurm_home_path: /etc/slurm
+slurm_packages_to_install:
+  controller:
+    - munge
+    - munge-libs
+    - slurm
+    - slurm-devel
+    - slurm-slurmctld
+  accounting:
+    - mariadb
+    - mariadb-server
+    - python3-mysqlclient
+    - slurm-slurmdbd
+  compute:
+    - munge
+    - munge-libs
+    - slurm
+    - slurm-devel
+    - slurm-slurmd
+  submitter:
+    - munge
+    - munge-libs
+    - slurm
+    - slurm-devel

--- a/collections/hpc/roles/slurm/vars/main.yml
+++ b/collections/hpc/roles/slurm/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-slurm_role_version: 1.2.4
+slurm_role_version: 1.2.5


### PR DESCRIPTION
## Describe your changes

Support for RedHat 9.

Because pkg name changed from `python3-mysql` to `python3-mysqlclient`...

## Issue ticket number and link if any

## Checklist before requesting a review
- [x] Document introduced changes / variables in role README.md if any
- [x] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [x] Update changelog inside role README.md
- [x] If not present, please also add your name in the related collection authors list in galaxy.yml
