### PR TITLE
infrastructure/clustershell: add config variable clustershell_prefix_path

### DIFF
--- a/collections/infrastructure/roles/clustershell/README.md
+++ b/collections/infrastructure/roles/clustershell/README.md
@@ -20,12 +20,18 @@ Once role has been deployed, check groups using:
 nodeset -LL
 ```
 
+Note:
+If you are using the Python virtual environment, the return of the command may not be correct.
+You can use the `clustershell_prefix_path` variable to copy the configuration file to the right place.
+Default value is empty.
+
 ## To be done
 
 Tree execution mode is missing.
 
 ## Changelog
 
+* 1.3.0: Add optional variable clustershell_prefix_path. Pierre Gay <pierre.gay@u-bordeaux.fr>, Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>
 * 1.2.0: Update to BB 2.0 format. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.1.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.0.2: Prevent dummy user to be included. Documentation. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/clustershell/defaults/main.yml
+++ b/collections/infrastructure/roles/clustershell/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 clustershell_install_from_package: false
 clustershell_install_from_pip: false
+
+clustershell_prefix_path: ""

--- a/collections/infrastructure/roles/clustershell/tasks/main.yml
+++ b/collections/infrastructure/roles/clustershell/tasks/main.yml
@@ -21,13 +21,13 @@
     state: directory
     mode: 0755
   loop:
-    - /etc/clustershell
-    - /etc/clustershell/groups.d
+    - "{{ clustershell_prefix_path }}/etc/clustershell"
+    - "{{ clustershell_prefix_path }}/etc/clustershell/groups.d"
 
-- name: template <|> Generate /etc/clustershell/groups.d/local.cfg
+- name: template <|> Generate {{ clustershell_prefix_path }}/etc/clustershell/groups.d/local.cfg
   ansible.builtin.template:
     src: local.cfg.j2
-    dest: /etc/clustershell/groups.d/local.cfg
+    dest: "{{ clustershell_prefix_path }}/etc/clustershell/groups.d/local.cfg"
     owner: root
     group: root
     mode: 0644

--- a/collections/infrastructure/roles/clustershell/vars/main.yml
+++ b/collections/infrastructure/roles/clustershell/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-clustershell_role_version: 1.2.0
+clustershell_role_version: 1.3.0


### PR DESCRIPTION
## Describe your changes

When used with online bootstrap, this role has to manage configuration files within `~bluebanquise/ansible_venv/etc/clustershell` instead of `/etc/clustershell`.

This PR allows to use `clustershell_prefix_path` to change the default to any desired value.

## Issue ticket number and link if any

## Checklist before requesting a review
- [x] Document introduced changes / variables in role README.md if any
- [x] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [x] Update changelog inside role README.md
- [x] If not present, please also add your name in the related collection authors list in galaxy.yml
