### PR TITLE
stable-1.6 Backport #787 - fix rsyslog service name

### DIFF
--- a/roles/core/log_server/readme.rst
+++ b/roles/core/log_server/readme.rst
@@ -17,6 +17,7 @@ log_server_port variable.
 Changelog
 ^^^^^^^^^
 
+* 1.2.2: Proper command to restart rsyslog post rotation. Thiago Cardozo <boubee.thiago@gmail.com> - BB 1.6 backport
 * 1.2.1: Register server local apps locally;more precise logrotate wildcards. <boubee.thiago@gmail.com> - BB 1.6 backport <gino.mcevoy@gmail.com>
 * 1.2.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.1.2: Added OpenSuSE variables. Neil Munday <neil@mundayweb.com>

--- a/roles/core/log_server/templates/rsyslog_logrotate.j2
+++ b/roles/core/log_server/templates/rsyslog_logrotate.j2
@@ -13,6 +13,6 @@
     rotate 5
     sharedscripts
     postrotate
-        /usr/bin/systemctl try-restart rsyslog-server.service > /dev/null 2>/dev/null || true
+        /usr/bin/systemctl kill -s HUP rsyslog.service > /dev/null 2>/dev/null || true
     endscript
 }

--- a/roles/core/log_server/vars/main.yml
+++ b/roles/core/log_server/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-log_server_role_version: 1.2.0
+log_server_role_version: 1.2.2
 log_server_packages_to_install:
   - rsyslog
   - logrotate


### PR DESCRIPTION
Backport of #PR 787 into stable-1.6. This fixes an erroneous service name in the logrotate config file.
