### PR TITLE
Fix ubuntu service names

### DIFF
--- a/collections/infrastructure/roles/dns_server/README.md
+++ b/collections/infrastructure/roles/dns_server/README.md
@@ -52,6 +52,7 @@ This will cause `/var/named/override` to be generated.
 
 ## Changelog
 
+* 1.7.2: Rename systemd service to named for Ubuntu. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.7.1: Find correct default resolution network in reverse zone. Alexandra Darrieutort <alexandra.darrieutort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.7.0: Add optional alias to every interface. Matthieu Isoard <indigoping4cgmi@gmail.com>
 * 1.6.0: Update to BB 2.0 format. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/dns_server/vars/Ubuntu.yml
+++ b/collections/infrastructure/roles/dns_server/vars/Ubuntu.yml
@@ -2,7 +2,7 @@
 dns_server_packages_to_install:
   - bind9
 dns_server_services_to_start:
-  - bind9
+  - named
 dns_server_dump_file: /var/named/data/cache_dump.db
 dns_server_localhost_file: /var/named/named.localhost
 dns_server_log_dir: data

--- a/collections/infrastructure/roles/dns_server/vars/main.yml
+++ b/collections/infrastructure/roles/dns_server/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-dns_server_role_version: 1.7.1
+dns_server_role_version: 1.7.2
 
 j2_dns_server_get_first_octets: "
 {%- set ip_networks = [] -%}

--- a/collections/infrastructure/roles/time/README.md
+++ b/collections/infrastructure/roles/time/README.md
@@ -73,6 +73,7 @@ variable.
 
 ## Changelog
 
+* 1.3.1: Rename systemd service to chrony for Ubuntu. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.3.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.2.1: Adapt role to handle multiple distributions. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.2.0: Add Ubuntu support. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/time/vars/Ubuntu.yml
+++ b/collections/infrastructure/roles/time/vars/Ubuntu.yml
@@ -3,5 +3,5 @@ time_packages_to_install:
   - chrony
   - tzdata
 time_services_to_start:
-  - chronyd
+  - chrony
 time_chrony_conf_path: /etc/chrony/chrony.conf

--- a/collections/infrastructure/roles/time/vars/main.yml
+++ b/collections/infrastructure/roles/time/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-time_role_version: 1.3.0
+time_role_version: 1.3.1


### PR DESCRIPTION
## Describe your changes
Issue with using aliases of systemd service names, the alias will stop working if the service is disabled.

Below is how to reproduce the issue, notice that the last two commands fail. This means that roles using the aliases (time_ will also fail. 

```
root@mngt0-1:~# systemctl status chronyd
● chrony.service - chrony, an NTP client/server
     Loaded: loaded (/lib/systemd/system/chrony.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2023-03-28 14:54:21 CEST; 1h 11min ago
       Docs: man:chronyd(8)
             man:chronyc(1)
             man:chrony.conf(5)
   Main PID: 22798 (chronyd)
      Tasks: 2 (limit: 9507)
     Memory: 1.5M
     CGroup: /system.slice/chrony.service
             ├─22798 /usr/sbin/chronyd -F -1
             └─22799 /usr/sbin/chronyd -F -1

Mar 28 14:54:21 mngt0-1 systemd[1]: Starting chrony, an NTP client/server...
Mar 28 14:54:21 mngt0-1 chronyd[22798]: chronyd version 3.5 starting (+CMDMON +NTP +REFCLOCK +RTC +PRIVDROP +SCFILTER +SIGND +ASYNCDNS +SECHASH +IPV>
Mar 28 14:54:21 mngt0-1 chronyd[22798]: Loaded seccomp filter
Mar 28 14:54:21 mngt0-1 systemd[1]: Started chrony, an NTP client/server.

root@mngt0-1:~# systemctl disable chronyd
Removed /etc/systemd/system/multi-user.target.wants/chrony.service.
Removed /etc/systemd/system/chronyd.service.

root@mngt0-1:~# systemctl enable chronyd
Failed to enable unit: Unit file chronyd.service does not exist.

root@mngt0-1:~# systemctl status chronyd
Unit chronyd.service could not be found.
```

This fix uses the standard service names, and the roles will not fail anymore.

## Issue ticket number and link if any
N/A