### PR TITLE
high_availability/pcs: Fix service name in RHEL firewall

### DIFF
--- a/collections/high_availability/roles/pcs/README.md
+++ b/collections/high_availability/roles/pcs/README.md
@@ -612,6 +612,7 @@ not present. Then in HA resources, declare the following:
 
 ## 6. Changelog
 
+* 1.1.1: Fix service name in RHEL firewall. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.1.0: Add Ubuntu support. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.0.6: (docs): examples to hash cluster password with Python and Perl. Leo Araujo <lmagdanello40@gmail.com>
 * 1.0.5: Allow specification of name of the cluster. Giacomo Mc Evoy <gino.mcevoy@gmail.com>

--- a/collections/high_availability/roles/pcs/tasks/RedHat/firewall.yml
+++ b/collections/high_availability/roles/pcs/tasks/RedHat/firewall.yml
@@ -3,7 +3,7 @@
 - name: firewalld <|> "Add services to firewall's {{ ha_firewall_zone | default('public') }} zone"
   ansible.posix.firewalld:
     zone: "{{ ha_firewall_zone | default('public') }}"
-    service: high_availability
+    service: high-availability
     immediate: "yes"
     permanent: "yes"
     state: enabled


### PR DESCRIPTION
## Describe your changes
Last PR #807 (support high_availability on Ubuntu) introduced a bug on RHEL due to a typo.

Apologies for the error, I thoroughly tested the Ubuntu support and thought I also tested RHEL, but I was only testing an old version of the role. Now that I updated the tests to the latest version, the issue appeared. I also confirmed that this PR fixes it.