### PR TITLE
high_availability: fix keepalived

### DIFF
--- a/collections/high_availability/roles/keepalived/README.md
+++ b/collections/high_availability/roles/keepalived/README.md
@@ -1,13 +1,26 @@
-keepalived_vrrp_instances:
-  -  name: VI_1
-    *interface: enp0s3
-     id:
-     state:
-     priority:
-     advert_int:
-     additional_parameters:
-       tutu: toto
-    *auth_pass: secret
-    *virtual_ipaddress:
-       - 10.10.0.3/16 brd 10.10.255.255 scope global
-    manage_haproxy:
+
+Example playbook:
+
+```YAML
+---
+- name: haproxy
+  hosts: "mg_khap"
+  become: true
+  vars:
+    keepalived_vrrp_instances:
+      - name: VI_1
+        interface: enp0s3
+        id: 100
+        state: MASTER
+        priority: 100
+        advert_int: 1
+        additional_parameters: {}
+        auth_pass: "<replace me>"
+        virtual_ipaddress:
+          - 10.10.0.3/16 brd 10.10.255.255 scope global
+        manage_haproxy: true
+  roles:
+    - role: bluebanquise.high_availability.keepalived
+      tags: keepalived
+```
+

--- a/collections/high_availability/roles/keepalived/defaults/main.yml
+++ b/collections/high_availability/roles/keepalived/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+keepalived_conf_file: /etc/keepalived/keepalived.conf

--- a/collections/high_availability/roles/keepalived/handlers/main.yml
+++ b/collections/high_availability/roles/keepalived/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: service <|> Restart keepalived server
+  ansible.builtin.service:
+    name: keepalived
+    state: restarted
+  when:
+    - "'service' not in ansible_skip_tags"
+    - (start_services | bool)

--- a/collections/high_availability/roles/keepalived/tasks/main.yml
+++ b/collections/high_availability/roles/keepalived/tasks/main.yml
@@ -54,7 +54,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: service <|> Restart dhcp server
+  notify: service <|> Restart keepalived server
   tags:
     - template
 

--- a/collections/high_availability/roles/keepalived/vars/Rocky_8.yml
+++ b/collections/high_availability/roles/keepalived/vars/Rocky_8.yml
@@ -1,0 +1,7 @@
+---
+
+keepalived_packages_to_install:
+  - keepalived
+
+keepalived_services_to_start:
+  - keepalived


### PR DESCRIPTION
## Describe your changes

high_availability/keepalived seemed to be broken. This is a proposal to fix it.

OS config vars are only provided for Rocky 8. Tell me if I may change that and what to add into the README.
## Issue ticket number and link if any

## Checklist before requesting a review
- [ ] Document introduced changes / variables in role README.md if any
- [ ] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [ ] Update changelog inside role README.md
- [ ] If not present, please also add your name in the related collection authors list in galaxy.yml
