### PR TITLE
Bootstrap dependencies error

### DIFF
--- a/bootstrap/configure_environment.sh
+++ b/bootstrap/configure_environment.sh
@@ -41,6 +41,7 @@ ansible-galaxy collection install community.general || sleep 30 && ansible-galax
 if [[ $COLLECTIONS_LOCAL_PATH != "none" ]]; then
   ansible-galaxy collection install $COLLECTIONS_LOCAL_PATH
 else
+  ansible-galaxy collection install git+https://github.com/bluebanquise/bluebanquise.git#/collections/commons,master -vvv --upgrade
   ansible-galaxy collection install git+https://github.com/bluebanquise/bluebanquise.git#/collections/infrastructure,master -vvv --upgrade
 fi
 


### PR DESCRIPTION
Hello,

I suggest a minor fix that adds a dependency to the automatic configuration of the ansible and bluebanquise environment.

patch works on alma 9.2

Best

the error was as follows: 

```
ERROR! Failed to resolve the requested dependencies map. Could not satisfy the following requirements:
* bluebanquise.commons:* (dependency of bluebanquise.infrastructure:2.1.2)
```