### PR TITLE
Fix prometheus restart services

### DIFF
--- a/collections/monitoring/roles/prometheus/README.md
+++ b/collections/monitoring/roles/prometheus/README.md
@@ -581,6 +581,7 @@ prometheus_server_prometheus_launch_parameters: |
 
 ## Changelog
 
+* 1.3.2: Restart services when systemd service file changes. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.3.1: Fix error when exporter is missing the service parameter. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.3.0: Support TLS and Basic Authentication. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.2.4: Update to BB 2.0 format. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>

--- a/collections/monitoring/roles/prometheus/handlers/main.yml
+++ b/collections/monitoring/roles/prometheus/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: systemd <|> Reload systemd configuration
+  ansible.builtin.systemd:
+    daemon_reload: yes
+
 - name: reload firewalld
   ansible.builtin.command: firewall-cmd --reload
 
@@ -41,7 +45,3 @@
   when:
     - "'service' not in ansible_skip_tags"
     - (start_services | bool)
-
-- name: systemd <|> Reload systemd configuration
-  ansible.builtin.systemd:
-    daemon_reload: yes

--- a/collections/monitoring/roles/prometheus/tasks/server_alertmanager.yml
+++ b/collections/monitoring/roles/prometheus/tasks/server_alertmanager.yml
@@ -28,7 +28,9 @@
     owner: root
     group: root
     mode: 0755
-  notify: systemd <|> Reload systemd configuration
+  notify:
+    - systemd <|> Reload systemd configuration
+    - service <|> Restart alertmanager service
   tags:
     - template
 

--- a/collections/monitoring/roles/prometheus/tasks/server_ipmi_exporter.yml
+++ b/collections/monitoring/roles/prometheus/tasks/server_ipmi_exporter.yml
@@ -28,7 +28,9 @@
     owner: root
     group: root
     mode: 0755
-  notify: systemd <|> Reload systemd configuration
+  notify:
+    - systemd <|> Reload systemd configuration
+    - service <|> Restart ipmi_exporter service
   tags:
     - template
 

--- a/collections/monitoring/roles/prometheus/tasks/server_karma.yml
+++ b/collections/monitoring/roles/prometheus/tasks/server_karma.yml
@@ -28,7 +28,9 @@
     owner: root
     group: root
     mode: 0755
-  notify: systemd <|> Reload systemd configuration
+  notify:
+    - systemd <|> Reload systemd configuration
+    - service <|> Restart karma service
   tags:
     - template
 

--- a/collections/monitoring/roles/prometheus/tasks/server_prometheus.yml
+++ b/collections/monitoring/roles/prometheus/tasks/server_prometheus.yml
@@ -28,7 +28,9 @@
     owner: root
     group: root
     mode: 0755
-  notify: systemd <|> Reload systemd configuration
+  notify:
+    - systemd <|> Reload systemd configuration
+    - service <|> Restart prometheus service
   tags:
     - template
 

--- a/collections/monitoring/roles/prometheus/tasks/server_snmp_exporter.yml
+++ b/collections/monitoring/roles/prometheus/tasks/server_snmp_exporter.yml
@@ -53,7 +53,9 @@
     owner: root
     group: root
     mode: 0755
-  notify: systemd <|> Reload systemd configuration
+  notify:
+    - systemd <|> Reload systemd configuration
+    - service <|> Restart snmp_exporter service
   tags:
     - template
 

--- a/collections/monitoring/roles/prometheus/vars/main.yml
+++ b/collections/monitoring/roles/prometheus/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-prometheus_role_version: 1.3.1
+prometheus_role_version: 1.3.2


### PR DESCRIPTION
## Describe your changes
Restart each service managed by the prometheus role when its systemd file changes. This is relevant when the launch parameters change: the services were not being updated automatically with new launch parameters.

Also changed the order of the handlers in handlers/main.yml, the handler for the systemd daemon-reload must go before the service restarts. FYI, the handlers are executed in the order they are defined, not in the order they are listed in the notify statement: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_handlers.html#handlers

## Issue ticket number and link if any

## Checklist before requesting a review
- [ ] Document introduced changes / variables in role README.md if any
- [X] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [X] Update changelog inside role README.md
- [X] If not present, please also add your name in the related collection authors list in galaxy.yml
