### PR TITLE
Fix nhc.j2 template bug

### DIFF
--- a/collections/hpc/roles/nhc/README.md
+++ b/collections/hpc/roles/nhc/README.md
@@ -76,5 +76,6 @@ checks.
 
 ## Changelog
 
+* 1.1.1: Bug fixes on nhc.j2. Lucas santos <lucassouzasantos@gmail.com>
 * 1.1.0: Template nhc_files. Bruno Travouillon <devel@travouillon.fr>
 * 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/hpc/roles/nhc/templates/nhc.conf.j2
+++ b/collections/hpc/roles/nhc/templates/nhc.conf.j2
@@ -27,9 +27,9 @@
 
 {% if nhc_checks is defined and nhc_checks is iterable %}
   {% for check, arguments in nhc_checks.items() %}
-    {% if arguments is iterable %}
+    {% if arguments is iterable and arguments is not string %}
       {% for arg in arguments %}
-* || {{ check }} {{ arguments }}
+* || {{ check }} {{ arg }}
       {% endfor %}
     {% else %}
 * || {{ check }} {{ arguments }}

--- a/collections/hpc/roles/nhc/vars/main.yml
+++ b/collections/hpc/roles/nhc/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-nhc_role_version: 1.1.0
+nhc_role_version: 1.1.1


### PR DESCRIPTION
Fix bug that was causing to template with iterable and string vars to be rendered wrongly:

Like this for strings:
```
* || check_fs_free /
* || check_fs_free  
* || check_fs_free 1
* || check_fs_free 0
* || check_fs_free %
```
And this for iterable list :
```
* || check_fs_mount_rw ['-f /scratch', '-f /opt/share']
* || check_fs_mount_rw ['-f /scratch', '-f /opt/share']
```

## Checklist before requesting a review
- [x] Document introduced changes / variables in role README.md if any
- [x] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [x] Update changelog inside role README.md
- [x] If not present, please also add your name in the related collection authors list in galaxy.yml
