### PR TITLE
fix: pxe_stack - fix kernel upgrade option in bluebanquise-diskless

### DIFF
--- a/collections/infrastructure/galaxy.yml
+++ b/collections/infrastructure/galaxy.yml
@@ -4,7 +4,7 @@ namespace: bluebanquise
 name: infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 2.6.1
+version: 2.6.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/infrastructure/roles/pxe_stack/README.md
+++ b/collections/infrastructure/roles/pxe_stack/README.md
@@ -653,6 +653,7 @@ Note that using an home folder into /home for the bluebanquise sudo user can be 
 
 ## Changelog
 
+* 1.11.1: Fix kernel upgrade option in bluebanquise-diskless. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.11.0: Add ability to select target disk with auto partitioning. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.10.0: Add ability to set sudo user uid and gid. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.9.5: Switch RHEL from atftp to native tftp-server (fix from @sgaosdgr). Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -515,13 +515,13 @@ while True:
 
         for count, value in enumerate(file_lines):
             if "set image-kernel" in value:
-                file_lines[count] = "set image-kernel vmlinuz-" + kernel_selected
+                file_lines[count] = "set image-kernel vmlinuz-" + kernel_selected + "\n"
             if "set image-initramfs" in value:
-                file_lines[count] = "set image-initramfs initramfs-" + kernel_selected + ".img"
+                file_lines[count] = "set image-initramfs initramfs-" + kernel_selected + ".img" + "\n"
 
         try:
             ipxe_file = open(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/boot.ipxe", "w")
-            ipxe_file.write(file_lines)
+            ipxe_file.writelines(file_lines)
             ipxe_file.close()
         except Exception:
             print(bcolors.FAIL + " An error occurred writing the file " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/boot.ipxe. Please investigate." + bcolors.ENDC)
@@ -530,11 +530,13 @@ while True:
         logging.info(bcolors.OKBLUE + 'Copying new kernel from nfs image to http folder...' + bcolors.ENDC)
 
         if image_selected_metadata['family'] == "el9":
-            protected_os_system("cp " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/boot/initramfs-" + kernel_selected + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-" + kernel_selected + ".img")
-            protected_os_system("cp " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/lib/modules/" + kernel_selected + "/vmlinuz " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/vmlinuz-" + kernel_selected)
+            protected_os_system("cp -a " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/boot/initramfs-" + kernel_selected + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-" + kernel_selected + ".img")
+            protected_os_system("cp -a " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/lib/modules/" + kernel_selected + "/vmlinuz " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/vmlinuz-" + kernel_selected)
+            protected_os_system("chmod 644 " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-*")
         elif image_selected_metadata['family'] == "el8":
-            protected_os_system("cp " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/boot/initramfs-" + kernel_selected + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-" + kernel_selected + ".img")
-            protected_os_system("cp " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/boot/vmlinuz-" + kernel_selected + " " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/vmlinuz-" + kernel_selected)
+            protected_os_system("cp -a " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/boot/initramfs-" + kernel_selected + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-" + kernel_selected + ".img")
+            protected_os_system("cp -a " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/boot/vmlinuz-" + kernel_selected + " " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/vmlinuz-" + kernel_selected)
+            protected_os_system("chmod 644 " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-*")
         else:
             print(" Sorry, image family " + image_selected_metadata['family'] + " is unknown :( , aborting.")
             quit(1)

--- a/collections/infrastructure/roles/pxe_stack/vars/main.yml
+++ b/collections/infrastructure/roles/pxe_stack/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pxe_stack_role_version: 1.11.0
+pxe_stack_role_version: 1.11.1
 
 pxe_stack_supported_os:
   redhat:


### PR DESCRIPTION
## Describe your changes

Option "Update a reference image default kernel" in bluebanquise-diskless failed on a dev environment. There are several issues and fixes here to make the option work.

1. Code failed:

```Traceback (most recent call last):
  File "./bluebanquise-diskless", line 531, in <module>
    ipxe_file.write(file_lines)
TypeError: write() argument must be str, not list 
```
Fix by using "writelines()".

2. Code to update boot.ipxe produces wrong output

```
#!ipxe
        echo |
        echo | Entering diskless/images/RHEL_9.3-ref/boot.ipxe
        echo |
set image-kernel vmlinuz-5.14.0-362.18.1.el9_3.x86_64set image-initramfs initramfs-5.14.0-362.18.1.el9_3.x86_64.img        echo | Now starting nfs image boot. 
```
Fix by adding '\n'

3. Wrong permissions and ownership on copied kernel/initramfs
```
-rw-r--r-- 1 root root 1.2K Feb 23 15:04 boot.ipxe
-rw------- 1 qemu qemu  29M Feb 23 15:04 initramfs-5.14.0-362.18.1.el9_3.x86_64.img
-rw-r--r-- 1 root root  53M Feb 23 15:04 initramfs-5.14.0-362.8.1.el9_3.x86_64.img
-rw-r--r-- 1 root root  385 Feb 23 15:04 metadata.yaml
-rwxr-xr-x 1 qemu qemu  13M Feb 23 15:04 vmlinuz-5.14.0-362.18.1.el9_3.x86_64
-rw-r--r-- 1 root root  13M Feb 23 15:04 vmlinuz-5.14.0-362.8.1.el9_3.x86_64 
```

Permission issue fixed by adding chmod command.
Issue with ownership may only happen when using a VM to boot reference image, the fix 'cp -p' should not affect normal procedure.