### PR TITLE
fix: nfs_server - Disable auto directories creation capability by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
     - Add capability to choose ipxe ROM. (#698)
   - nfs_server:
     - Add auto directories creation capability. (#685)
+    - Disable auto directories creation capability by default. (#910)
   - nic:
     - Add missing dns entry. (#694)
   - advanced_dhcp_server:

--- a/roles/core/nfs_server/defaults/main.yml
+++ b/roles/core/nfs_server/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-nfs_server_create_directories_if_not_exist: true
+nfs_server_create_directories_if_not_exist: false

--- a/roles/core/nfs_server/readme.rst
+++ b/roles/core/nfs_server/readme.rst
@@ -62,6 +62,7 @@ Packages installed:
 Changelog
 ^^^^^^^^^
 
+* 1.3.1: Disable auto directories creation capability by default. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.3.0: Add auto directories creation capability. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.2.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.1.2: Add OpenSUSE support. Neil Munday <neil@mundayweb.com>

--- a/roles/core/nfs_server/vars/main.yml
+++ b/roles/core/nfs_server/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-nfs_server_role_version: 1.3.0
+nfs_server_role_version: 1.3.1


### PR DESCRIPTION
## Describe your changes

Previous change added new feature in stable-1.6, but it can break existing systems. This fix is to disable the feature by default, it can be enabled by setting "nfs_server_create_directories_if_not_exist: true".

## Issue ticket number and link if any

#895 

## Checklist before requesting a review
- [X] Document introduced changes / variables in role README.md if any
- [X] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [X] Update changelog inside role README.md
- [X] If not present, please also add your name in the related collection authors list in galaxy.yml
