### PR TITLE
Update kickstart.cfg.j2 for RedHat to assign  /var/lib/bluebanquise/.ssh to bluebanquise user

### DIFF
--- a/collections/infrastructure/galaxy.yml
+++ b/collections/infrastructure/galaxy.yml
@@ -4,7 +4,7 @@ namespace: bluebanquise
 name: infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.10.1
+version: 3.10.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -26,6 +26,7 @@ authors:
   - Pierre Gay <pierre.gay@u-bordeaux.fr>
   - Alexandra Darrieutort <alexandra.darrieutort@u-bordeaux.fr>
   - Leo Magdanello <lmagdanello40@gmail.com>
+  - Patrick Begou <patrick.begou@univ-grenoble-alpes.fr>
 
 ### OPTIONAL but strongly recommended
 # A short summary description of the collection

--- a/collections/infrastructure/roles/pxe_stack/README.md
+++ b/collections/infrastructure/roles/pxe_stack/README.md
@@ -717,6 +717,7 @@ Note that using an home folder into /home for the bluebanquise sudo user can be 
 
 ## Changelog
 
+* 1.16.2: Fix owner and group for bluebanquise .ssh directory. <patrick.begou@univ-grenoble-alpes.fr>
 * 1.16.1: Fix proxy settings. Bug reported by @erkrali. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.16.0: Allow to pull netboot and core repo from a custom URL. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.15.0: diskless.yml task must be optional <jp.mazzilli@gmail.com>

--- a/collections/infrastructure/roles/pxe_stack/templates/RedHat/kickstart.cfg.j2
+++ b/collections/infrastructure/roles/pxe_stack/templates/RedHat/kickstart.cfg.j2
@@ -133,6 +133,7 @@ cat << xxEOFxx >> {{ pxe_stack_sudo_user_home }}/.ssh/authorized_keys
 {{ ssh_key }}
 {% endfor %}
 xxEOFxx
+chown -R {{pxe_stack_sudo_user}}.{{pxe_stack_sudo_user}} {{ pxe_stack_sudo_user_home }}/.ssh
 # Ensure SELinux configuration is ok, best effort
 restorecon -R -v {{ pxe_stack_sudo_user_home }}/.ssh
 # Set admin user as sudo

--- a/collections/infrastructure/roles/pxe_stack/templates/RedHat/kickstart.cfg.j2
+++ b/collections/infrastructure/roles/pxe_stack/templates/RedHat/kickstart.cfg.j2
@@ -133,7 +133,7 @@ cat << xxEOFxx >> {{ pxe_stack_sudo_user_home }}/.ssh/authorized_keys
 {{ ssh_key }}
 {% endfor %}
 xxEOFxx
-chown -R {{pxe_stack_sudo_user}}.{{pxe_stack_sudo_user}} {{ pxe_stack_sudo_user_home }}/.ssh
+chown -R {{pxe_stack_sudo_user}}:{{pxe_stack_sudo_user}} {{ pxe_stack_sudo_user_home }}/.ssh
 # Ensure SELinux configuration is ok, best effort
 restorecon -R -v {{ pxe_stack_sudo_user_home }}/.ssh
 # Set admin user as sudo

--- a/collections/infrastructure/roles/pxe_stack/vars/main.yml
+++ b/collections/infrastructure/roles/pxe_stack/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pxe_stack_role_version: 1.16.1
+pxe_stack_role_version: 1.16.2
 
 pxe_stack_supported_os:
   redhat:


### PR DESCRIPTION
**Update kickstart.cfg.j2 for RedHat to assign  /var/lib/bluebanquise/.ssh to bluebanquise user**

When deploying RedHat based OS on nodes and creating ssh keys from the kickstart.cfg, files in bluebanquise home directory belong to root and not to bluebanquise user. A chown is added.

## Describe your changes
Added a chown command in the RedHat template file to solve the problem.

## Issue ticket number and link if any

## Checklist before requesting a review
- [ ] Document introduced changes / variables in role README.md if any
- [ ] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [ ] Update changelog inside role README.md
- [ ] If not present, please also add your name in the related collection authors list in galaxy.yml
