### PR TITLE
Fixes to bluebanquise diskless

### DIFF
--- a/collections/infrastructure/roles/pxe_stack/README.md
+++ b/collections/infrastructure/roles/pxe_stack/README.md
@@ -717,6 +717,7 @@ Note that using an home folder into /home for the bluebanquise sudo user can be 
 
 ## Changelog
 
+* 1.16.5: Several fixes to bluebanquise-diskless (version 2.0.7). Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 * 1.16.4: Ensure bluebanquise-bootset is run as root/sudo. <patrick.begou@univ-grenoble-alpes.fr>
 * 1.16.3: Fix bug in kickstart (reported by jpm38). Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.16.2: Fix owner and group for bluebanquise .ssh directory. <patrick.begou@univ-grenoble-alpes.fr>

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -7,8 +7,9 @@
 # ██████╔╝███████╗╚██████╔╝███████╗██████╔╝██║  ██║██║ ╚████║╚██████╔╝╚██████╔╝██║███████║███████╗
 # ╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═══╝ ╚══▀▀═╝  ╚═════╝ ╚═╝╚══════╝╚══════╝
 #
+# 2.0.3: Sanitize user input. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.2: Improve handling of paths. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
-# 2.0.1: Fix kernel upgrade option. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
+# 2.0.1: Fix kernel upgrade. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.0: Full rewamp. Benoît Leveugle <benoit.leveugle@gmail.com>
 # 1.3.7: Improved disklessset checks. Thiago Cardozo <thiago_cardozo@yahoo.com.br>
 # 1.3.6: Fix permissions. Benoit Leveugle <benoit.leveugle@gmail.com>
@@ -81,6 +82,7 @@ import requests
 import shutil
 import subprocess
 import crypt
+import string
 
 
 # Colors, from https://stackoverflow.com/questions/287871/how-to-print-colored-text-in-terminal-in-python
@@ -236,13 +238,42 @@ def get_live_image_path(tool_paths, live_image_name):
     return os.path.join(tool_paths['http_pxe_diskless'], live_image_name)
 
 
+def get_user_input(msg, validate_name=False):
+    """Sanitizes the user's input by removing whitespace, keeps prompting until input is valid.
+
+    If validate_name is True, then it also checks that the input complies with the POSIX
+    specification "Portable Filename Character Set" (letters, digits, -, _, .). The goal is to
+    avoid issues with the shell commands executed by the tool.
+    """
+    user_input = ""
+    while user_input == "":
+        # prompt for a non-empty string
+        print(msg)
+        raw_input = input(" -->: ")
+        user_input = raw_input.strip()
+
+        if not validate_name:
+            continue
+
+        # optionally (validate_name True), validate compliance with POSIX "Portable Filename Character Set"
+        allowed_characters = string.ascii_letters + string.digits + '-_.'
+        invalid_characters = set(user_input).difference(set(allowed_characters))
+
+        if len(invalid_characters) > 0:
+            first_invalid_char = list(invalid_characters)[0]
+            print(bcolors.FAIL + "\n Sorry, the character '" + first_invalid_char + "' cannot be used for this input: " + bcolors.ENDC + user_input)
+            user_input = ""
+
+    return user_input
+
+
 print("""\
 
                 (o_
       (o_  (o_  //\\
       (/)_ (/)_ V_/_
    BlueBanquise diskless
-   v2.0.2 - beta
+   v2.0.3 - beta
    https://github.com/bluebanquise/bluebanquise/
 
 """)
@@ -308,7 +339,7 @@ while True:
     print(" 9 - Get help")
     print(" 10 - Exit tool")
 
-    main_action = input(" -->: ")
+    main_action = get_user_input("")
 
     if main_action == "1":
 
@@ -324,22 +355,20 @@ while True:
         print(" 1 - From local file")
         print(" 2 - From http URL")
 
-        source_action = input(" -->: ")
+        source_action = get_user_input("")
 
         protected_os_system("mkdir -p " + tool_paths['bootstrap_images_tmp'])
         logging.info(bcolors.OKBLUE + "Image will be temporary stored inside " + tool_paths['bootstrap_images_tmp'] + bcolors.ENDC)
 
         if source_action == "1":
-            print(" Please enter bootstrap image ABSOLUTE path of tar.gz archive:")
-            image_path = input(" -->: ")
+            image_path = get_user_input(" Please enter bootstrap image ABSOLUTE path of tar.gz archive:")
             image_source_file_name = image_path.split('/')[-1]
             tmp_image_source_path = get_tmp_image_source_path(tool_paths, image_source_file_name)
             logging.info(bcolors.OKBLUE + 'Copying image from ' + image_path + ', please be patient...' + bcolors.ENDC)
             protected_os_system("cp " + image_path + " " + tmp_image_source_path)
 
         elif source_action == "2":
-            print(" Please enter bootstrap image URL of tar.gz archive:")
-            image_url = input(" -->: ")
+            image_url = get_user_input(" Please enter bootstrap image URL of tar.gz archive:")
             image_source_file_name = image_url.split('/')[-1]
             tmp_image_source_path = get_tmp_image_source_path(tool_paths, image_source_file_name)
             logging.info(bcolors.OKBLUE + 'Downloading image from ' + image_url + ', please be patient...' + bcolors.ENDC)
@@ -382,10 +411,8 @@ while True:
 
         if display_images("bootstrap", tool_paths) == 1: continue
 
-        print(" Please enter bootstrap image name to use as source:")
-        image_selected_input = input(" -->: ")
-        print(" Now, please enter new reference image name:")
-        image_selected_input_name = input(" -->: ")
+        image_selected_input = get_user_input(" Please enter bootstrap image name to use as source:", validate_name=True)
+        image_selected_input_name = get_user_input(" Now, please enter new reference image name:", validate_name=True)
         print("")
 
         bootstrap_image_path = get_bootstrap_image_path(tool_paths, image_selected_input)
@@ -474,16 +501,14 @@ while True:
 
         if display_images("reference", tool_paths) == 1: continue
 
-        print(" Please enter reference image to link to a node:")
-        image_selected_input = input(" -->: ")
+        image_selected_input = get_user_input(" Please enter reference image to link to a node:", validate_name=True)
         reference_image_nfs_path = get_reference_image_nfs_path(tool_paths, image_selected_input)
 
-        print(" Now, please enter target node to be linked to this image:")
-        node_selected_input = input(" -->: ")
+        node_selected_input = get_user_input(" Now, please enter target node to be linked to this image:")
         print(" Ok, and to finish, I would need a temporary password for image's internal bluebanquise user.")
         print(" You will be able to update it, or remove it once image is created")
         print(" to allow ssh keys based authentication only.")
-        image_selected_user_password = input(" -->: ")
+        image_selected_user_password = get_user_input("")
         print("")
         image_selected_user_password = crypt.crypt(image_selected_user_password, crypt.mksalt(crypt.METHOD_SHA512))
 
@@ -510,8 +535,7 @@ while True:
 
         if display_images("reference", tool_paths) == 1: continue
 
-        print(" Please enter reference image to check available kernels:")
-        image_selected_input = input(" -->: ")
+        image_selected_input = get_user_input(" Please enter reference image to check available kernels:", validate_name=True)
         reference_image_nfs_path = get_reference_image_nfs_path(tool_paths, image_selected_input)
         reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_selected_input)
 
@@ -521,8 +545,7 @@ while True:
             if it.is_dir():
                 print(" - " + it.name)
 
-        print(" Now, please enter kernel to be used as default for boot:")
-        kernel_selected = input(" -->: ")
+        kernel_selected = get_user_input(" Now, please enter kernel to be used as default for boot:", validate_name=True)
 
         logging.info(bcolors.OKBLUE + 'Updating image metadata...' + bcolors.ENDC)
 
@@ -592,13 +615,11 @@ while True:
             
         if display_images("reference", tool_paths) == 1: continue
 
-        print(" Please enter reference image to clone:")
-        image_selected_input = input(" -->: ")
+        image_selected_input = get_user_input(" Please enter reference image to clone:", validate_name=True)
         reference_image_nfs_path = get_reference_image_nfs_path(tool_paths, image_selected_input)
         reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_selected_input)
 
-        print(" Please enter clone reference image name:")
-        image_clone_input = input(" -->: ")
+        image_clone_input = get_user_input(" Please enter clone reference image name:", validate_name=True)
         clone_image_nfs_path = get_reference_image_nfs_path(tool_paths, image_clone_input)
         clone_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_clone_input)
 
@@ -632,8 +653,7 @@ while True:
 
         if display_images("reference", tool_paths) == 1: continue
 
-        print(" Please enter reference image to convert to live:")
-        image_selected_input = input(" -->: ")
+        image_selected_input = get_user_input(" Please enter reference image to convert to live:", validate_name=True)
         reference_image_nfs_path = get_reference_image_nfs_path(tool_paths, image_selected_input)
         reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_selected_input)
 
@@ -647,8 +667,7 @@ while True:
             print(bcolors.FAIL + " An error occurred reading the file " + reference_image_pxe_path + "/metadata.yaml. Please investigate." + bcolors.ENDC)
             quit(1)
 
-        print(" Now, please enter new live image name:")
-        image_selected_input_name = input(" -->: ")
+        image_selected_input_name = get_user_input(" Now, please enter new live image name:", validate_name=True)
         image_selected_metadata['reference_name'] = image_selected_metadata['name'] + "," + image_selected_metadata['reference_name']
         image_selected_metadata['name'] = image_selected_input_name
         image_selected_metadata['type'] = "live"
@@ -657,8 +676,7 @@ while True:
         reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_selected_metadata['reference_name'].split(",")[0])
         live_image_path = get_live_image_path(tool_paths, image_selected_metadata['name'])
 
-        print(" I now need a live size limit in RAM, in Mb:")
-        live_size = input(" -->: ")
+        live_size = get_user_input(" I now need a live size limit in RAM, in Mb:")
         logging.info(bcolors.OKBLUE + 'Preparing FS...' + bcolors.ENDC)
         protected_os_system("mkdir -p " + live_image_path + "/workdir/LiveOS/")
         protected_os_system("dd if=/dev/zero of=" + live_image_path + "/workdir/LiveOS/rootfs.img bs=1M count=" + live_size)
@@ -728,14 +746,13 @@ while True:
         print(" 2 - \033[92mreference\033[0m image")
         print(" 3 - \033[91mlive\033[0m image")
 
-        delete_image_type = input(" -->: ")
+        delete_image_type = get_user_input("")
 
         if str(delete_image_type) == "1":
 
             if display_images("bootstrap", tool_paths) == 1: continue
             
-            print("\n Please enter bootstrap image name to be deleted:")
-            delete_image = input(" -->: ")
+            delete_image = get_user_input("\n Please enter bootstrap image name to be deleted:", validate_name=True)
             bootstrap_image_path = get_bootstrap_image_path(tool_paths, delete_image)
             logging.info(bcolors.OKBLUE + 'Deleting image...' + bcolors.ENDC)
             protected_os_system("rm -Rf " + bootstrap_image_path)
@@ -744,8 +761,7 @@ while True:
 
             if display_images("reference", tool_paths) == 1: continue
             
-            print("\n Please enter reference image name to be deleted:")
-            delete_image = input(" -->: ")
+            delete_image = get_user_input("\n Please enter reference image name to be deleted:", validate_name=True)
             reference_image_nfs_path = get_reference_image_nfs_path(tool_paths, delete_image)
             reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, delete_image)
 
@@ -757,8 +773,7 @@ while True:
 
             if display_images("live", tool_paths) == 1: continue
 
-            print("\n Please enter live image name to be deleted:")
-            delete_image = input(" -->: ")
+            delete_image = get_user_input("\n Please enter live image name to be deleted:", validate_name=True)
             live_image_path = get_live_image_path(tool_paths, delete_image)
             logging.info(bcolors.OKBLUE + 'Deleting image...' + bcolors.ENDC)
             protected_os_system("rm -Rf " + live_image_path)
@@ -774,7 +789,7 @@ while True:
         print(" 1 - Display in current terminal")
         print(" 2 - Write into /tmp/bluebanquise-diskless-help.md")
 
-        help_entry = input(" -->: ")
+        help_entry = get_user_input("")
 
         help_content = """
 # INTRODUCTION AND GENERAL CONCEPT

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -102,15 +102,15 @@ def display_image_metadata(image_metadata):
     print("          └─ description: " + image_metadata['description'])
 
 
-def display_images(image_type):
+def display_images(image_type, tool_paths):
     """ Display existing images, return 1 if none found"""
 
     if image_type == "bootstrap":
 
         # Gather bootstrap images
         gathered_bootstrap = []
-        logging.info(bcolors.OKBLUE + "Checking bootstrap images in " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + bcolors.ENDC)
-        for it in os.scandir(tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/"):
+        logging.info(bcolors.OKBLUE + "Checking bootstrap images in " + tool_paths['bootstrap_images'] + bcolors.ENDC)
+        for it in os.scandir(tool_paths['bootstrap_images']):
             if it.is_dir() and it.name != "tmp":
                 try:
                     with open(it.path + "/metadata.yaml", "r") as file:
@@ -136,8 +136,8 @@ def display_images(image_type):
 
         # Gather reference images
         gathered_reference = []
-        logging.info(bcolors.OKBLUE + "Checking reference images in " + tool_parameters['http_pxe_folder'] + "/diskless/" + bcolors.ENDC)
-        for it in os.scandir(tool_parameters['http_pxe_folder'] + "/diskless/"):
+        logging.info(bcolors.OKBLUE + "Checking reference images in " + tool_paths['http_pxe_diskless'] + bcolors.ENDC)
+        for it in os.scandir(tool_paths['http_pxe_diskless']):
             if it.is_dir():
                 try:
                     with open(it.path + "/metadata.yaml", "r") as file:
@@ -165,8 +165,8 @@ def display_images(image_type):
 
         # Gather live images
         gathered_live = []
-        logging.info(bcolors.OKBLUE + "Checking live images in " + tool_parameters['http_pxe_folder'] + "/diskless/" + bcolors.ENDC)
-        for it in os.scandir(tool_parameters['http_pxe_folder'] + "/diskless/"):
+        logging.info(bcolors.OKBLUE + "Checking live images in " + tool_paths['http_pxe_diskless'] + bcolors.ENDC)
+        for it in os.scandir(tool_paths['http_pxe_diskless']):
             if it.is_dir():
                 try:
                     with open(it.path + "/metadata.yaml", "r") as file:
@@ -285,8 +285,8 @@ if not os.path.exists(tool_paths['bootstrap_images']):
     logging.info(bcolors.OKBLUE + "Creating " + tool_paths['bootstrap_images'] + " folder." + bcolors.ENDC)
     protected_os_system("mkdir -p " + tool_paths['bootstrap_images_tmp'])
 if not os.path.exists(tool_parameters['nfs_path'] + ""):
-    logging.info(bcolors.OKBLUE + "Creating " + tool_parameters['nfs_path'] + " folder." + bcolors.ENDC)
-    protected_os_system("mkdir -p " + tool_parameters['nfs_path'] + "")
+    logging.info(bcolors.OKBLUE + "Creating " + tool_paths['nfs'] + " folder." + bcolors.ENDC)
+    protected_os_system("mkdir -p " + tool_paths['nfs'] + "")
 if not os.path.exists(tool_paths['http_pxe_diskless']):
     logging.info(bcolors.OKBLUE + "Creating " + tool_paths['http_pxe_diskless'] + " folder." + bcolors.ENDC)
     protected_os_system("mkdir -p " + tool_paths['http_pxe_diskless'])
@@ -310,9 +310,9 @@ while True:
 
     if main_action == "1":
 
-        display_images("bootstrap")
-        display_images("reference")
-        display_images("live")
+        display_images("bootstrap", tool_paths)
+        display_images("reference", tool_paths)
+        display_images("live", tool_paths)
 
     if main_action == "2":
 
@@ -378,7 +378,7 @@ while True:
         print("")
         print(" Available bootstrap images to use as reference:")
 
-        if display_images("bootstrap") == 1: continue
+        if display_images("bootstrap", tool_paths) == 1: continue
 
         print(" Please enter bootstrap image name to use as source:")
         image_selected_input = input(" -->: ")
@@ -470,7 +470,7 @@ while True:
 
     if main_action == '4':
 
-        if display_images("reference") == 1: continue
+        if display_images("reference", tool_paths) == 1: continue
 
         print(" Please enter reference image to link to a node:")
         image_selected_input = input(" -->: ")
@@ -506,7 +506,7 @@ while True:
 
     if main_action == '5':
 
-        if display_images("reference") == 1: continue
+        if display_images("reference", tool_paths) == 1: continue
 
         print(" Please enter reference image to check available kernels:")
         image_selected_input = input(" -->: ")
@@ -588,7 +588,7 @@ while True:
 
     if main_action == '6':
             
-        if display_images("reference") == 1: continue
+        if display_images("reference", tool_paths) == 1: continue
 
         print(" Please enter reference image to clone:")
         image_selected_input = input(" -->: ")
@@ -628,7 +628,7 @@ while True:
 
     if main_action == '7':
 
-        if display_images("reference") == 1: continue
+        if display_images("reference", tool_paths) == 1: continue
 
         print(" Please enter reference image to convert to live:")
         image_selected_input = input(" -->: ")
@@ -730,7 +730,7 @@ while True:
 
         if str(delete_image_type) == "1":
 
-            if display_images("bootstrap") == 1: continue
+            if display_images("bootstrap", tool_paths) == 1: continue
             
             print("\n Please enter bootstrap image name to be deleted:")
             delete_image = input(" -->: ")
@@ -740,7 +740,7 @@ while True:
 
         if str(delete_image_type) == "2":
 
-            if display_images("reference") == 1: continue
+            if display_images("reference", tool_paths) == 1: continue
             
             print("\n Please enter reference image name to be deleted:")
             delete_image = input(" -->: ")
@@ -753,7 +753,7 @@ while True:
 
         if str(delete_image_type) == "3":
 
-            if display_images("live") == 1: continue
+            if display_images("live", tool_paths) == 1: continue
 
             print("\n Please enter live image name to be deleted:")
             delete_image = input(" -->: ")

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -214,6 +214,13 @@ def protected_os_system(raw_command):
     return 0
 
 
+def get_tmp_image_info(tool_paths, image_source_file_name):
+    tmp_image_info = {}
+    tmp_image_info['metadata'] = os.path.join(tool_paths['bootstrap_images_tmp'], "metadata.yaml")
+    tmp_image_info['image_source'] = os.path.join(tool_paths['bootstrap_images_tmp'], image_source_file_name)
+    return tmp_image_info
+
+
 print("""\
 
                 (o_
@@ -251,16 +258,24 @@ except Exception:
     print(bcolors.FAIL + " An error occurred reading the file /etc/bluebanquise/diskless.yml. Please investigate." + bcolors.ENDC)
     quit(1)
 
+
+# Use os.path.join to avoid issues with missing '/' and to reduce code duplication
+tool_paths = {}
+tool_paths['bootstrap_images'] = os.path.join(tool_parameters['sudo_user_home'], "diskless/bootstrap_images")
+tool_paths['bootstrap_images_tmp'] = os.path.join(tool_paths['bootstrap_images'], "tmp")
+tool_paths['http_pxe_diskless'] = os.path.join(tool_parameters['http_pxe_folder'], "diskless")
+
+
 logging.info(bcolors.OKBLUE + 'Checking folders exist...' + bcolors.ENDC)
-if not os.path.exists(tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images"):
-    logging.info(bcolors.OKBLUE + "Creating " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/ folder." + bcolors.ENDC)
-    protected_os_system("mkdir -p " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/")
+if not os.path.exists(tool_paths['bootstrap_images']):
+    logging.info(bcolors.OKBLUE + "Creating " + tool_paths['bootstrap_images'] + " folder." + bcolors.ENDC)
+    protected_os_system("mkdir -p " + tool_paths['bootstrap_images_tmp'])
 if not os.path.exists(tool_parameters['nfs_path'] + ""):
     logging.info(bcolors.OKBLUE + "Creating " + tool_parameters['nfs_path'] + " folder." + bcolors.ENDC)
     protected_os_system("mkdir -p " + tool_parameters['nfs_path'] + "")
-if not os.path.exists(tool_parameters['http_pxe_folder'] + "/diskless"):
-    logging.info(bcolors.OKBLUE + "Creating " + tool_parameters['http_pxe_folder'] + "/diskless/ folder." + bcolors.ENDC)
-    protected_os_system("mkdir -p " + tool_parameters['http_pxe_folder'] + "/diskless/")
+if not os.path.exists(tool_paths['http_pxe_diskless']):
+    logging.info(bcolors.OKBLUE + "Creating " + tool_paths['http_pxe_diskless'] + " folder." + bcolors.ENDC)
+    protected_os_system("mkdir -p " + tool_paths['http_pxe_diskless'])
 
 
 while True:
@@ -295,40 +310,42 @@ while True:
 
         source_action = input(" -->: ")
 
-        protected_os_system("mkdir -p " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/")
-        logging.info(bcolors.OKBLUE + "Image will be temporary stored inside " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/" + bcolors.ENDC)
+        protected_os_system("mkdir -p " + tool_paths['bootstrap_images_tmp'])
+        logging.info(bcolors.OKBLUE + "Image will be temporary stored inside " + tool_paths['bootstrap_images_tmp'] + bcolors.ENDC)
 
         if source_action == "1":
             print(" Please enter bootstrap image ABSOLUTE path of tar.gz archive:")
             image_path = input(" -->: ")
             image_source_file_name = image_path.split('/')[-1]
+            tmp_image_info = get_tmp_image_info(tool_paths, image_source_file_name)
             logging.info(bcolors.OKBLUE + 'Copying image from ' + image_path + ', please be patient...' + bcolors.ENDC)
-            protected_os_system("cp " + image_path + " " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/" + image_source_file_name)
+            protected_os_system("cp " + image_path + " " + tmp_image_info['image_source'])
 
         elif source_action == "2":
             print(" Please enter bootstrap image URL of tar.gz archive:")
             image_url = input(" -->: ")
             image_source_file_name = image_url.split('/')[-1]
+            tmp_image_info = get_tmp_image_info(tool_paths, image_source_file_name)
             logging.info(bcolors.OKBLUE + 'Downloading image from ' + image_url + ', please be patient...' + bcolors.ENDC)
             response = requests.get(image_url)
             try:
-                with open(tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/" + image_source_file_name, 'wb') as file:
+                with open(tmp_image_info['image_source'], 'wb') as file:
                     file.write(response.content)
             except Exception:
                 print(bcolors.FAIL + " An error occurred writing the image locally. Please investigate." + bcolors.ENDC)
                 quit(1)
 
         logging.info(bcolors.OKBLUE + 'Extracting image metadata...' + bcolors.ENDC)
-        protected_os_system("rm -f " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/metadata.yaml")
-        protected_os_system("tar xzf " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/" + image_source_file_name + " -C " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/ metadata.yaml")
+        protected_os_system("rm -f " + tmp_image_info['metadata'])
+        protected_os_system("tar xzf " + tmp_image_info['image_source'] + " -C " + tool_paths['bootstrap_images_tmp'] + "/ metadata.yaml")
         try:
-            with open(tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/metadata.yaml", "r") as file:
+            with open(tmp_image_info['metadata'], "r") as file:
                 image_metadata = yaml.safe_load(file)
         except FileNotFoundError:
-            print(bcolors.FAIL + " File " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/metadata.yaml does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
+            print(bcolors.FAIL + " File " + tmp_image_info['metadata'] + " does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
             quit(1)
         except Exception:
-            print(bcolors.FAIL + " An error occurred reading the file " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/metadata.yaml. Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred reading the file " + tmp_image_info['metadata'] + ". Please investigate." + bcolors.ENDC)
             quit(1)
         print(" Found following metadata for new image:")
         display_image_metadata(image_metadata)
@@ -336,12 +353,12 @@ while True:
         logging.info(bcolors.OKBLUE + 'Storing image...' + bcolors.ENDC)
         protected_os_system("mkdir -p " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + image_metadata['name'])
         protected_os_system("mv " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/" + image_source_file_name + " " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + image_metadata['name'] + "/image.tar.gz")
-        protected_os_system("mv " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/metadata.yaml " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + image_metadata['name'] + "/metadata.yaml")
+        protected_os_system("mv " + tmp_image_info['metadata'] + " " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + image_metadata['name'] + "/metadata.yaml")
         print(bcolors.OKGREEN + "\n == Bootstrap image " + image_metadata['name'] + " is now ready to be used :) ==" + bcolors.ENDC)
 
     if main_action == '3':
 
-        logging.info(bcolors.OKBLUE + "Checking bootstrap images in " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + bcolors.ENDC)
+        logging.info(bcolors.OKBLUE + "Checking bootstrap images in " + tool_paths['bootstrap_images'] + bcolors.ENDC)
 
         print("")
         print(" Available bootstrap images to use as reference:")

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -222,12 +222,16 @@ def get_bootstrap_image_path(tool_paths, bootstrap_image_name):
     return os.path.join(tool_paths['bootstrap_images'], bootstrap_image_name)
 
 
-def get_reference_image_nfs_path(tool_parameters, reference_image_name):
-    return os.path.join(tool_parameters['nfs_path'], reference_image_name)
+def get_reference_image_nfs_path(tool_paths, reference_image_name):
+    return os.path.join(tool_paths['nfs'], reference_image_name)
 
 
 def get_reference_image_pxe_path(tool_paths, reference_image_name):
     return os.path.join(tool_paths['http_pxe_diskless'], reference_image_name)
+
+
+def get_live_image_path(tool_paths, live_image_name):
+    return os.path.join(tool_paths['http_pxe_diskless'], live_image_name)
 
 
 print("""\
@@ -273,6 +277,7 @@ tool_paths = {}
 tool_paths['bootstrap_images'] = os.path.join(tool_parameters['sudo_user_home'], "diskless/bootstrap_images")
 tool_paths['bootstrap_images_tmp'] = os.path.join(tool_paths['bootstrap_images'], "tmp")
 tool_paths['http_pxe_diskless'] = os.path.join(tool_parameters['http_pxe_folder'], "diskless")
+tool_paths['nfs'] = tool_parameters['nfs_path']
 
 
 logging.info(bcolors.OKBLUE + 'Checking folders exist...' + bcolors.ENDC)
@@ -397,7 +402,7 @@ while True:
         image_selected_metadata['type'] = "nfs_reference"
 
         bootstrap_image_path = get_bootstrap_image_path(tool_paths, image_selected_metadata['reference_name'])
-        reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_metadata['name'])
+        reference_image_nfs_path = get_reference_image_nfs_path(tool_paths, image_selected_metadata['name'])
         reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_selected_metadata['name'])
 
         logging.info(bcolors.OKBLUE + "Extracting bootstrap image copy in " + reference_image_nfs_path + bcolors.ENDC)
@@ -469,7 +474,7 @@ while True:
 
         print(" Please enter reference image to link to a node:")
         image_selected_input = input(" -->: ")
-        reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_input)
+        reference_image_nfs_path = get_reference_image_nfs_path(tool_paths, image_selected_input)
 
         print(" Now, please enter target node to be linked to this image:")
         node_selected_input = input(" -->: ")
@@ -505,7 +510,7 @@ while True:
 
         print(" Please enter reference image to check available kernels:")
         image_selected_input = input(" -->: ")
-        reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_input)
+        reference_image_nfs_path = get_reference_image_nfs_path(tool_paths, image_selected_input)
         reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_selected_input)
 
         ## Attention, RHEL 9 et 8 uniquement pour le moment
@@ -587,12 +592,12 @@ while True:
 
         print(" Please enter reference image to clone:")
         image_selected_input = input(" -->: ")
-        reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_input)
+        reference_image_nfs_path = get_reference_image_nfs_path(tool_paths, image_selected_input)
         reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_selected_input)
 
         print(" Please enter clone reference image name:")
         image_clone_input = input(" -->: ")
-        clone_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_clone_input)
+        clone_image_nfs_path = get_reference_image_nfs_path(tool_paths, image_clone_input)
         clone_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_clone_input)
 
         logging.info(bcolors.OKBLUE + 'Cloning image...' + bcolors.ENDC)
@@ -627,7 +632,7 @@ while True:
 
         print(" Please enter reference image to convert to live:")
         image_selected_input = input(" -->: ")
-        reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_input)
+        reference_image_nfs_path = get_reference_image_nfs_path(tool_paths, image_selected_input)
         reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_selected_input)
 
         try:
@@ -646,24 +651,28 @@ while True:
         image_selected_metadata['name'] = image_selected_input_name
         image_selected_metadata['type'] = "live"
 
+        reference_image_nfs_path = get_reference_image_nfs_path(tool_paths, image_selected_metadata['reference_name'].split(",")[0])
+        reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_selected_metadata['reference_name'].split(",")[0])
+        live_image_path = get_live_image_path(tool_paths, image_selected_metadata['name'])
+
         print(" I now need a live size limit in RAM, in Mb:")
         live_size = input(" -->: ")
         logging.info(bcolors.OKBLUE + 'Preparing FS...' + bcolors.ENDC)
-        protected_os_system("mkdir -p " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/workdir/LiveOS/")
-        protected_os_system("dd if=/dev/zero of=" + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/workdir/LiveOS/rootfs.img bs=1M count=" + live_size)
-        protected_os_system("mkfs.xfs " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/workdir/LiveOS/rootfs.img")
-        os.makedirs(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/mountdir/")
-        protected_os_system("mount -o loop " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/workdir/LiveOS/rootfs.img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/mountdir/")
+        protected_os_system("mkdir -p " + live_image_path + "/workdir/LiveOS/")
+        protected_os_system("dd if=/dev/zero of=" + live_image_path + "/workdir/LiveOS/rootfs.img bs=1M count=" + live_size)
+        protected_os_system("mkfs.xfs " + live_image_path + "/workdir/LiveOS/rootfs.img")
+        os.makedirs(live_image_path + "/mountdir/")
+        protected_os_system("mount -o loop " + live_image_path + "/workdir/LiveOS/rootfs.img " + live_image_path + "/mountdir/")
         logging.info(bcolors.OKBLUE + 'Copying files from reference image...' + bcolors.ENDC)
-        protected_os_system("cp -a " + reference_image_nfs_path + "/* " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/mountdir/")
-        protected_os_system("umount " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/mountdir/")
+        protected_os_system("cp -a " + reference_image_nfs_path + "/* " + live_image_path + "/mountdir/")
+        protected_os_system("umount " + live_image_path + "/mountdir/")
         logging.info(bcolors.OKBLUE + 'Squashing image...' + bcolors.ENDC)
-        protected_os_system("mksquashfs " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/workdir " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/squashfs.img")
+        protected_os_system("mksquashfs " + live_image_path + "/workdir " + live_image_path + "/squashfs.img")
         logging.info(bcolors.OKBLUE + 'Copying kernel and initramfs...' + bcolors.ENDC)
-        shutil.rmtree(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/workdir")
-        protected_os_system("cp -a " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['reference_name'].split(",")[0] + "/initramfs* " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/")
-        protected_os_system("chmod 644 " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/initramfs-*")
-        protected_os_system("cp -a " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['reference_name'].split(",")[0] + "/vmlinuz* " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/")
+        shutil.rmtree(live_image_path + "/workdir")
+        protected_os_system("cp -a " + reference_image_pxe_path + "/initramfs* " + live_image_path + "/")
+        protected_os_system("chmod 644 " + live_image_path + "/initramfs-*")
+        protected_os_system("cp -a " + reference_image_pxe_path + "/vmlinuz* " + live_image_path + "/")
 
         ipxe_content = '''#!ipxe
         echo |
@@ -691,18 +700,18 @@ while True:
         '''.format(image_kernel=("vmlinuz-" + image_selected_metadata['kernel']), image_initramfs=("initramfs-" + image_selected_metadata['kernel'] + ".img"), image_name=image_selected_metadata['name'])
 
         try:
-            ipxe_file = open(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/boot.ipxe", "w")
+            ipxe_file = open(live_image_path + "/boot.ipxe", "w")
             ipxe_file.write(ipxe_content)
             ipxe_file.close()
         except Exception:
-            print(bcolors.FAIL + " An error occurred writing the file " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/boot.ipxe. Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred writing the file " + live_image_path + "/boot.ipxe. Please investigate." + bcolors.ENDC)
             quit(1)
 
         try:
-            with open(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/metadata.yaml", "w") as file:
+            with open(live_image_path + "/metadata.yaml", "w") as file:
                 yaml.dump(image_selected_metadata, file)
         except Exception:
-            print(bcolors.FAIL + " An error occurred writing the file " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/metadata.yaml. Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred writing the file " + live_image_path + "/metadata.yaml. Please investigate." + bcolors.ENDC)
             quit(1)
 
         print(bcolors.OKGREEN + "\n == Livenet image created :) ==" + bcolors.ENDC)
@@ -735,10 +744,12 @@ while True:
             
             print("\n Please enter reference image name to be deleted:")
             delete_image = input(" -->: ")
-            reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, delete_image)
+            reference_image_nfs_path = get_reference_image_nfs_path(tool_paths, delete_image)
+            reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, delete_image)
+
             logging.info(bcolors.OKBLUE + 'Deleting image...' + bcolors.ENDC)
             protected_os_system("rm -Rf " + reference_image_nfs_path)
-            protected_os_system("rm -Rf " + tool_parameters['http_pxe_folder'] + "diskless/" + delete_image)
+            protected_os_system("rm -Rf " + reference_image_pxe_path)
 
         if str(delete_image_type) == "3":
 
@@ -746,8 +757,9 @@ while True:
 
             print("\n Please enter live image name to be deleted:")
             delete_image = input(" -->: ")
+            live_image_path = get_live_image_path(tool_paths, delete_image)
             logging.info(bcolors.OKBLUE + 'Deleting image...' + bcolors.ENDC)
-            protected_os_system("rm -Rf " + tool_parameters['http_pxe_folder'] + "diskless/" + delete_image)
+            protected_os_system("rm -Rf " + live_image_path)
 
         print(bcolors.OKGREEN + "\n == Image deleted :) ==" + bcolors.ENDC)
 

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -218,8 +218,12 @@ def get_tmp_image_source_path(tool_paths, image_source_file_name):
     return os.path.join(tool_paths['bootstrap_images_tmp'], image_source_file_name)
 
 
-def get_bootstrap_image_path(tool_paths, image_name):
-    return os.path.join(tool_paths['bootstrap_images'], image_name)
+def get_bootstrap_image_path(tool_paths, bootstrap_image_name):
+    return os.path.join(tool_paths['bootstrap_images'], bootstrap_image_name)
+
+
+def get_reference_image_nfs_path(tool_parameters, reference_image_name):
+    return os.path.join(tool_parameters['nfs_path'], reference_image_name)
 
 
 print("""\
@@ -374,6 +378,7 @@ while True:
         print("")
 
         bootstrap_image_path = get_bootstrap_image_path(tool_paths, image_selected_input)
+        reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_input_name)
 
         try:
             with open(bootstrap_image_path + "/metadata.yaml", "r") as file:
@@ -390,19 +395,19 @@ while True:
 
         bootstrap_image_path = get_bootstrap_image_path(tool_paths, image_selected_metadata['reference_name'])
 
-        logging.info(bcolors.OKBLUE + "Extracting bootstrap image copy in " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'] + bcolors.ENDC)
-        protected_os_system("mkdir -p " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'])
-        protected_os_system("tar xzf " + bootstrap_image_path + "/image.tar.gz -C " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'])
-        protected_os_system("rm -f " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'] + "/metadata.yaml")
+        logging.info(bcolors.OKBLUE + "Extracting bootstrap image copy in " + reference_image_nfs_path + bcolors.ENDC)
+        protected_os_system("mkdir -p " + reference_image_nfs_path)
+        protected_os_system("tar xzf " + bootstrap_image_path + "/image.tar.gz -C " + reference_image_nfs_path + "/")
+        protected_os_system("rm -f " + reference_image_nfs_path + "/metadata.yaml")
         logging.info(bcolors.OKBLUE + "Creating image folder at " + tool_parameters['http_pxe_folder'] + "/diskless/" + image_selected_metadata['name'] + bcolors.ENDC)
         protected_os_system("mkdir -p " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'])
 
         if image_selected_metadata['family'] == "el9":
-            protected_os_system("cp " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'] + "/boot/initramfs-" + image_selected_metadata['kernel'] + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/initramfs-" + image_selected_metadata['kernel'] + ".img")
-            protected_os_system("cp " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'] + "/usr/lib/modules/" + image_selected_metadata['kernel'] + "/vmlinuz " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/vmlinuz-" + image_selected_metadata['kernel'])
+            protected_os_system("cp " + reference_image_nfs_path + "/boot/initramfs-" + image_selected_metadata['kernel'] + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/initramfs-" + image_selected_metadata['kernel'] + ".img")
+            protected_os_system("cp " + reference_image_nfs_path + "/usr/lib/modules/" + image_selected_metadata['kernel'] + "/vmlinuz " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/vmlinuz-" + image_selected_metadata['kernel'])
         elif image_selected_metadata['family'] == "el8":
-            protected_os_system("cp " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'] + "/boot/initramfs-" + image_selected_metadata['kernel'] + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/initramfs-" + image_selected_metadata['kernel'] + ".img")
-            protected_os_system("cp " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'] + "/boot/vmlinuz-" + image_selected_metadata['kernel'] + " " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/vmlinuz-" + image_selected_metadata['kernel'])
+            protected_os_system("cp " + reference_image_nfs_path + "/boot/initramfs-" + image_selected_metadata['kernel'] + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/initramfs-" + image_selected_metadata['kernel'] + ".img")
+            protected_os_system("cp " + reference_image_nfs_path + "/boot/vmlinuz-" + image_selected_metadata['kernel'] + " " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/vmlinuz-" + image_selected_metadata['kernel'])
         else:
             print(" Sorry, image family " + image_selected_metadata['family'] + " is unknown :( , aborting.")
             quit(1)
@@ -448,7 +453,7 @@ while True:
             quit(1)
 
         print(bcolors.OKGREEN + "\n == Reference image has been created :) ==" + bcolors.ENDC)
-        print(" You can now edit image directly inside " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'])
+        print(" You can now edit image directly inside " + reference_image_nfs_path)
         print(" Or you can also link image to a node of the target pool, boot it,")
         print(" and live modify it. To do so, use next section in main menu.")
         print(" Please read related help section for detailed explanations and warnings.")
@@ -459,6 +464,8 @@ while True:
 
         print(" Please enter reference image to link to a node:")
         image_selected_input = input(" -->: ")
+        reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_input)
+
         print(" Now, please enter target node to be linked to this image:")
         node_selected_input = input(" -->: ")
         print(" Ok, and to finish, I would need a temporary password for image's internal bluebanquise user.")
@@ -469,15 +476,15 @@ while True:
         image_selected_user_password = crypt.crypt(image_selected_user_password, crypt.mksalt(crypt.METHOD_SHA512))
 
         logging.info(bcolors.OKBLUE + 'Adding bluebanquise user to image...' + bcolors.ENDC)
-        protected_os_system("groupadd -R " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/ --system " + tool_parameters['sudo_user'])
-        protected_os_system("useradd  -R " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/ -m -c 'BlueBanquise user' -d " + tool_parameters['sudo_user_home'] + " --system -g " + tool_parameters['sudo_user'] + " -s /bin/bash -p '" + image_selected_user_password + "' " + tool_parameters['sudo_user'])
+        protected_os_system("groupadd -R " + reference_image_nfs_path + "/ --system " + tool_parameters['sudo_user'])
+        protected_os_system("useradd  -R " + reference_image_nfs_path + "/ -m -c 'BlueBanquise user' -d " + tool_parameters['sudo_user_home'] + " --system -g " + tool_parameters['sudo_user'] + " -s /bin/bash -p '" + image_selected_user_password + "' " + tool_parameters['sudo_user'])
 #            protected_os_system("useradd  -R " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/ -m -c 'BlueBanquise user' -d /var/lib/bluebanquise --system -g bluebanquise -s /bin/bash bluebanquise")
 
-        protected_os_system("echo '" + tool_parameters['sudo_user'] + " ALL=(ALL:ALL) NOPASSWD:ALL' > " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/etc/sudoers.d/" + tool_parameters['sudo_user'])
+        protected_os_system("echo '" + tool_parameters['sudo_user'] + " ALL=(ALL:ALL) NOPASSWD:ALL' > " + reference_image_nfs_path + "/etc/sudoers.d/" + tool_parameters['sudo_user'])
 
         logging.info(bcolors.OKBLUE + 'Updating /etc/exports...' + bcolors.ENDC)
         protected_os_system("cat /etc/exports | grep '# diskless' || echo '# diskless' | tee -a /etc/exports")
-        protected_os_system("cat /etc/exports | grep '" + tool_parameters['nfs_path'] + "/" + image_selected_input + "' && sed -i 's/\/nfs\/diskless\/" + image_selected_input + "\ .*/\/nfs\/diskless\/" + image_selected_input + " " + node_selected_input + "(rw,no_root_squash)/' /etc/exports || sed -i -e '$a" + tool_parameters['nfs_path'] + "/" + image_selected_input + " " + node_selected_input + "(rw,no_root_squash)' /etc/exports")
+        protected_os_system("cat /etc/exports | grep '" + reference_image_nfs_path + "' && sed -i 's/\/nfs\/diskless\/" + image_selected_input + "\ .*/\/nfs\/diskless\/" + image_selected_input + " " + node_selected_input + "(rw,no_root_squash)/' /etc/exports || sed -i -e '$a" + reference_image_nfs_path + " " + node_selected_input + "(rw,no_root_squash)' /etc/exports")
         #  cat /etc/exports | grep '" + tool_parameters['nfs_path'] + "/almalinux_8_minimal ' && sudo sed -i 's/\/nfs\/diskless\/almalinux_9_minimal\ .*/\/nfs\/diskless\/almalinux_9_minimal mgt8(rw,no_root_squash)/' /etc/exports || sudo sed -i -e '$a" + tool_parameters['nfs_path'] + "/almalinux_9_minimal mgt2(rw,no_root_squash)' /etc/exports
         logging.info(bcolors.OKBLUE + 'Restarting nfs server service...' + bcolors.ENDC)
         protected_os_system("systemctl restart nfs-server")
@@ -493,10 +500,11 @@ while True:
 
         print(" Please enter reference image to check available kernels:")
         image_selected_input = input(" -->: ")
+        reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_input)
 
         ## Attention, RHEL 9 et 8 uniquement pour le moment
         print(" Detected kernels are the following:")
-        for it in os.scandir(tool_parameters['nfs_path'] + "/" + image_selected_input + "/lib/modules/"):
+        for it in os.scandir(reference_image_nfs_path + "/lib/modules/"):
             if it.is_dir():
                 print(" - " + it.name)
 
@@ -553,12 +561,12 @@ while True:
         logging.info(bcolors.OKBLUE + 'Copying new kernel from nfs image to http folder...' + bcolors.ENDC)
 
         if image_selected_metadata['family'] == "el9":
-            protected_os_system("cp -a " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/boot/initramfs-" + kernel_selected + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-" + kernel_selected + ".img")
-            protected_os_system("cp -a " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/lib/modules/" + kernel_selected + "/vmlinuz " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/vmlinuz-" + kernel_selected)
+            protected_os_system("cp -a " + reference_image_nfs_path + "/boot/initramfs-" + kernel_selected + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-" + kernel_selected + ".img")
+            protected_os_system("cp -a " + reference_image_nfs_path + "/lib/modules/" + kernel_selected + "/vmlinuz " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/vmlinuz-" + kernel_selected)
             protected_os_system("chmod 644 " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-*")
         elif image_selected_metadata['family'] == "el8":
-            protected_os_system("cp -a " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/boot/initramfs-" + kernel_selected + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-" + kernel_selected + ".img")
-            protected_os_system("cp -a " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/boot/vmlinuz-" + kernel_selected + " " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/vmlinuz-" + kernel_selected)
+            protected_os_system("cp -a " + reference_image_nfs_path + "/boot/initramfs-" + kernel_selected + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-" + kernel_selected + ".img")
+            protected_os_system("cp -a " + reference_image_nfs_path + "/boot/vmlinuz-" + kernel_selected + " " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/vmlinuz-" + kernel_selected)
             protected_os_system("chmod 644 " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-*")
         else:
             print(" Sorry, image family " + image_selected_metadata['family'] + " is unknown :( , aborting.")
@@ -573,11 +581,14 @@ while True:
 
         print(" Please enter reference image to clone:")
         image_selected_input = input(" -->: ")
+        reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_input)
+
         print(" Please enter clone reference image name:")
         image_clone_input = input(" -->: ")
+        clone_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_clone_input)
 
         logging.info(bcolors.OKBLUE + 'Cloning image...' + bcolors.ENDC)
-        protected_os_system("cp -a " + tool_parameters['nfs_path'] + "/" + image_selected_input + " " + tool_parameters['nfs_path'] + "/" + image_clone_input)
+        protected_os_system("cp -a " + reference_image_nfs_path + " " + clone_image_nfs_path)
         protected_os_system("cp -a " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + " " + tool_parameters['http_pxe_folder'] + "diskless/" + image_clone_input)
         logging.info(bcolors.OKBLUE + 'Updating new image metadata...' + bcolors.ENDC)
 
@@ -608,6 +619,7 @@ while True:
 
         print(" Please enter reference image to convert to live:")
         image_selected_input = input(" -->: ")
+        reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_input)
 
         try:
             with open(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/metadata.yaml", "r") as file:
@@ -634,7 +646,7 @@ while True:
         os.makedirs(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/mountdir/")
         protected_os_system("mount -o loop " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/workdir/LiveOS/rootfs.img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/mountdir/")
         logging.info(bcolors.OKBLUE + 'Copying files from reference image...' + bcolors.ENDC)
-        protected_os_system("cp -a " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['reference_name'].split(",")[0] + "/* " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/mountdir/")
+        protected_os_system("cp -a " + reference_image_nfs_path + "/* " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/mountdir/")
         protected_os_system("umount " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/mountdir/")
         logging.info(bcolors.OKBLUE + 'Squashing image...' + bcolors.ENDC)
         protected_os_system("mksquashfs " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/workdir " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/squashfs.img")
@@ -714,8 +726,9 @@ while True:
             
             print("\n Please enter reference image name to be deleted:")
             delete_image = input(" -->: ")
+            reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, delete_image)
             logging.info(bcolors.OKBLUE + 'Deleting image...' + bcolors.ENDC)
-            protected_os_system("rm -Rf " + tool_parameters['nfs_path'] + "/" + delete_image)
+            protected_os_system("rm -Rf " + reference_image_nfs_path)
             protected_os_system("rm -Rf " + tool_parameters['http_pxe_folder'] + "diskless/" + delete_image)
 
         if str(delete_image_type) == "3":

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -226,6 +226,10 @@ def get_reference_image_nfs_path(tool_parameters, reference_image_name):
     return os.path.join(tool_parameters['nfs_path'], reference_image_name)
 
 
+def get_reference_image_pxe_path(tool_paths, reference_image_name):
+    return os.path.join(tool_paths['http_pxe_diskless'], reference_image_name)
+
+
 print("""\
 
                 (o_
@@ -378,7 +382,6 @@ while True:
         print("")
 
         bootstrap_image_path = get_bootstrap_image_path(tool_paths, image_selected_input)
-        reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_input_name)
 
         try:
             with open(bootstrap_image_path + "/metadata.yaml", "r") as file:
@@ -394,24 +397,26 @@ while True:
         image_selected_metadata['type'] = "nfs_reference"
 
         bootstrap_image_path = get_bootstrap_image_path(tool_paths, image_selected_metadata['reference_name'])
+        reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_metadata['name'])
+        reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_selected_metadata['name'])
 
         logging.info(bcolors.OKBLUE + "Extracting bootstrap image copy in " + reference_image_nfs_path + bcolors.ENDC)
         protected_os_system("mkdir -p " + reference_image_nfs_path)
         protected_os_system("tar xzf " + bootstrap_image_path + "/image.tar.gz -C " + reference_image_nfs_path + "/")
         protected_os_system("rm -f " + reference_image_nfs_path + "/metadata.yaml")
-        logging.info(bcolors.OKBLUE + "Creating image folder at " + tool_parameters['http_pxe_folder'] + "/diskless/" + image_selected_metadata['name'] + bcolors.ENDC)
-        protected_os_system("mkdir -p " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'])
+        logging.info(bcolors.OKBLUE + "Creating image folder at " + reference_image_pxe_path + bcolors.ENDC)
+        protected_os_system("mkdir -p " + reference_image_pxe_path)
 
         if image_selected_metadata['family'] == "el9":
-            protected_os_system("cp " + reference_image_nfs_path + "/boot/initramfs-" + image_selected_metadata['kernel'] + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/initramfs-" + image_selected_metadata['kernel'] + ".img")
-            protected_os_system("cp " + reference_image_nfs_path + "/usr/lib/modules/" + image_selected_metadata['kernel'] + "/vmlinuz " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/vmlinuz-" + image_selected_metadata['kernel'])
+            protected_os_system("cp " + reference_image_nfs_path + "/boot/initramfs-" + image_selected_metadata['kernel'] + ".img " + reference_image_pxe_path + "/initramfs-" + image_selected_metadata['kernel'] + ".img")
+            protected_os_system("cp " + reference_image_nfs_path + "/usr/lib/modules/" + image_selected_metadata['kernel'] + "/vmlinuz " + reference_image_pxe_path + "/vmlinuz-" + image_selected_metadata['kernel'])
         elif image_selected_metadata['family'] == "el8":
-            protected_os_system("cp " + reference_image_nfs_path + "/boot/initramfs-" + image_selected_metadata['kernel'] + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/initramfs-" + image_selected_metadata['kernel'] + ".img")
-            protected_os_system("cp " + reference_image_nfs_path + "/boot/vmlinuz-" + image_selected_metadata['kernel'] + " " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/vmlinuz-" + image_selected_metadata['kernel'])
+            protected_os_system("cp " + reference_image_nfs_path + "/boot/initramfs-" + image_selected_metadata['kernel'] + ".img " + reference_image_pxe_path + "/initramfs-" + image_selected_metadata['kernel'] + ".img")
+            protected_os_system("cp " + reference_image_nfs_path + "/boot/vmlinuz-" + image_selected_metadata['kernel'] + " " + reference_image_pxe_path + "/vmlinuz-" + image_selected_metadata['kernel'])
         else:
             print(" Sorry, image family " + image_selected_metadata['family'] + " is unknown :( , aborting.")
             quit(1)
-        protected_os_system("chmod 644 " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/*")
+        protected_os_system("chmod 644 " + reference_image_pxe_path + "/*")
         ipxe_content = '''#!ipxe
         echo |
         echo | Entering diskless/images/{image_name}/boot.ipxe
@@ -438,18 +443,18 @@ while True:
         '''.format(image_kernel=("vmlinuz-" + image_selected_metadata['kernel']), image_initramfs=("initramfs-" + image_selected_metadata['kernel'] + ".img"), image_name=image_selected_metadata['name'], nfs_path=tool_parameters['nfs_path'])
 
         try:
-            ipxe_file = open(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/boot.ipxe", "w")
+            ipxe_file = open(reference_image_pxe_path + "/boot.ipxe", "w")
             ipxe_file.write(ipxe_content)
             ipxe_file.close()
         except Exception:
-            print(bcolors.FAIL + " An error occurred writing the file " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/boot.ipxe. Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred writing the file " + reference_image_pxe_path + "/boot.ipxe. Please investigate." + bcolors.ENDC)
             quit(1)
 
         try:
-            with open(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/metadata.yaml", "w") as file:
+            with open(reference_image_pxe_path + "/metadata.yaml", "w") as file:
                 yaml.dump(image_selected_metadata, file)
         except Exception:
-            print(bcolors.FAIL + " An error occurred writing the file " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'] + "/metadata.yaml. Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred writing the file " + reference_image_pxe_path + "/metadata.yaml. Please investigate." + bcolors.ENDC)
             quit(1)
 
         print(bcolors.OKGREEN + "\n == Reference image has been created :) ==" + bcolors.ENDC)
@@ -501,6 +506,7 @@ while True:
         print(" Please enter reference image to check available kernels:")
         image_selected_input = input(" -->: ")
         reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_input)
+        reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_selected_input)
 
         ## Attention, RHEL 9 et 8 uniquement pour le moment
         print(" Detected kernels are the following:")
@@ -514,34 +520,34 @@ while True:
         logging.info(bcolors.OKBLUE + 'Updating image metadata...' + bcolors.ENDC)
 
         try:
-            with open(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/metadata.yaml", "r") as file:
+            with open(reference_image_pxe_path + "/metadata.yaml", "r") as file:
                 image_selected_metadata = yaml.safe_load(file)
         except FileNotFoundError:
-            print(bcolors.FAIL + " File " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/metadata.yaml does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
+            print(bcolors.FAIL + " File " + reference_image_pxe_path + "/metadata.yaml does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
             quit(1)
         except Exception:
-            print(bcolors.FAIL + " An error occurred reading the file " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/metadata.yaml. Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred reading the file " + reference_image_pxe_path + "/metadata.yaml. Please investigate." + bcolors.ENDC)
             quit(1)
 
         image_selected_metadata['kernel'] = kernel_selected
 
         try:
-            with open(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/metadata.yaml", "w") as file:
+            with open(reference_image_pxe_path + "/metadata.yaml", "w") as file:
                 yaml.dump(image_selected_metadata, file)
         except Exception:
-            print(bcolors.FAIL + " An error occurred writing the file " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/metadata.yaml. Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred writing the file " + reference_image_pxe_path + "/metadata.yaml. Please investigate." + bcolors.ENDC)
             quit(1)
 
         logging.info(bcolors.OKBLUE + 'Updating boot.ipxe file...' + bcolors.ENDC)
 
         try:
-            with open(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/boot.ipxe", 'r') as file:
+            with open(reference_image_pxe_path + "/boot.ipxe", 'r') as file:
                 file_lines = file.readlines()
         except FileNotFoundError:
-            print(bcolors.FAIL + " File " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/boot.ipxe does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
+            print(bcolors.FAIL + " File " + reference_image_pxe_path + "/boot.ipxe does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
             quit(1)
         except Exception:
-            print(bcolors.FAIL + " An error occurred reading the file " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/boot.ipxe. Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred reading the file " + reference_image_pxe_path + "/boot.ipxe. Please investigate." + bcolors.ENDC)
             quit(1)
 
         for count, value in enumerate(file_lines):
@@ -551,23 +557,23 @@ while True:
                 file_lines[count] = "set image-initramfs initramfs-" + kernel_selected + ".img" + "\n"
 
         try:
-            ipxe_file = open(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/boot.ipxe", "w")
+            ipxe_file = open(reference_image_pxe_path + "/boot.ipxe", "w")
             ipxe_file.writelines(file_lines)
             ipxe_file.close()
         except Exception:
-            print(bcolors.FAIL + " An error occurred writing the file " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/boot.ipxe. Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred writing the file " + reference_image_pxe_path + "/boot.ipxe. Please investigate." + bcolors.ENDC)
             quit(1)
 
         logging.info(bcolors.OKBLUE + 'Copying new kernel from nfs image to http folder...' + bcolors.ENDC)
 
         if image_selected_metadata['family'] == "el9":
-            protected_os_system("cp -a " + reference_image_nfs_path + "/boot/initramfs-" + kernel_selected + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-" + kernel_selected + ".img")
-            protected_os_system("cp -a " + reference_image_nfs_path + "/lib/modules/" + kernel_selected + "/vmlinuz " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/vmlinuz-" + kernel_selected)
-            protected_os_system("chmod 644 " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-*")
+            protected_os_system("cp -a " + reference_image_nfs_path + "/boot/initramfs-" + kernel_selected + ".img " + reference_image_pxe_path + "/initramfs-" + kernel_selected + ".img")
+            protected_os_system("cp -a " + reference_image_nfs_path + "/lib/modules/" + kernel_selected + "/vmlinuz " + reference_image_pxe_path + "/vmlinuz-" + kernel_selected)
+            protected_os_system("chmod 644 " + reference_image_pxe_path + "/initramfs-*")
         elif image_selected_metadata['family'] == "el8":
-            protected_os_system("cp -a " + reference_image_nfs_path + "/boot/initramfs-" + kernel_selected + ".img " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-" + kernel_selected + ".img")
-            protected_os_system("cp -a " + reference_image_nfs_path + "/boot/vmlinuz-" + kernel_selected + " " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/vmlinuz-" + kernel_selected)
-            protected_os_system("chmod 644 " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/initramfs-*")
+            protected_os_system("cp -a " + reference_image_nfs_path + "/boot/initramfs-" + kernel_selected + ".img " + reference_image_pxe_path + "/initramfs-" + kernel_selected + ".img")
+            protected_os_system("cp -a " + reference_image_nfs_path + "/boot/vmlinuz-" + kernel_selected + " " + reference_image_pxe_path + "/vmlinuz-" + kernel_selected)
+            protected_os_system("chmod 644 " + reference_image_pxe_path + "/initramfs-*")
         else:
             print(" Sorry, image family " + image_selected_metadata['family'] + " is unknown :( , aborting.")
             quit(1)
@@ -582,33 +588,35 @@ while True:
         print(" Please enter reference image to clone:")
         image_selected_input = input(" -->: ")
         reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_input)
+        reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_selected_input)
 
         print(" Please enter clone reference image name:")
         image_clone_input = input(" -->: ")
         clone_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_clone_input)
+        clone_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_clone_input)
 
         logging.info(bcolors.OKBLUE + 'Cloning image...' + bcolors.ENDC)
         protected_os_system("cp -a " + reference_image_nfs_path + " " + clone_image_nfs_path)
-        protected_os_system("cp -a " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + " " + tool_parameters['http_pxe_folder'] + "diskless/" + image_clone_input)
+        protected_os_system("cp -a " + reference_image_pxe_path + " " + clone_image_pxe_path)
         logging.info(bcolors.OKBLUE + 'Updating new image metadata...' + bcolors.ENDC)
 
         try:
-            with open(tool_parameters['http_pxe_folder'] + "diskless/" + image_clone_input + "/metadata.yaml", "r") as file:
+            with open(clone_image_pxe_path + "/metadata.yaml", "r") as file:
                 image_selected_metadata = yaml.safe_load(file)
         except FileNotFoundError:
-            print(bcolors.FAIL + " File " + tool_parameters['http_pxe_folder'] + "diskless/" + image_clone_input + "/metadata.yaml does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
+            print(bcolors.FAIL + " File " + clone_image_pxe_path + "/metadata.yaml does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
             quit(1)
         except Exception:
-            print(bcolors.FAIL + " An error occurred reading the file " + tool_parameters['http_pxe_folder'] + "diskless/" + image_clone_input + "/metadata.yaml. Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred reading the file " + clone_image_pxe_path + "/metadata.yaml. Please investigate." + bcolors.ENDC)
             quit(1)
 
         image_selected_metadata['name'] = image_clone_input
 
         try:
-            with open(tool_parameters['http_pxe_folder'] + "diskless/" + image_clone_input + "/metadata.yaml", "w") as file:
+            with open(clone_image_pxe_path + "/metadata.yaml", "w") as file:
                 yaml.dump(image_selected_metadata, file)
         except Exception:
-            print(bcolors.FAIL + " An error occurred writing the file " + tool_parameters['http_pxe_folder'] + "diskless/" + image_clone_input + "/metadata.yaml. Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred writing the file " + clone_image_pxe_path + "/metadata.yaml. Please investigate." + bcolors.ENDC)
             quit(1)
 
         print(bcolors.OKGREEN + "\n == Image cloned successfully :) ==" + bcolors.ENDC)
@@ -620,15 +628,16 @@ while True:
         print(" Please enter reference image to convert to live:")
         image_selected_input = input(" -->: ")
         reference_image_nfs_path = get_reference_image_nfs_path(tool_parameters, image_selected_input)
+        reference_image_pxe_path = get_reference_image_pxe_path(tool_paths, image_selected_input)
 
         try:
-            with open(tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/metadata.yaml", "r") as file:
+            with open(reference_image_pxe_path + "/metadata.yaml", "r") as file:
                         image_selected_metadata = yaml.safe_load(file)
         except FileNotFoundError:
-            print(bcolors.FAIL + " File " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/metadata.yaml does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
+            print(bcolors.FAIL + " File " + reference_image_pxe_path + "/metadata.yaml does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
             quit(1)
         except Exception:
-            print(bcolors.FAIL + " An error occurred reading the file " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_input + "/metadata.yaml. Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred reading the file " + reference_image_pxe_path + "/metadata.yaml. Please investigate." + bcolors.ENDC)
             quit(1)
 
         print(" Now, please enter new live image name:")

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -7,6 +7,8 @@
 # ██████╔╝███████╗╚██████╔╝███████╗██████╔╝██║  ██║██║ ╚████║╚██████╔╝╚██████╔╝██║███████║███████╗
 # ╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═══╝ ╚══▀▀═╝  ╚═════╝ ╚═╝╚══════╝╚══════╝
 #
+# 2.0.2: Improve handling of paths. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
+# 2.0.1: Fix kernel upgrade option. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.0: Full rewamp. Benoît Leveugle <benoit.leveugle@gmail.com>
 # 1.3.7: Improved disklessset checks. Thiago Cardozo <thiago_cardozo@yahoo.com.br>
 # 1.3.6: Fix permissions. Benoit Leveugle <benoit.leveugle@gmail.com>
@@ -240,7 +242,7 @@ print("""\
       (o_  (o_  //\\
       (/)_ (/)_ V_/_
    BlueBanquise diskless
-   v2.0.0 - beta
+   v2.0.2 - beta
    https://github.com/bluebanquise/bluebanquise/
 
 """)

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -214,11 +214,12 @@ def protected_os_system(raw_command):
     return 0
 
 
-def get_tmp_image_info(tool_paths, image_source_file_name):
-    tmp_image_info = {}
-    tmp_image_info['metadata'] = os.path.join(tool_paths['bootstrap_images_tmp'], "metadata.yaml")
-    tmp_image_info['image_source'] = os.path.join(tool_paths['bootstrap_images_tmp'], image_source_file_name)
-    return tmp_image_info
+def get_tmp_image_source_path(tool_paths, image_source_file_name):
+    return os.path.join(tool_paths['bootstrap_images_tmp'], image_source_file_name)
+
+
+def get_bootstrap_image_path(tool_paths, image_name):
+    return os.path.join(tool_paths['bootstrap_images'], image_name)
 
 
 print("""\
@@ -317,43 +318,44 @@ while True:
             print(" Please enter bootstrap image ABSOLUTE path of tar.gz archive:")
             image_path = input(" -->: ")
             image_source_file_name = image_path.split('/')[-1]
-            tmp_image_info = get_tmp_image_info(tool_paths, image_source_file_name)
+            tmp_image_source_path = get_tmp_image_source_path(tool_paths, image_source_file_name)
             logging.info(bcolors.OKBLUE + 'Copying image from ' + image_path + ', please be patient...' + bcolors.ENDC)
-            protected_os_system("cp " + image_path + " " + tmp_image_info['image_source'])
+            protected_os_system("cp " + image_path + " " + tmp_image_source_path)
 
         elif source_action == "2":
             print(" Please enter bootstrap image URL of tar.gz archive:")
             image_url = input(" -->: ")
             image_source_file_name = image_url.split('/')[-1]
-            tmp_image_info = get_tmp_image_info(tool_paths, image_source_file_name)
+            tmp_image_source_path = get_tmp_image_source_path(tool_paths, image_source_file_name)
             logging.info(bcolors.OKBLUE + 'Downloading image from ' + image_url + ', please be patient...' + bcolors.ENDC)
             response = requests.get(image_url)
             try:
-                with open(tmp_image_info['image_source'], 'wb') as file:
+                with open(tmp_image_path, 'wb') as file:
                     file.write(response.content)
             except Exception:
                 print(bcolors.FAIL + " An error occurred writing the image locally. Please investigate." + bcolors.ENDC)
                 quit(1)
 
         logging.info(bcolors.OKBLUE + 'Extracting image metadata...' + bcolors.ENDC)
-        protected_os_system("rm -f " + tmp_image_info['metadata'])
-        protected_os_system("tar xzf " + tmp_image_info['image_source'] + " -C " + tool_paths['bootstrap_images_tmp'] + "/ metadata.yaml")
+        protected_os_system("rm -f " + tool_paths['bootstrap_images_tmp'] + "/metadata.yaml")
+        protected_os_system("tar xzf " + tmp_image_source_path + " -C " + tool_paths['bootstrap_images_tmp'] + "/ metadata.yaml")
         try:
-            with open(tmp_image_info['metadata'], "r") as file:
+            with open(tool_paths['bootstrap_images_tmp'] + "/metadata.yaml", "r") as file:
                 image_metadata = yaml.safe_load(file)
         except FileNotFoundError:
-            print(bcolors.FAIL + " File " + tmp_image_info['metadata'] + " does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
+            print(bcolors.FAIL + " File " + tool_paths['bootstrap_images_tmp'] + "/metadata.yaml does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
             quit(1)
         except Exception:
-            print(bcolors.FAIL + " An error occurred reading the file " + tmp_image_info['metadata'] + ". Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred reading the file " + tool_paths['bootstrap_images_tmp'] + "/metadata.yaml. Please investigate." + bcolors.ENDC)
             quit(1)
         print(" Found following metadata for new image:")
         display_image_metadata(image_metadata)
+        bootstrap_image_path = get_bootstrap_image_path(tool_paths, image_metadata['name'])
 
         logging.info(bcolors.OKBLUE + 'Storing image...' + bcolors.ENDC)
-        protected_os_system("mkdir -p " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + image_metadata['name'])
-        protected_os_system("mv " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/tmp/" + image_source_file_name + " " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + image_metadata['name'] + "/image.tar.gz")
-        protected_os_system("mv " + tmp_image_info['metadata'] + " " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + image_metadata['name'] + "/metadata.yaml")
+        protected_os_system("mkdir -p " + bootstrap_image_path)
+        protected_os_system("mv " + tmp_image_source_path + " " + bootstrap_image_path + "/image.tar.gz")
+        protected_os_system("mv " + tool_paths['bootstrap_images_tmp'] + "/metadata.yaml " + bootstrap_image_path + "/metadata.yaml")
         print(bcolors.OKGREEN + "\n == Bootstrap image " + image_metadata['name'] + " is now ready to be used :) ==" + bcolors.ENDC)
 
     if main_action == '3':
@@ -371,22 +373,26 @@ while True:
         image_selected_input_name = input(" -->: ")
         print("")
 
+        bootstrap_image_path = get_bootstrap_image_path(tool_paths, image_selected_input)
+
         try:
-            with open(tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + image_selected_input + "/metadata.yaml", "r") as file:
+            with open(bootstrap_image_path + "/metadata.yaml", "r") as file:
                 image_selected_metadata = yaml.safe_load(file)
         except FileNotFoundError:
-            print(bcolors.FAIL + " File " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + image_selected_input + "/metadata.yaml does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
+            print(bcolors.FAIL + " File " + bootstrap_image_path + "/metadata.yaml does not exist, please re-run pxe_stack role before using the tool." + bcolors.ENDC)
             quit(1)
         except Exception:
-            print(bcolors.FAIL + " An error occurred reading the file " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + image_selected_input + "/metadata.yaml. Please investigate." + bcolors.ENDC)
+            print(bcolors.FAIL + " An error occurred reading the file " + bootstrap_image_path + "/metadata.yaml. Please investigate." + bcolors.ENDC)
             quit(1)
         image_selected_metadata['reference_name'] = image_selected_metadata['name']
         image_selected_metadata['name'] = image_selected_input_name
         image_selected_metadata['type'] = "nfs_reference"
 
+        bootstrap_image_path = get_bootstrap_image_path(tool_paths, image_selected_metadata['reference_name'])
+
         logging.info(bcolors.OKBLUE + "Extracting bootstrap image copy in " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'] + bcolors.ENDC)
         protected_os_system("mkdir -p " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'])
-        protected_os_system("tar xzf " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + image_selected_metadata['reference_name'] + "/image.tar.gz -C " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'])
+        protected_os_system("tar xzf " + bootstrap_image_path + "/image.tar.gz -C " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'])
         protected_os_system("rm -f " + tool_parameters['nfs_path'] + "/" + image_selected_metadata['name'] + "/metadata.yaml")
         logging.info(bcolors.OKBLUE + "Creating image folder at " + tool_parameters['http_pxe_folder'] + "/diskless/" + image_selected_metadata['name'] + bcolors.ENDC)
         protected_os_system("mkdir -p " + tool_parameters['http_pxe_folder'] + "diskless/" + image_selected_metadata['name'])
@@ -698,8 +704,9 @@ while True:
             
             print("\n Please enter bootstrap image name to be deleted:")
             delete_image = input(" -->: ")
+            bootstrap_image_path = get_bootstrap_image_path(tool_paths, delete_image)
             logging.info(bcolors.OKBLUE + 'Deleting image...' + bcolors.ENDC)
-            protected_os_system("rm -Rf " + tool_parameters['sudo_user_home'] + "/diskless/bootstrap_images/" + delete_image)
+            protected_os_system("rm -Rf " + bootstrap_image_path)
 
         if str(delete_image_type) == "2":
 

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -7,6 +7,7 @@
 # ██████╔╝███████╗╚██████╔╝███████╗██████╔╝██║  ██║██║ ╚████║╚██████╔╝╚██████╔╝██║███████║███████╗
 # ╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═══╝ ╚══▀▀═╝  ╚═════╝ ╚═╝╚══════╝╚══════╝
 #
+# 2.0.6: Use --numeric-owner when extracting bootstrap image to ensure correct uid/gid. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.5: Add debug optional parameter. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.4: Ensure parent of home dir exists. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.3: Sanitize user input. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
@@ -278,7 +279,7 @@ print("""\
       (o_  (o_  //\\
       (/)_ (/)_ V_/_
    BlueBanquise diskless
-   v2.0.5 - beta
+   v2.0.6 - beta
    https://github.com/bluebanquise/bluebanquise/
 
 """)
@@ -441,7 +442,7 @@ while True:
 
         logging.info(bcolors.OKBLUE + "Extracting bootstrap image copy in " + reference_image_nfs_path + bcolors.ENDC)
         protected_os_system("mkdir -p " + reference_image_nfs_path)
-        protected_os_system("tar xzf " + bootstrap_image_path + "/image.tar.gz -C " + reference_image_nfs_path + "/")
+        protected_os_system("tar --numeric-owner -x -z -f " + bootstrap_image_path + "/image.tar.gz -C " + reference_image_nfs_path + "/")
         protected_os_system("rm -f " + reference_image_nfs_path + "/metadata.yaml")
         logging.info(bcolors.OKBLUE + "Creating image folder at " + reference_image_pxe_path + bcolors.ENDC)
         protected_os_system("mkdir -p " + reference_image_pxe_path)

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -7,6 +7,7 @@
 # ██████╔╝███████╗╚██████╔╝███████╗██████╔╝██║  ██║██║ ╚████║╚██████╔╝╚██████╔╝██║███████║███████╗
 # ╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═══╝ ╚══▀▀═╝  ╚═════╝ ╚═╝╚══════╝╚══════╝
 #
+# 2.0.7: Update boot.ipxe when cloning reference image. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.6: Use --numeric-owner when extracting bootstrap image to ensure correct uid/gid. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.5: Add debug optional parameter. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.4: Ensure parent of home dir exists. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
@@ -279,7 +280,7 @@ print("""\
       (o_  (o_  //\\
       (/)_ (/)_ V_/_
    BlueBanquise diskless
-   v2.0.6 - beta
+   v2.0.7 - beta
    https://github.com/bluebanquise/bluebanquise/
 
 """)
@@ -646,6 +647,38 @@ while True:
             quit(1)
 
         image_selected_metadata['name'] = image_clone_input
+        ipxe_content = '''#!ipxe
+        echo |
+        echo | Entering diskless/images/{image_name}/boot.ipxe
+        echo |
+        set image-kernel {image_kernel}
+        set image-initramfs {image_initramfs}
+        echo | Now starting nfs image boot.
+        echo |
+        echo | Parameters used:
+        echo | > Image target: {image_name}
+        echo | > Console: ${{eq-console}}
+        echo | > Additional kernel parameters: ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}}
+        echo |
+        echo | Loading linux ...
+        kernel http://${{next-server}}/pxe/diskless/{image_name}/${{image-kernel}} initrd=${{image-initramfs}} selinux=0 text=1 root=nfs:${{next-server}}:{nfs_path}/{image_name},vers=4.2,rw rw ${{eq-console}} ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}} rd.net.timeout.carrier=30 rd.net.timeout.ifup=60 rd.net.dhcp.retry=4
+        echo | Loading initial ramdisk ...
+        initrd http://${{next-server}}/pxe/diskless/{image_name}/${{image-initramfs}}
+        echo | ALL DONE! We are ready.
+        echo | Booting in 4s ...
+        echo |
+        echo +----------------------------------------------------+
+        sleep 4
+        boot
+        '''.format(image_kernel=("vmlinuz-" + image_selected_metadata['kernel']), image_initramfs=("initramfs-" + image_selected_metadata['kernel'] + ".img"), image_name=image_selected_metadata['name'], nfs_path=tool_parameters['nfs_path'])
+
+        try:
+            ipxe_file = open(clone_image_pxe_path + "/boot.ipxe", "w")
+            ipxe_file.write(ipxe_content)
+            ipxe_file.close()
+        except Exception:
+            print(bcolors.FAIL + " An error occurred writing the file " + clone_image_pxe_path + "/boot.ipxe. Please investigate." + bcolors.ENDC)
+            quit(1)
 
         try:
             with open(clone_image_pxe_path + "/metadata.yaml", "w") as file:

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -7,6 +7,7 @@
 # ██████╔╝███████╗╚██████╔╝███████╗██████╔╝██║  ██║██║ ╚████║╚██████╔╝╚██████╔╝██║███████║███████╗
 # ╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═══╝ ╚══▀▀═╝  ╚═════╝ ╚═╝╚══════╝╚══════╝
 #
+# 2.0.5: Add debug optional parameter. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.4: Ensure parent of home dir exists. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.3: Sanitize user input. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.2: Improve handling of paths. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
@@ -84,6 +85,7 @@ import shutil
 import subprocess
 import crypt
 import string
+import sys
 
 
 # Colors, from https://stackoverflow.com/questions/287871/how-to-print-colored-text-in-terminal-in-python
@@ -199,6 +201,8 @@ def display_images(image_type, tool_paths):
 
 
 def protected_os_system(raw_command):
+    if '--debug' in sys.argv or '-d' in sys.argv:
+        print(raw_command)
 
     try:
         child = subprocess.Popen(raw_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
@@ -274,7 +278,7 @@ print("""\
       (o_  (o_  //\\
       (/)_ (/)_ V_/_
    BlueBanquise diskless
-   v2.0.4 - beta
+   v2.0.5 - beta
    https://github.com/bluebanquise/bluebanquise/
 
 """)
@@ -797,6 +801,7 @@ while True:
 # INTRODUCTION AND GENERAL CONCEPT
 
 bluebanquise-diskless tool is made to manage diskless images life cycles, from creation to production and maintenance.
+You need to run this script with sudo or as root. Pass "-d" or "--debug" parameter to the script to display commands executed.
 
 Workflow is the following, assuming user wishes to boot a pool of nodes with the same live image:
 

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -7,6 +7,7 @@
 # ██████╔╝███████╗╚██████╔╝███████╗██████╔╝██║  ██║██║ ╚████║╚██████╔╝╚██████╔╝██║███████║███████╗
 # ╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═══╝ ╚══▀▀═╝  ╚═════╝ ╚═╝╚══════╝╚══════╝
 #
+# 2.0.4: Ensure parent of home dir exists. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.3: Sanitize user input. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.2: Improve handling of paths. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.1: Fix kernel upgrade. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
@@ -273,7 +274,7 @@ print("""\
       (o_  (o_  //\\
       (/)_ (/)_ V_/_
    BlueBanquise diskless
-   v2.0.3 - beta
+   v2.0.4 - beta
    https://github.com/bluebanquise/bluebanquise/
 
 """)
@@ -513,6 +514,7 @@ while True:
         image_selected_user_password = crypt.crypt(image_selected_user_password, crypt.mksalt(crypt.METHOD_SHA512))
 
         logging.info(bcolors.OKBLUE + 'Adding bluebanquise user to image...' + bcolors.ENDC)
+        protected_os_system("mkdir -p " + reference_image_nfs_path + os.path.dirname(tool_parameters['sudo_user_home']))
         protected_os_system("groupadd -R " + reference_image_nfs_path + "/ --system " + tool_parameters['sudo_user'])
         protected_os_system("useradd  -R " + reference_image_nfs_path + "/ -m -c 'BlueBanquise user' -d " + tool_parameters['sudo_user_home'] + " --system -g " + tool_parameters['sudo_user'] + " -s /bin/bash -p '" + image_selected_user_password + "' " + tool_parameters['sudo_user'])
 #            protected_os_system("useradd  -R " + tool_parameters['nfs_path'] + "/" + image_selected_input + "/ -m -c 'BlueBanquise user' -d /var/lib/bluebanquise --system -g bluebanquise -s /bin/bash bluebanquise")

--- a/collections/infrastructure/roles/pxe_stack/vars/main.yml
+++ b/collections/infrastructure/roles/pxe_stack/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pxe_stack_role_version: 1.16.4
+pxe_stack_role_version: 1.16.5
 
 pxe_stack_supported_os:
   redhat:


### PR DESCRIPTION
## Describe your changes
Fixes  and minor improvements to bluebanquise diskless
- 2.0.2: some refactoring to path handling, this avoids issues with missing "/" in the diskless.yml fole
- 2.0.3: sanitize user input: use strip(), don't accept empty strings, don't allow special characters for image names (POSIX Portable Filename Character Set)
- 2.0.4: Ensure parent of home dir exists, this prevents failure of "useradd" on non-standard home directories
- 2.0.5: Add debug optional parameter (--debug)
- 2.0.6: The tar command to extract bootstrap image may modify uid/gid of files to match the uid/gid of the local node. Adding "--numeric-owner" to keep the original uid/gid. Otherwise, services like sssd / chrony may fail in image.
- 2.0.7: Fix #953 now a new boot.ipxe file is created for clone image

## Issue ticket number and link if any
#953 

Note: I have more changes to bluebanquise-diskless planned, let's begin with these :) Please let me know if I need to edit/remove any of the changes.