### PR TITLE
Change to only reboot if something was updated

### DIFF
--- a/collections/infrastructure/galaxy.yml
+++ b/collections/infrastructure/galaxy.yml
@@ -4,7 +4,7 @@ namespace: bluebanquise
 name: infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.13.2
+version: 3.13.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/infrastructure/roles/update_reboot/README.md
+++ b/collections/infrastructure/roles/update_reboot/README.md
@@ -23,4 +23,5 @@ to `600`, which means `600s -> 600/60 = 10 minutes`.
 
 ## Changelog
 
+* 1.0.1: Just a simple update so only reboot if something was changed. Lucas Santos <lucassouzasantos@gmail.com>
 * 1.0.0: Role creation. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/update_reboot/tasks/main.yml
+++ b/collections/infrastructure/roles/update_reboot/tasks/main.yml
@@ -3,8 +3,9 @@
     name: "*"
     state: latest
   when: update_reboot_upgrade_packages
+  register: packages_update
 
 - name: reboot <|> Reboot system to run latest kernel
   ansible.builtin.reboot:
     reboot_timeout: "{{ update_reboot_reboot_timeout }}"
-  when: update_reboot_reboot
+  when: update_reboot_reboot and packages_update.changed


### PR DESCRIPTION
## Describe your changes

change the update_reboot role to only reboot the server if something was really updated.

## Checklist before requesting a review
- [x] Document introduced changes / variables in role README.md if any
- [x] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [x] Update changelog inside role README.md
- [x] If not present, please also add your name in the related collection authors list in galaxy.yml
