### PR TITLE
fix(clustershell): Unnecessary leading comma in Clustershell template

### DIFF
--- a/collections/infrastructure/galaxy.yml
+++ b/collections/infrastructure/galaxy.yml
@@ -4,7 +4,7 @@ namespace: bluebanquise
 name: infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.14.3
+version: 3.14.4
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/infrastructure/roles/clustershell/README.md
+++ b/collections/infrastructure/roles/clustershell/README.md
@@ -31,6 +31,7 @@ Tree execution mode is missing.
 
 ## Changelog
 
+* 1.4.0: Unnecessary leading comma in Clustershell template. Leo Magdanello <lmagdanello40@gmail.com>
 * 1.3.0: Add optional variable clustershell_prefix_path. Pierre Gay <pierre.gay@u-bordeaux.fr>, Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>
 * 1.2.0: Update to BB 2.0 format. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.1.0: Update to pip Ansible. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/clustershell/templates/local.cfg.j2
+++ b/collections/infrastructure/roles/clustershell/templates/local.cfg.j2
@@ -1,9 +1,9 @@
 #### Blue Banquise file ####
-## {{ansible_managed}}
+## {{ ansible_managed }}
 
 {% for gr, nodes in groups.items() %}
 {% if (gr | string) != 'ungrouped' %}
-{{ gr }}: {% for node in nodes | sort %}{% if loop.first %}{{ node }}{% else %},{{ node }}{% endif %}{% endfor %}
+{{ gr }}: {{ nodes | sort | join(',') }}
 
 {% endif %}
 {% endfor %}

--- a/collections/infrastructure/roles/clustershell/vars/main.yml
+++ b/collections/infrastructure/roles/clustershell/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-clustershell_role_version: 1.3.0
+clustershell_role_version: 1.4.0


### PR DESCRIPTION
## Describe your changes

- Replaced manual comma placement logic using `loop.first` with the `join(',')` filter to handle node separation.
- This change simplifies the template by removing unnecessary conditional logic for commas and ensures no leading or trailing commas are present in the output.
- The join(',') filter automatically joins the sorted nodes with commas, improving both readability and functionality.

## Issue ticket number and link if any
[!983](https://github.com/bluebanquise/bluebanquise/issues/983)

## Checklist before requesting a review
- [ x ] Document introduced changes / variables in role README.md if any
- [ x ] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [ x ] Update changelog inside role README.md
- [ x ] If not present, please also add your name in the related collection authors list in galaxy.yml