### PR TITLE
FIX: pxe_stack for RH causing duplicated PermitRootLogin entry in sshd_config

### DIFF
--- a/collections/infrastructure/galaxy.yml
+++ b/collections/infrastructure/galaxy.yml
@@ -4,7 +4,7 @@ namespace: bluebanquise
 name: infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.14.4
+version: 3.14.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/infrastructure/roles/pxe_stack/README.md
+++ b/collections/infrastructure/roles/pxe_stack/README.md
@@ -189,7 +189,7 @@ However, an host CANNOT be in 2 hardware or os groups at the same time. Create a
 
 Lets take as an example a cluster with 2 kind of servers, one kind based on Ubuntu 22.04 with GPUs (hosts c1 to c10) and another one based on RHEL 9 for CPU only (hosts c11 to c100), and both based on the same server hardware (ASUS_G9).
 
-This will mean 2 virtual equipment profiles : 
+This will mean 2 virtual equipment profiles :
 
 * `hw_ASUS_G9_with_os_ubuntu_22.04_GPU`
 * `hw_ASUS_G9_with_os_rhel9`
@@ -550,7 +550,7 @@ Remember to skip "identify" and "secret" tags:
 
 ```
 ansible-playbook --become --skip-tags identify,secret /path/to/playbook.yml
-``` 
+```
 
 ##### Using chroot
 
@@ -614,7 +614,7 @@ If using BlueBanquise roles, simply apply playbook with missing tags:
 
 ```
 ansible-playbook --become --tags identify,secret /path/to/playbook.yml
-```  
+```
 
 #### Debug and errors
 
@@ -645,7 +645,7 @@ It is possible to see that this even fail with nfs 4.2 mount:
  Flags: rw,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=10.10.0.8,local_lock=none,addr=10.10.0.1
 [bluebanquise@c001 ~]$
 ```
- 
+
 Solution is to install the failing package using chroot method on NFS server:
 
 ```
@@ -726,6 +726,7 @@ Note that using an home folder into /home for the bluebanquise sudo user can be 
 
 ## Changelog
 
+* 1.18.3: Fix dublicated PermitRootLogin in RH sshd_config. Thiago Cardozo <boubee.thiago@gmail.com>
 * 1.18.2: Fix opensuse leap autoyast. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.18.1: Fix ubuntu 24.04 support. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.18.0: Add ubuntu 24.04 support. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/pxe_stack/templates/RedHat/kickstart.cfg.j2
+++ b/collections/infrastructure/roles/pxe_stack/templates/RedHat/kickstart.cfg.j2
@@ -112,7 +112,7 @@ set -x
 {% if pxe_stack_enable_root %}
 
 # Ensure root login is enabled via ssh
-sed -i 's/^.*PermitRootLogin.*$/PermitRootLogin\ yes/' /etc/ssh/sshd_config
+sed -i "s/^#PermitRootLogin.*\$/PermitRootLogin yes/g" /etc/ssh/sshd_config
 # Add ssh keys from ssh_keys list
 mkdir /root/.ssh
 cat << xxEOFxx >> /root/.ssh/authorized_keys
@@ -125,7 +125,7 @@ restorecon -R -v /root/.ssh
 
 {% else %}
 # Ensure no root login is enabled via ssh
-sed -i 's/^.*PermitRootLogin.*$/PermitRootLogin\ no/' /etc/ssh/sshd_config
+sed -i "s/^#PermitRootLogin.*\$/PermitRootLogin no/g" /etc/ssh/sshd_config
 # Add ssh keys from ssh_keys list
 mkdir {{ pxe_stack_sudo_user_home }}/.ssh
 cat << xxEOFxx >> {{ pxe_stack_sudo_user_home }}/.ssh/authorized_keys

--- a/collections/infrastructure/roles/pxe_stack/vars/main.yml
+++ b/collections/infrastructure/roles/pxe_stack/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pxe_stack_role_version: 1.18.2
+pxe_stack_role_version: 1.18.3
 
 pxe_stack_supported_os:
   redhat:


### PR DESCRIPTION
## Describe your changes
The sed command present in the kickstart template has a too inclusive regexp,
resulting in the substitution of a PermitRootLogin parameter description in a documentation block,
which leads to 2 repetitive entries.
So we narrow it down to the line starting with "#PermitRootLogin", which is the actual commented out option.

## Checklist before requesting a review
- [ ] Document introduced changes / variables in role README.md if any
- [x] Increment role version in vars/main.yml (a.b.c: +1 to b for a feature added, +1 to c for a bug fix)
- [x] Update changelog inside role README.md
- [x] If not present, please also add your name in the related collection authors list in galaxy.yml
