### PR TITLE
Fix: HA pcs - Task doesn`t find file on running node

### DIFF
--- a/collections/high_availability/galaxy.yml
+++ b/collections/high_availability/galaxy.yml
@@ -4,7 +4,7 @@ namespace: bluebanquise
 name: high_availability
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.1.1
+version: 3.1.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/high_availability/roles/pcs/README.md
+++ b/collections/high_availability/roles/pcs/README.md
@@ -374,9 +374,9 @@ pcs_stonith:
     avoids: ha1                                                        # Avoid resource to be running on own host
 ```
 
-If `pcs_stonith` is not defined in the inventory, then this role will disable 
-STONITH (stonith-enabled: false). This will allow the HA cluster to operate 
-without STONITH (not recommended for production). 
+If `pcs_stonith` is not defined in the inventory, then this role will disable
+STONITH (stonith-enabled: false). This will allow the HA cluster to operate
+without STONITH (not recommended for production).
 Adding the `pcs_stonith` variable will enable STONITH again.
 
 ## 3. Deploy HA
@@ -613,14 +613,15 @@ not present. Then in HA resources, declare the following:
 
 ## 5. Known Issues
 
-* When pacemaker/corosync are first installed in Ubuntu 20/22, 
-a default pacemaker cluster is created. 
-This role will detect the presence of the default cluster and destroy it. 
-The conditions for destroying the cluster are matching the cluster name 'debian' 
+* When pacemaker/corosync are first installed in Ubuntu 20/22,
+a default pacemaker cluster is created.
+This role will detect the presence of the default cluster and destroy it.
+The conditions for destroying the cluster are matching the cluster name 'debian'
 and having 0 resources configured.
 
 ## 6. Changelog
 
+* 1.1.4: Fix error when running with multiple mngt nodes. Thiago Cardozo <boubee.thiago@gmail.com>
 * 1.1.3: README update. Hamid MERZOUKI <hamid.merzouki@naverlabs.com>
 * 1.1.2: Adapt to hw os split. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.1.1: Fix service name in RHEL firewall. Giacomo Mc Evoy <gino.mcevoy@gmail.com>

--- a/collections/high_availability/roles/pcs/tasks/main.yml
+++ b/collections/high_availability/roles/pcs/tasks/main.yml
@@ -174,6 +174,7 @@
 
     - name: command <|> Store current configuration into cib file
       ansible.builtin.command: "pcs cluster cib {{ pcs_cib_file_path }}"
+      delegate_to: "{{ ansible_hostname }}"
       changed_when: false
 
     - name: command <|> Add resources to cluster

--- a/collections/high_availability/roles/pcs/vars/main.yml
+++ b/collections/high_availability/roles/pcs/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-pcs_role_version: 1.1.3
+pcs_role_version: 1.1.4


### PR DESCRIPTION
When the task to load a cib configuration file runs in the secondary mngt node, we get the following error:

`stderr: 'Error: unable to parse new cib: [Errno 2] No such file or directory: ''/root/ha_config.ansible.xml''`

As it happens the task that stores the file previously runs only on mngt1.
This PR changes that in that every node will create the cib file locally.