### PR TITLE
Fix/Feat: Grafana - fix uid/gid conflict; Allow custom firewall port

### DIFF
--- a/collections/monitoring/roles/grafana/README.md
+++ b/collections/monitoring/roles/grafana/README.md
@@ -151,6 +151,7 @@ Note: if you try to add dashboards, the role will alwats at checking if the data
 
 ## Changelog
 
+* 2.2.0: Optional uid/gid;Custom firewall port. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.1.2: Adapt to hw os split. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 2.1.1: Added additional\_json\_data variable in datasource. Alexandra Darrieutort <alexandra.darrieutort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 2.1.0: Ability to install a recent version of Grafana. Alexandra Darrieutort <alexandra.darrieutort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>

--- a/collections/monitoring/roles/grafana/defaults/main.yml
+++ b/collections/monitoring/roles/grafana/defaults/main.yml
@@ -4,8 +4,8 @@ grafana_provisioning_synced: false
 grafana_install_oss_packages: false
 
 # RPM is configuring the following user: uid=990(grafana) gid=984(grafana) groups=984(grafana)
-grafana_user_gid: 984
-grafana_user_uid: 990
+grafana_user_gid:
+grafana_user_uid:
 grafana_user_home: /usr/share/grafana
 
 grafana_instance: "{{ ansible_fqdn | default(ansible_host) | default(inventory_hostname) }}"

--- a/collections/monitoring/roles/grafana/tasks/install.yml
+++ b/collections/monitoring/roles/grafana/tasks/install.yml
@@ -2,16 +2,16 @@
 - name: install <|> Add grafana group
   ansible.builtin.group:
     name: grafana
-    gid: "{{ grafana_user_gid }}"
+    gid: "{{ grafana_user_gid | default(omit) }}"
     state: present
 
 - name: install <|> Add grafana user
   ansible.builtin.user:
     name: grafana
     shell: /bin/false
-    uid: "{{ grafana_user_uid }}"
+    uid: "{{ grafana_user_uid | default(omit) }}"
     group: grafana
-    home: "{{ grafana_user_home }}"
+    system: True
     state: present
 
 - name: install <|> Check for log file
@@ -22,8 +22,8 @@
 - name: install <|> Change log owner
   ansible.builtin.file:
     path: "{{ grafana_logs_dir }}"
-    owner: "{{ grafana_user_uid }}"
-    group: "{{ grafana_user_gid }}"
+    owner: "grafana"
+    group: "grafana"
   when: log_exists.stat.exists
 
 - name: "install <|> Add services to firewall's {{ grafana_firewall_zone | default('public') }} zone"
@@ -36,7 +36,22 @@
   when:
     - ansible_facts.os_family == "RedHat"
     - os_firewall | default(false) | bool
+    - grafana_port == grafana_default_port
   loop: "{{ grafana_firewall_services_to_add }}"
+  tags:
+    - firewall
+
+- name: "install ¦ Add custom grafana port to firewall's {{ grafana_firewall_zone | default('public') }} zone"
+  ansible.builtin.firewalld:
+    zone: "{{ grafana_firewall_zone | default('public') }}"
+    port: "{{ grafana_port }}/tcp"
+    immediate: "yes"
+    permanent: "yes"
+    state: enabled
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - ep_firewall | default(false) | bool
+    - grafana_port != grafana_default_port
   tags:
     - firewall
 

--- a/collections/monitoring/roles/grafana/vars/main.yml
+++ b/collections/monitoring/roles/grafana/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-grafana_role_version: 2.1.2
+grafana_role_version: 2.2.0


### PR DESCRIPTION
* Grafana user/group ids are usually created at package installation, so let it empty as default to avoid conflicts
* Grafana user changed to system type
* Set log owner by name as uid may vary with change above
* Allow setting custom port in firewalld