### PR TITLE
Fix: powerman - Expand powerman nodeset for ipmipower

### DIFF
--- a/collections/commons/plugins/filter/nodeset.py
+++ b/collections/commons/plugins/filter/nodeset.py
@@ -8,6 +8,7 @@ __metaclass__ = type
 
 from ansible.errors import AnsibleError
 from ClusterShell.NodeSet import NodeSet
+from ClusterShell.NodeSet import expand
 from ansible.module_utils.common.text.converters import to_native
 
 
@@ -15,7 +16,7 @@ def nodeset(nodes_list):
     '''Convert a list of nodes to ClusterShell's NodeSet'''
 
     try:
-        nodeset = NodeSet(",".join(nodes_list))
+        nodeset = ",".join(expand(NodeSet(",".join(nodes_list))))
     except Exception as e:
         raise AnsibleError('Error joining nodeset, original exception: %s' % to_native(e))
 

--- a/collections/infrastructure/galaxy.yml
+++ b/collections/infrastructure/galaxy.yml
@@ -4,7 +4,7 @@ namespace: bluebanquise
 name: infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.14.4
+version: 3.14.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/infrastructure/roles/powerman/README.md
+++ b/collections/infrastructure/roles/powerman/README.md
@@ -57,6 +57,7 @@ Files generated:
 
 ## Changelog
 
+* 1.3.3: Expand nodeset for ipmipower. Thiago Cardozo <boubee.thiago@gmail.com>
 * 1.3.2: Adapt to hw os split. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.3.1: Fix defaults path. Pierre Gay <pierre.gay@u-bordeaux.fr>, Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>
 * 1.3.0: add optional variable powerman_enable_ipmi_lan_2_0. Pierre Gay <pierre.gay@u-bordeaux.fr>, Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>

--- a/collections/infrastructure/roles/powerman/vars/main.yml
+++ b/collections/infrastructure/roles/powerman/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-powerman_role_version: 1.3.2
+powerman_role_version: 1.3.3


### PR DESCRIPTION
ipimipower isn't expanding nodesets with multiple intervals properly, ex:

> ipmipower -h head_[0-1]-tail_[0,1]
head_0-tail_[0
head_1-tail_[0

A workaround is to do a prior expansion in powerman config:

> ipmipower -h head_0-tail_0,head_0-tail_1,head_1-tail_0,head_1-tail_1
head_0-tail_0
head_0-tail_1
head_1-tail_0
head_1-tail_1
