### PR TITLE
Feat: allow to use hw for partitioning along os

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ Format: <date> - <author (username or mail or both)> - <change description>
 
 # To 3.2.1
 
+* 3/5/25 - oxedions - [pxe_stack] Add capability to precedence partitioning from hardware profile
 * 3/3/25 - oxedions - [hosts_file] allow the FDQN to be set first in /etc/hosts (# 1005, from @levaillx)
-#1005
 
 # 3.2.0

--- a/collections/infrastructure/galaxy.yml
+++ b/collections/infrastructure/galaxy.yml
@@ -5,7 +5,7 @@ name: infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
 
-version: 3.2.1
+version: 3.2.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/infrastructure/roles/pxe_stack/templates/Debian/preseed.cfg.j2
+++ b/collections/infrastructure/roles/pxe_stack/templates/Debian/preseed.cfg.j2
@@ -52,7 +52,7 @@ d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 
-{{ equipment['os']['os_partitioning'] | default(pxe_stack_os_partitioning) | default(pxe_stack_debian_automatic_partitioning, true) }}
+{{ equipment['os']['os_partitioning'] | default(equipment['hw']['hw_partitioning'], true) | default(pxe_stack_os_partitioning, true) | default(pxe_stack_debian_automatic_partitioning, true) }}
 
 ### Users
 {% if not pxe_stack_enable_root %}

--- a/collections/infrastructure/roles/pxe_stack/templates/RedHat/kickstart.cfg.j2
+++ b/collections/infrastructure/roles/pxe_stack/templates/RedHat/kickstart.cfg.j2
@@ -80,7 +80,7 @@ firewall --disabled
 bootloader --append="{{ equipment['os']['os_kernel_parameters'] | default(pxe_stack_os_kernel_parameters) }} {{ equipment['hw']['hw_kernel_parameters'] | default(pxe_stack_hw_kernel_parameters) }} " --location=mbr
 
 # Partitioning
-{{ equipment['os']['os_partitioning'] | default(pxe_stack_os_partitioning) | default(pxe_stack_redhat_automatic_partitioning, true) }}
+{{ equipment['os']['os_partitioning'] | default(equipment['hw']['hw_partitioning'], true) | default(pxe_stack_os_partitioning, true) | default(pxe_stack_redhat_automatic_partitioning, true) }}
 
 ##### Packages
 %packages

--- a/collections/infrastructure/roles/pxe_stack/templates/Suse/autoyast.xml.j2
+++ b/collections/infrastructure/roles/pxe_stack/templates/Suse/autoyast.xml.j2
@@ -81,7 +81,7 @@
     <loader_type>default</loader_type>
   </bootloader>
 
-{{ equipment['os']['os_partitioning'] | default(pxe_stack_os_partitioning) | default(pxe_stack_suse_automatic_partitioning, true) }}
+{{ equipment['os']['os_partitioning'] | default(equipment['hw']['hw_partitioning'], true) | default(pxe_stack_os_partitioning, true) | default(pxe_stack_suse_automatic_partitioning, true) }}
 
 {% if pxe_stack_enable_root %}
  <users config:type="list">

--- a/collections/infrastructure/roles/pxe_stack/templates/Ubuntu/user-data.j2
+++ b/collections/infrastructure/roles/pxe_stack/templates/Ubuntu/user-data.j2
@@ -66,7 +66,7 @@ autoinstall:
     install-server: true
     allow-pw: true
 
-{{ (equipment['os']['os_partitioning'] | default(pxe_stack_os_partitioning) | default(pxe_stack_ubuntu_automatic_partitioning, true)) | indent(2, True) }}
+{{ (equipment['os']['os_partitioning'] | default(equipment['hw']['hw_partitioning'], true) | default(pxe_stack_os_partitioning, true) | default(pxe_stack_ubuntu_automatic_partitioning, true)) | indent(2, True) }}
  
   late-commands:
   {% if pxe_stack_enable_root %}


### PR DESCRIPTION
Allow to use an hw profile to define partitioning. Precedenced by os if set.