### PR TITLE
Fix: grafana - Added missing variable

### DIFF
--- a/collections/infrastructure/galaxy.yml
+++ b/collections/infrastructure/galaxy.yml
@@ -5,7 +5,7 @@ name: infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
 
-version: 3.2.2
+version: 3.2.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/infrastructure/roles/grafana/README.md
+++ b/collections/infrastructure/roles/grafana/README.md
@@ -151,6 +151,7 @@ Note: if you try to add dashboards, the role will alwats at checking if the data
 
 ## Changelog
 
+* 2.2.1: Missing default port reference. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.0: Optional uid/gid;Custom firewall port. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.1.2: Adapt to hw os split. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 2.1.1: Added additional\_json\_data variable in datasource. Alexandra Darrieutort <alexandra.darrieutort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>

--- a/collections/infrastructure/roles/grafana/vars/main.yml
+++ b/collections/infrastructure/roles/grafana/vars/main.yml
@@ -1,2 +1,3 @@
 ---
-grafana_role_version: 2.2.0
+grafana_role_version: 2.2.1
+grafana_default_port: 3000


### PR DESCRIPTION
Grafana custom firewall port setting is missing definition of _grafana_default_port_ variable.
