### PR TITLE
Feat: comnan - Added ssh settings for conman

### DIFF
--- a/collections/infrastructure/galaxy.yml
+++ b/collections/infrastructure/galaxy.yml
@@ -4,7 +4,7 @@ namespace: bluebanquise
 name: infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.15.0
+version: 3.3.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/infrastructure/galaxy.yml
+++ b/collections/infrastructure/galaxy.yml
@@ -4,7 +4,7 @@ namespace: bluebanquise
 name: infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.14.4
+version: 3.15.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/infrastructure/roles/conman/README.md
+++ b/collections/infrastructure/roles/conman/README.md
@@ -83,6 +83,7 @@ Once these pam_limits parameter pushed, restart conman daemon.
 
 ## Changelog
 
+* 1.7.0: Added ssh config file for user conman. Thiago Cardozo <boubee.thiago@gmail.com>
 * 1.6.0: Adapt to hw os split. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.5.1: Fix logrotate paths. Alexandra Darrieutort <alexandra.darrieurtort@u-bordeaux.fr>, Pierre Gay <pierre.gay@u-bordeaux.fr>
 * 1.5.0: Add logrotate file. Matthieu Isoard <indigoping4cgmi@gmail.com>

--- a/collections/infrastructure/roles/conman/tasks/main.yml
+++ b/collections/infrastructure/roles/conman/tasks/main.yml
@@ -58,6 +58,24 @@
   when:
     - ansible_facts.os_family == "RedHat"
 
+- name: file <|> Create /var/run/conman/.ssh directory
+  ansible.builtin.file:
+    path: /var/run/conman/.ssh
+    owner: conman
+    group: conman
+    state: directory
+    mode: 0700
+
+- name: template <|> Generate /var/run/conman/.ssh/config
+  ansible.builtin.template:
+    src: config.j2
+    dest: /var/run/conman/.ssh/config
+    owner: conman
+    group: conman
+    mode: 0600
+  tags:
+    - template
+
 - name: file <|> Create /var/log/conman directory
   ansible.builtin.file:  # noqa risky-file-permissions
     path: /var/log/conman

--- a/collections/infrastructure/roles/conman/templates/config.j2
+++ b/collections/infrastructure/roles/conman/templates/config.j2
@@ -1,0 +1,4 @@
+Host *
+StrictHostKeyChecking no
+UserKnownHostsFile=/dev/null
+LogLevel=ERROR

--- a/collections/infrastructure/roles/conman/vars/main.yml
+++ b/collections/infrastructure/roles/conman/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-conman_role_version: 1.6.0
+conman_role_version: 1.7.0
 
 conman_execpath: "/usr/lib/conman/exec"
 


### PR DESCRIPTION
When using conman with redfish(ssh) a known_hosts file is create for user conman.
This leads to issues when performing changes in HW, which won't update the file.