### PR TITLE
Fix: dns_client - DNS client default domain overriding

### DIFF
--- a/collections/infrastructure/galaxy.yml
+++ b/collections/infrastructure/galaxy.yml
@@ -5,7 +5,7 @@ name: infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
 
-version: 3.2.2
+version: 3.2.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/infrastructure/roles/dns_client/README.md
+++ b/collections/infrastructure/roles/dns_client/README.md
@@ -38,6 +38,7 @@ Note also that on most recent distributions, editing `/etc/resolv.conf` file is 
 
 ## Changelog
 
+* 1.3.4: Fix variable default value. Thiago Cardozo <boubee.thiago@gmail.com>
 * 1.3.3: Fix variable typo. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.3.2: Fix global logic. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.3.1: be able to set dns servers using a new variable <jean-pascal.mazzilli@gmail.com>

--- a/collections/infrastructure/roles/dns_client/defaults/main.yml
+++ b/collections/infrastructure/roles/dns_client/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-dns_client_domain_name: cluster.local
+dns_client_domain_name:

--- a/collections/infrastructure/roles/dns_client/vars/main.yml
+++ b/collections/infrastructure/roles/dns_client/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 
-dns_client_role_version: 1.3.3
+dns_client_role_version: 1.3.4


### PR DESCRIPTION
dns_client_domain_name has a default value set, and since it takes precedence over bb_domain_name, which is global,
dns_client always sets resolv.conf to the default value.

The template also has a default value hardcoded directly, so an empty variable will not fail:

search {{ dns_client_domain_name | default(bb_domain_name, true) | default('cluster.local', true)}} 
