### PR TITLE
Slurm role enhancement + support accounting and MYSQL on Ubuntu 22.04

### DIFF
--- a/collections/infrastructure/roles/slurm/README.md
+++ b/collections/infrastructure/roles/slurm/README.md
@@ -5,7 +5,7 @@ Role compatibility:
 |      OS      | Version | Supported |
 |:-------------|:--------|:---------:|
 | Ubuntu       |   20.04 |    yes (does not support local MYSQL installation) |
-| Ubuntu       |   22.04 |    yes (does not support local MYSQL installation) |
+| Ubuntu       |   22.04 |    yes    |
 | RHEL         |       7 |    yes    |
 | RHEL         |       8 |    yes    |
 | RHEL         |       9 |    yes    |
@@ -384,6 +384,7 @@ See more explanation on https://slurm.schedmd.com/acct_gather.conf.html
 
 ## Changelog
 
+* 1.6.4: Add slurm accounting and MYSQL support on ubuntu 22.04. Hamid MERZOUKI <hamid@sesterce.com>
 * 1.6.3: Switch deb packages to official names. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.6.2: Fix the way mysql databse is defined. Code from @sgaosdgr. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.6.1: Add missing handler for scrontrol. Code from @vedmonds. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/slurm/handlers/main.yml
+++ b/collections/infrastructure/roles/slurm/handlers/main.yml
@@ -7,7 +7,7 @@
 
 - name: service <|> Restart munge
   ansible.builtin.service:
-    name: munge
+    name: munge.service
     state: restarted
   when:
     - "'service' not in ansible_skip_tags"
@@ -19,3 +19,23 @@
   changed_when: true
   when:
     - slurm_allow_scontrol_handler
+
+- name: service <|> restart slurmdbd
+  ansible.builtin.service:
+    name: slurmdbd.service
+    state: restarted
+
+- name: service <|> restart mariadb
+  ansible.builtin.service:
+    name: mariadb.service
+    state: restarted
+
+- name: service <|> restart slurmctld
+  ansible.builtin.service:
+    name: slurmctld.service
+    state: restarted
+
+- name: service <|> restart slurmd
+  ansible.builtin.service:
+    name: slurmd.service
+    state: restarted

--- a/collections/infrastructure/roles/slurm/tasks/accounting.yml
+++ b/collections/infrastructure/roles/slurm/tasks/accounting.yml
@@ -6,6 +6,20 @@
   tags:
     - package
 
+- name: file <|> Check if slurmdbd PID file exists
+  stat:
+    path: "{{ slurm_slurmdbdpidfile }}"
+  register: pid_file
+
+- name: file <|> Create slurmdbd PID file if missing
+  file:
+    path: "{{ slurm_slurmdbdpidfile }}"
+    state: touch
+    owner: slurm
+    group: slurm
+    mode: '0644'
+  when: not pid_file.stat.exists
+
 - name: "template <|> Generate {{ slurm_home_path }}/slurmdbd.conf"
   ansible.builtin.template:
     src: slurmdbd.conf.j2
@@ -15,6 +29,7 @@
     mode: 0600
   tags:
     - template
+  notify: service <|> restart slurmdbd
 
 - name: include_tasks <|> Deploy local mysql
   ansible.builtin.include_tasks: "accounting_local_mysql.yml"
@@ -34,7 +49,46 @@
 #   tags:
 #     - service
 
-- name: mysql_db <|> Create slurm_acct_db database
+#- name: command <|> Create slurm user database
+#  ansible.builtin.command: mysql -e "CREATE USER '{{ slurm_accounting_mysql_login_user }}'@'{{ slurm_accounting_mysql_login_host }}' IDENTIFIED BY '{{ slurm_accounting_mysql_login_password }}';"
+#  register: slurm_create_user
+#  changed_when: false
+#  when:
+#    - slurm_accounting_mysql_create_user
+#    - ansible_distribution == 'Ubuntu'
+#  tags:
+#   - service
+
+- name: Ensure slurm user exists in the database
+  community.mysql.mysql_user:
+    name: "{{ slurm_accounting_mysql_login_user }}"
+    host: "{{ item }}"
+    password: "{{ slurm_accounting_mysql_login_password }}"
+    state: present
+    priv: 'slurm_acct_db.*:ALL'
+    login_user: root
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+    column_case_sensitive: false
+  loop:
+    - "{{ ansible_hostname }}"
+    - "{{ slurm_accounting_mysql_login_host }}"
+  when:
+    - slurm_accounting_mysql_create_user
+    - ansible_distribution == 'Ubuntu'
+  tags:
+    - service
+
+#- name: command <|> Give slurm user privilege
+#  ansible.builtin.command: mysql -e "GRANT ALL PRIVILEGES ON slurm_acct_db.* TO '{{ slurm_accounting_mysql_login_user }}'@'{{ slurm_accounting_mysql_login_host}}';"
+#  register: slurm_user_privilege
+#  changed_when: false
+#  when:
+#    - slurm_accounting_mysql_create_user
+#    - ansible_distribution == 'Ubuntu'
+#  tags:
+#    - service
+
+- name: mysql_db <|> 
   community.mysql.mysql_db:
     name: slurm_acct_db
     state: present
@@ -56,7 +110,9 @@
     login_port: "{{ slurm_accounting_mysql_login_port | default(omit, true) }}"
     login_user: "{{ slurm_accounting_mysql_login_user | default(omit, true) }}"
     login_password: "{{ slurm_accounting_mysql_login_password | default(omit, true) }}"
-  when: slurm_accounting_mysql_create_user
+  when: 
+    - slurm_accounting_mysql_create_user
+    - ansible_distribution not in 'Ubuntu'
   tags:
     - service
 
@@ -65,8 +121,6 @@
     name: slurmdbd
     enabled: "{{ (slurm_enable_services | default(bb_enable_services) | default(true) | bool) | ternary('yes', 'no') }}"
     state: "{{ (slurm_start_services | default(bb_start_services) | default(true) | bool) | ternary('started', omit) }}"
-  tags:
-    - service
 
 - name: "firewalld <|> Add Slurmdbd ports to firewall's {{ slurm_firewall_zone | default('public') }} zone"
   ansible.posix.firewalld:

--- a/collections/infrastructure/roles/slurm/tasks/accounting_local_mysql.yml
+++ b/collections/infrastructure/roles/slurm/tasks/accounting_local_mysql.yml
@@ -15,11 +15,19 @@
     mode: 0644
   tags:
     - template
+  notify: service <|> restart slurmdbd
 
-- name: service <|> Manage mariadb state
-  ansible.builtin.service:
-    name: mariadb
-    enabled: "{{ (slurm_enable_services | default(bb_enable_services) | default(true) | bool) | ternary('yes', 'no') }}"
-    state: "{{ (slurm_start_services | default(bb_start_services) | default(true) | bool) | ternary('started', omit) }}"
-  tags:
-    - service
+- name: file <|> Configure MariaDB to listen on all interfaces
+  lineinfile:
+    path: /etc/mysql/mariadb.conf.d/50-server.cnf
+    regexp: '^bind-address\s*=\s*127\.0\.0\.1'
+    line: 'bind-address = 0.0.0.0'
+    backrefs: yes
+  when:
+    - ansible_distribution == 'Ubuntu'
+  notify: service <|> restart mariadb
+  register: mariadb_config
+
+- name: Force handlers
+  meta: flush_handlers
+  when: mariadb_config.changed

--- a/collections/infrastructure/roles/slurm/tasks/compute.yml
+++ b/collections/infrastructure/roles/slurm/tasks/compute.yml
@@ -21,6 +21,7 @@
     mode: 0644
   tags:
     - template
+  notify: service <|> restart slurmd
 
 - name: include_tasks <|> Deploy Slurm compute configuration
   ansible.builtin.include_tasks: "compute_{{ slurm_computes_config }}.yml"

--- a/collections/infrastructure/roles/slurm/tasks/compute_configfull.yml
+++ b/collections/infrastructure/roles/slurm/tasks/compute_configfull.yml
@@ -10,6 +10,7 @@
     - template
   loop:
     - slurm.conf
+  notify: service <|> restart slurmd
 
 - name: "template <|> Generate gres.conf in {{ slurm_home_path }}"
   ansible.builtin.template:
@@ -23,6 +24,7 @@
   loop:
     - gres.conf
   when: slurm_grestypes is defined and slurm_gresTypes == 'gpu' and hw_specs['gpu'] is defined
+  notify: service <|> restart slurmd
 
 - name: "template <|> Generate acct_gather.conf in {{ slurm_home_path }}"
   ansible.builtin.template:
@@ -36,3 +38,4 @@
   loop:
     - acct_gather.conf
   when: (slurm_acct_gather_energy_type is not none) or (slurm_acct_gather_interconnect_type is not none) or (slurm_acct_gather_filesystem_type is not none) or (slurm_acct_gather_profile_type is not none)
+  notify: service <|> restart slurmd

--- a/collections/infrastructure/roles/slurm/tasks/controller.yml
+++ b/collections/infrastructure/roles/slurm/tasks/controller.yml
@@ -49,5 +49,3 @@
     name: slurmctld
     enabled: "{{ (slurm_enable_services | default(bb_enable_services) | default(true) | bool) | ternary('yes', 'no') }}"
     state: "{{ (slurm_start_services | default(bb_start_services) | default(true) | bool) | ternary('started', omit) }}"
-  tags:
-    - service

--- a/collections/infrastructure/roles/slurm/templates/slurm.conf.j2
+++ b/collections/infrastructure/roles/slurm/templates/slurm.conf.j2
@@ -1,4 +1,4 @@
-#jinja2: lstrip_blocks: True
+#jinja2: lstrip_blocks: True, trim_blocks: True
 #### Blue Banquise file ####
 ## {{ansible_managed}}
 
@@ -15,7 +15,7 @@ SlurmctldHost={{ slurm_controller_hostname | default(slurm_control_machine, true
 {% if slurm_computes_config == "configless" %}
 ## Use configless mode
 SlurmctldParameters=enable_configless
-{% endif %}
+{%- endif %}
 
 ## Authentication
 SlurmUser=slurm
@@ -74,8 +74,10 @@ AcctGatherProfileType=acct_gather_profile/{{ slurm_acct_gather_profile_type }}
 
 ## Additional content if exist
 {% if slurm_slurm_conf_additional_content is defined and slurm_slurm_conf_additional_content is iterable %}
-  {% for slurm_slurm_conf_content in slurm_slurm_conf_additional_content %}
-{{ slurm_slurm_conf_content | default('', true) }}                                                                                                                       
+  {% for item in slurm_slurm_conf_additional_content %}
+    {% for key, value in item.items() %}
+{{ key }}={{ value }}
+    {% endfor %}
   {% endfor %}
 {% endif %}
 
@@ -84,10 +86,10 @@ AcctGatherProfileType=acct_gather_profile/{{ slurm_acct_gather_profile_type }}
 # We need to compact all configuration into this single file.
 # -> no includes allowed.
 
-{# NODENAMES #}
+{#- NODENAMES -#}
 {# First we create a full list of all nodes that should be included in the file #}
-{% set slurm_nodes = [] %}
-{% for partition in slurm_partitions_list %}
+{%- set slurm_nodes = [] -%}
+{%- for partition in slurm_partitions_list %}
   {% if partition['computes_groups'] is defined and partition['computes_groups'] is not none %}
     {% for compute_group in partition['computes_groups'] %}
       {% for nn in groups[compute_group] %}{# We cannot merge both list inside a for loop in Jinja2 #}
@@ -109,7 +111,7 @@ AcctGatherProfileType=acct_gather_profile/{{ slurm_acct_gather_profile_type }}
     {% else %}
 # WARNING: node {{ node }} is associated with an hw and an os profile
     {% endif %}
-  {% endfor %}
+  {% endfor -%}
 {% endif %}
 {# Now we can generate final NodeNames for slurm #}
 {% for hw_pack, hw_pack_vars in hw_packs.items() %}
@@ -126,7 +128,7 @@ AcctGatherProfileType=acct_gather_profile/{{ slurm_acct_gather_profile_type }}
     {% if buffer.slurm_extra_nodes_parameters is defined and buffer.slurm_extra_nodes_parameters is not none %}
         {% set nodes_parameters = nodes_parameters + ' ' +  buffer.slurm_extra_nodes_parameters %}
     {% endif %}
-NodeName={{ hw_pack_vars['nodes'] | bluebanquise.infrastructure.nodeset }} {{ nodes_parameters }}
+NodeName={{ hw_pack_vars['nodes'] | bluebanquise.commons.nodeset }} {{ nodes_parameters }}
   {% else %}
 # WARNING: pack {{ hw_pack }} does not have hw_specs
   {% endif %}
@@ -134,8 +136,8 @@ NodeName={{ hw_pack_vars['nodes'] | bluebanquise.infrastructure.nodeset }} {{ no
 
 {# PARTITIONS #}
 ## Partitions list
-{% if slurm_partitions_list is defined and slurm_partitions_list %}
-  {% for partition in slurm_partitions_list %}
+{%- if slurm_partitions_list is defined and slurm_partitions_list -%}
+  {%- for partition in slurm_partitions_list -%}
     {% set partition_nodes = [] %}
     {% if partition['computes_groups'] is defined and partition['computes_groups'] is not none %}
       {% for compute_group in partition['computes_groups'] %}
@@ -145,7 +147,6 @@ NodeName={{ hw_pack_vars['nodes'] | bluebanquise.infrastructure.nodeset }} {{ no
       {% endfor %}
     {% endif %}
     {% set partition_nodes = (partition_nodes | unique) %}
-PartitionName={{partition.partition_name}} {% for arg, arg_value in partition.partition_configuration.items() %} {{ arg }}={{ arg_value }}{% endfor %} Nodes={{ partition_nodes | bluebanquise.infrastructure.nodeset }}
-
-  {% endfor %}
-{% endif %}
+PartitionName={{partition.partition_name}} {% for arg, arg_value in partition.partition_configuration.items() %} {{ arg }}={{ arg_value }}{% endfor %} Nodes={{ partition_nodes | bluebanquise.commons.nodeset }}
+  {%- endfor -%}
+{%- endif -%}

--- a/collections/infrastructure/roles/slurm/vars/Ubuntu.yml
+++ b/collections/infrastructure/roles/slurm/vars/Ubuntu.yml
@@ -24,6 +24,8 @@ slurm_packages_to_install:
     - slurm-smd-client
     - slurm-smd-libpmi0
     - slurm-smd-libpmi2-0
+    - libpmix2
+    - libpmix-dev
   submitter:
     - munge
     - libmunge2

--- a/collections/infrastructure/roles/slurm/vars/main.yml
+++ b/collections/infrastructure/roles/slurm/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-slurm_role_version: 1.6.3
+slurm_role_version: 1.6.4


### PR DESCRIPTION
## Describe your changes

- added support for slurm accounting on Ubuntu 22.04, these new MYSQL modifications will only impact Ubuntu, other OS are not impacted.
- added slurm pmix support
- added a check for the presence of slurmdbd PID as this otherwise causes an error
- supressed blank line and useless space in templating slurm.conf
- added service notify handlers when some files are modified


## Issue ticket number and link if any

## Checklist before requesting a review
- [x] Document introduced changes / variables in role README.md if any
- [x] Increment collection version in the galaxy.yml file of the infrastructure collection (a.b.c: +1 to b for a feature added, +1 to c for a bug fix). If not present, please also add your name in the related collection authors list in galaxy.yml
- [ ] Update CHANGELOG file at repository root.
