### PR TITLE
Fix: grafana - wait for grafana-db before loading data

### DIFF
--- a/collections/infrastructure/roles/grafana/README.md
+++ b/collections/infrastructure/roles/grafana/README.md
@@ -151,6 +151,7 @@ Note: if you try to add dashboards, the role will alwats at checking if the data
 
 ## Changelog
 
+* 2.2.3: Wait for external db when in ha mode. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.2: Reuse better variable for output;Don't print admin password at end. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.1: Missing default port reference. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.0: Optional uid/gid;Custom firewall port. Thiago Cardozo <boubee.thiago@gmail.com>

--- a/collections/infrastructure/roles/grafana/tasks/main.yml
+++ b/collections/infrastructure/roles/grafana/tasks/main.yml
@@ -74,6 +74,16 @@
   tags:
     - plugins
 
+- name: service <|> Wait for grafana-db
+  ansible.builtin.wait_for:
+    host: localhost
+    port: "{{ grafana_db_port }}"
+  when:
+    - grafana_ha_enabled|default(false)
+    - grafana_start_services | default(bb_start_services) | default(true) | bool
+  tags:
+    - configure
+
 - name: service <|> Force all notified handlers to run at this point
   ansible.builtin.meta: flush_handlers
 
@@ -143,6 +153,7 @@
 - name: include_tasks <|> dashboards
   ansible.builtin.include_tasks: dashboards.yml
   when: grafana_dashboards | length > 0 or found_dashboards | length > 0
+  run_once: "{{ grafana_ha_enabled | default(false) }}"
   tags:
     - dashboards
 

--- a/collections/infrastructure/roles/grafana/vars/main.yml
+++ b/collections/infrastructure/roles/grafana/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-grafana_role_version: 2.2.2
+grafana_role_version: 2.3.0
 grafana_default_port: 3000


### PR DESCRIPTION
Added task to wait for external db to be up before trying to load data.