### PR TITLE
Fix: grafana - service start in BB3, user creation error

### DIFF
--- a/collections/infrastructure/roles/grafana/README.md
+++ b/collections/infrastructure/roles/grafana/README.md
@@ -113,7 +113,7 @@ If you want to enforce you own password or update any other variables in default
   hosts: "mg_managements"
   vars:
     start_services: true
-    enable_services: true
+    bb_enable_services: true
   roles:
     - role: prometheus
       vars:
@@ -151,6 +151,8 @@ Note: if you try to add dashboards, the role will alwats at checking if the data
 
 ## Changelog
 
+* 2.2.3: Fixed service start and user creation. Thiago Cardozo <boubee.thiago@gmail.com>
+* 2.2.2: Reuse better variable for output;Don't print admin password at end. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.1: Missing default port reference. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.0: Optional uid/gid;Custom firewall port. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.1.2: Adapt to hw os split. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/grafana/handlers/main.yml
+++ b/collections/infrastructure/roles/grafana/handlers/main.yml
@@ -6,7 +6,7 @@
   with_items: "{{ grafana_services_to_start }}"
   when:
     - "'service' not in ansible_skip_tags"
-    - (start_services | bool)
+    - (bb_start_services | bool)
 
 - name: Set privileges on provisioned dashboards
   ansible.builtin.file:

--- a/collections/infrastructure/roles/grafana/tasks/install.yml
+++ b/collections/infrastructure/roles/grafana/tasks/install.yml
@@ -2,17 +2,19 @@
 - name: install <|> Add grafana group
   ansible.builtin.group:
     name: grafana
-    gid: "{{ grafana_user_gid | default(omit) }}"
+    gid: "{{ grafana_user_gid }}"
     state: present
+  when: grafana_user_gid|int
 
 - name: install <|> Add grafana user
   ansible.builtin.user:
     name: grafana
     shell: /bin/false
-    uid: "{{ grafana_user_uid | default(omit) }}"
+    uid: "{{ grafana_user_uid }}"
     group: grafana
     system: True
     state: present
+  when: grafana_user_uid|int
 
 - name: install <|> Check for log file
   ansible.builtin.stat:
@@ -83,8 +85,8 @@
 - name: service <|> Manage grafana-server state
   ansible.builtin.service:
     name: "{{ item }}"
-    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
-    state: "{{ (start_services | bool) | ternary('started', omit) }}"
+    enabled: "{{ (grafana_enable_services | default(bb_enable_services) | default(true) | bool) | ternary('yes', 'no') }}"
+    state: "{{ (grafana_start_services | default(bb_start_services) | default(true) | bool) | ternary('started', omit) }}"
   loop: "{{ grafana_services_to_start }}"
   tags:
     - service

--- a/collections/infrastructure/roles/grafana/vars/main.yml
+++ b/collections/infrastructure/roles/grafana/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-grafana_role_version: 2.2.1
+grafana_role_version: 2.2.3
 grafana_default_port: 3000


### PR DESCRIPTION
- Replaced start_services by bb_start_services
- Fixed user creation check error(string to int conversion)
