### PR TITLE
Feat: dhcp_server - external patterns

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,8 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # To 3.3.0
 
-* 3/21/25 - thiagocardozo [grafana] Fixed service start and user creation.
+* 3/27/25 - thiagocardozo - [dhcp-server] Ported patterns from advanced_dhcp_server role.
+* 3/21/25 - thiagocardozo - [grafana] Fixed service start and user creation.
 * 3/18/25 - thiagocardozo - [dns_server] DNS server dnssec
 * 3/17/25 - thiagocardozo - [grafana] Reuse better variable for output;Don't print admin password at end.
 * 3/13/25 - oxedions - [INFRA] Updated slurm to 24.05.6

--- a/collections/infrastructure/roles/dhcp_server/README.md
+++ b/collections/infrastructure/roles/dhcp_server/README.md
@@ -185,6 +185,50 @@ server, you **must** define this host in a shared network, even if this shared
 network contains a single network (see this very well made page for more
 information: http://www.miquels.cistron.nl/isc-dhcpd/).
 
+#### Use patterns
+
+It is possible, for advanced dhcp patterns, to enable capability to use external macros to write hosts configuration into the dhcp configuration.
+
+Then, adding a pattern variable to an host NIC definition will trigger the associated macro.
+
+For example:
+
+```yaml
+hosts:
+  c001:
+    network_interfaces:
+      - interface: eth0
+        ip4: 10.10.3.1
+        mac: 08:00:27:36:c0:ac
+        network: ice1-1
+        match: my_equipment_x
+
+Will trigger macro called my_equipment_x.
+
+To enable this feature, define advanced_dhcp_server_enable_patterns to true and set the macro name for the host at the match option. The role will now look for a file called patterns.j2 in files folder of the role (and fail if the file do not exist).
+
+patterns.j2 file should contains the macro to be used, named like the pattern targeted in the node definition. Each macro have 6 inputs, in this order:
+
+1. hostname of the host to be written
+#. dictionary of the nic to be written
+#. ipxe driver of the host to be written
+#. ipxe embed option of the host to be written
+#. pxe filename of the host to be written
+#. set_filename macro to set correct filename for host to be written
+
+An example of macro would be, for the pattern my_equipment_x defined above:
+
+```
+{% macro my_equipment_x(host, nic, ipxe_driver, ipxe_embed, pxe_filename, set_filename)) %}
+host {{ host }} {
+  option host-name "{{host}}";
+    hardware ethernet {{nic.mac}};
+    fixed-address {{nic.ip4}};
+    filename "{{set_filename}}";
+}
+{% endmacro %}
+```
+
 #### Add dhcp node specific parameters and options
 
 It is possible to add specific dhcp settings to an host interface, which can be

--- a/collections/infrastructure/roles/dhcp_server/README.md
+++ b/collections/infrastructure/roles/dhcp_server/README.md
@@ -201,11 +201,11 @@ hosts:
         ip4: 10.10.3.1
         mac: 08:00:27:36:c0:ac
         network: ice1-1
-        match: my_equipment_x
+        dhcp_pattern: my_equipment_x
 
 Will trigger macro called my_equipment_x.
 
-To enable this feature, define advanced_dhcp_server_enable_patterns to true and set the macro name for the host at the match option. The role will now look for a file called patterns.j2 in files folder of the role (and fail if the file do not exist).
+To enable this feature, define advanced_dhcp_server_enable_patterns to true and set the macro name for the host at the dhcp_pattern option. The role will now look for a file called patterns.j2 in files folder of the role (and fail if the file do not exist).
 
 patterns.j2 file should contains the macro to be used, named like the pattern targeted in the node definition. Each macro have 6 inputs, in this order:
 

--- a/collections/infrastructure/roles/dhcp_server/README.md
+++ b/collections/infrastructure/roles/dhcp_server/README.md
@@ -72,7 +72,7 @@ Example of network configuration, advanced dhcp server:
           - ip: 8.8.4.4
         ntp4:                                          # Is optional
           - hostname: time-a-g.nist.gov
-            ip: 129.6.15.28 
+            ip: 129.6.15.28
         pxe4:                                          # Is optional, needed for pxe
           - hostname: mg1
             ip: 10.11.0.1
@@ -150,7 +150,7 @@ It is possible to combine networks into shared-networks when multiple subnets
 are on the same NIC, or when using opt82/option_match parameter.
 To do so, add a dedicated optional `shared_network` key in the network definition.
 
-Networks of the same shared network must have the same `shared_network` value, 
+Networks of the same shared network must have the same `shared_network` value,
 which is the name of this share.
 
 For example to add net-1 and net-2 into the same shared network, define them
@@ -219,6 +219,7 @@ This allows for example to have an heterogenous cluster, with a group of hosts b
 
 ## Changelog
 
+* 1.8.0: Import external matching patterns. Thiago Cardozo <boubee.thiago@gmail.com>
 * 1.7.1: Fix global logic. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.7.0: Allow services and services_ip together. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.6.3: Fix double character for ipxe rom. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/dhcp_server/defaults/main.yml
+++ b/collections/infrastructure/roles/dhcp_server/defaults/main.yml
@@ -33,3 +33,4 @@ dhcp_server_stash_agent_options: false
 # Add user custom global settings to main dhcp configuration file
 # No need to add ";" at the end, template will add it
 dhcp_server_global_settings: []
+dhcp_server_enable_patterns: true

--- a/collections/infrastructure/roles/dhcp_server/defaults/main.yml
+++ b/collections/infrastructure/roles/dhcp_server/defaults/main.yml
@@ -33,4 +33,4 @@ dhcp_server_stash_agent_options: false
 # Add user custom global settings to main dhcp configuration file
 # No need to add ";" at the end, template will add it
 dhcp_server_global_settings: []
-dhcp_server_enable_patterns: true
+dhcp_server_enable_patterns: false

--- a/collections/infrastructure/roles/dhcp_server/templates/dhcpd.subnet.conf.j2
+++ b/collections/infrastructure/roles/dhcp_server/templates/dhcpd.subnet.conf.j2
@@ -33,7 +33,10 @@
   Write entries for each possible methods for current nic
 ###############################################################################}
 {% macro write_host(host, nic, ipxe_driver, ipxe_embed, pxe_filename) %}
-  {% if nic.mac is defined and (nic.mac | ansible.utils.hwaddr)%}
+  {%- if dhcp_server_enable_patterns and nic.match is defined and nic.match is not none %}
+    {{ patterns[nic.match](host, nic, ipxe_driver, ipxe_embed, pxe_filename, set_filename) }}
+  {% else %}
+    {% if nic.mac is defined and (nic.mac | ansible.utils.hwaddr)%}
 
   host {{host}}-{{item}}-mac {
     option host-name "{{host}}";
@@ -47,8 +50,8 @@
     {% endif %}
   }
 
-  {%- endif %}
-  {% if nic.dhcp_client_identifier is defined %}
+    {%- endif %}
+    {% if nic.dhcp_client_identifier is defined %}
 
   host {{host}}-{{item}}-dhcp-client-identifier {
     option host-name "{{host}}";
@@ -62,8 +65,8 @@
     {% endif %}
   }
 
-  {%- endif %}
-  {% if nic.host_identifier is defined %}
+    {%- endif %}
+    {% if nic.host_identifier is defined %}
 
   host {{host}}-{{item}}-host-identifier {
     option host-name "{{host}}";
@@ -77,8 +80,8 @@
     {% endif %}
   }
 
-  {%- endif %}
-  {% if nic.match is defined %}{# Warning, only works in a shared network!! #}
+    {%- endif %}
+    {% if nic.match is defined %}{# Warning, only works in a shared network!! #}
 
   class "option_match_{{host}}" {
     match if (
@@ -97,8 +100,18 @@
     {% endif %}
   }
 
+    {%- endif %}
   {%- endif %}
 {%- endmacro %}
+
+
+{###############################################################################
+  Import external patterns if asked for. Expected to fail if file not present.
+###############################################################################}
+{% if dhcp_server_enable_patterns %}
+{% import 'patterns.j2' as patterns without context %}
+{% endif %}
+
 
 {###############################################################################
   Main iteration over hosts

--- a/collections/infrastructure/roles/dhcp_server/templates/dhcpd.subnet.conf.j2
+++ b/collections/infrastructure/roles/dhcp_server/templates/dhcpd.subnet.conf.j2
@@ -33,8 +33,8 @@
   Write entries for each possible methods for current nic
 ###############################################################################}
 {% macro write_host(host, nic, ipxe_driver, ipxe_embed, pxe_filename) %}
-  {%- if dhcp_server_enable_patterns and nic.match is defined and nic.match is not none %}
-    {{ patterns[nic.match](host, nic, ipxe_driver, ipxe_embed, pxe_filename, set_filename) }}
+  {%- if dhcp_server_enable_patterns and nic.dhcp_pattern is defined and nic.dhcp_pattern is not none %}
+    {{ patterns[nic.dhcp_pattern](host, nic, ipxe_driver, ipxe_embed, pxe_filename, set_filename) }}
   {% else %}
     {% if nic.mac is defined and (nic.mac | ansible.utils.hwaddr)%}
 

--- a/collections/infrastructure/roles/dhcp_server/vars/main.yml
+++ b/collections/infrastructure/roles/dhcp_server/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-dhcp_server_role_version: 1.7.1
+dhcp_server_role_version: 1.8.0


### PR DESCRIPTION
This PR ports the advanced patterns from the old advanced_dhcp_server, where a complex matching pattern could be written
in external macros.

- Add a parameter _advanced_dhcp_server_enable_patterns_ to enable feature
- Name macro in the option _dhcp_pattern_ of the host network interface
