### PR TITLE
Feat: dns_server - round robin load balance

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,8 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # To 3.3.0
 
-* 3/21/25 - thiagocardozo [grafana] Fixed service start and user creation.
+* 3/27/25 - thiagocardozo - [dns_server] Option to sign zones.
+* 3/21/25 - thiagocardozo - [grafana] Fixed service start and user creation.
 * 3/18/25 - thiagocardozo - [dns_server] DNS server dnssec
 * 3/17/25 - thiagocardozo - [grafana] Reuse better variable for output;Don't print admin password at end.
 * 3/13/25 - oxedions - [INFRA] Updated slurm to 24.05.6

--- a/collections/infrastructure/roles/dns_server/README.md
+++ b/collections/infrastructure/roles/dns_server/README.md
@@ -258,8 +258,40 @@ dns_server_raw_options_content: |
   also-notify port 5353;
 ```
 
+### DNS Round Robin
+
+For load balancing with multiple DNS server nodes, the variable `dns_alias` can be added in the network interface section of each node in the inventory.
+These entries will be skipped by roles like `hosts_file`. Ex:
+
+```yaml
+fn_management:
+  hosts:
+    mgt1
+	  network_interfaces:
+        - interface: eth0
+          ip4: 10.0.0.10
+          network: ice1-1
+          dns_alias:
+            - www
+    mgt2
+	  network_interfaces:
+        - interface: eth0
+          ip4: 10.0.0.20
+          network: ice1-1
+          dns_alias:
+            - www
+```
+
+This will create a `foward.zone` file with:
+
+```yaml
+  www IN A 10.0.0.10
+  www IN A 10.0.0.20
+```
+
 ## Changelog
 
+* 1.12.0: Added alias for round robin load balance. Thiago Cardozo <boubee.thiago@gmail.com>
 * 1.11.0: Enable dnssec at dns server. Thiago Cardozo <boubee.thiago@gmail.com>
 * 1.10.4: Increase role performances bby caching first octets. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.10.3: Fix global logic. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/dns_server/templates/forward.j2
+++ b/collections/infrastructure/roles/dns_server/templates/forward.j2
@@ -27,6 +27,11 @@ $INCLUDE "{{ dns_server_named_dir }}/forward.soa"
           {% if nic.alias is defined %}
 {{ nic.alias }} IN A {{ nic.ip4 }}
           {% endif %}
+          {% if nic['dns_alias'] is defined and nic['dns_alias'] %}
+            {% for dns_alias in nic['dns_alias'] %}
+{{ dns_alias }} IN A {{ nic.ip4 }}
+            {% endfor %}
+          {% endif %}
         {% endif %}
       {% endfor %}
     {% endif %}
@@ -66,8 +71,3 @@ $INCLUDE "{{ dns_server_named_dir }}/forward.soa"
     {% endfor %}
   {% endif %}
 {% endfor %}
-
-{% if dns_server_dnssec_sign %}
-$INCLUDE "{{ dns_foward_public_keys.files[0].path }}"
-$INCLUDE "{{ dns_foward_public_keys.files[1].path }}"
-{% endif %}


### PR DESCRIPTION
The idea is to create aliases that point to the same IP without also being inserted in /etc/hosts.

So this entry:

```
fn_management:
  hosts:
    mgt1
      network_interfaces:
        - interface: eth0
          ip4: 10.0.0.10
          network: ice1-1
          dns_alias:
            - www
    mgt2
      network_interfaces:
        - interface: eth0
          ip4: 10.0.0.20
          network: ice1-1
          dns_alias:
            - www
```
Will create a foward.zone file with:

```
  www IN A 10.0.0.10
  www IN A 10.0.0.20
```
A lookup to the webserver should return:

```
www.bluebanquise.example.com has address 10.0.0.10
www.bluebanquise.example.com has address 10.0.0.20
```

Ref:
https://access.redhat.com/solutions/54311
