### PR TITLE
Revert change diskless path

### DIFF
--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -882,7 +882,7 @@ WantedBy=multi-user.target
         echo | > Additional kernel parameters: ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}}
         echo |
         echo | Loading linux ...
-        kernel http://${{next-server}}/pxe/diskless/{image_name}/${{image-kernel}} initrd=${{image-initramfs}} {selinux_parameter} text=1 root=live:http://${{next-server}}/preboot_execution_environment/diskless/{image_name}/squashfs.img rw ${{eq-console}} ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}} rd.net.timeout.carrier=30 rd.net.timeout.ifup=60 rd.net.dhcp.retry=4
+        kernel http://${{next-server}}/pxe/diskless/{image_name}/${{image-kernel}} initrd=${{image-initramfs}} {selinux_parameter} text=1 root=live:http://${{next-server}}/pxe/diskless/{image_name}/squashfs.img rw ${{eq-console}} ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}} rd.net.timeout.carrier=30 rd.net.timeout.ifup=60 rd.net.dhcp.retry=4
         echo | Loading initial ramdisk ...
         initrd http://${{next-server}}/pxe/diskless/{image_name}/${{image-initramfs}}
         echo | ALL DONE! We are ready.

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -14,7 +14,7 @@
 # 2.1.2: (SMC feature) Use specific export file in /etc/exports.d. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.1.1: (SMC change) Remove "beta", remove links to external images. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.1.0: (SMC feature) Replace systemctl restart nfs for exportfs -a. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
-# 2.0.9: (SMC fix) Tolerate disklessset images. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
+# 2.0.9: (SMC fix) Tolerate legacy paths inside /var/www/html/pxe/diskless. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.0.8: (SMC change) Do not use --system to create user. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.0.7: Update boot.ipxe when cloning reference image. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.6: Use --numeric-owner when extracting bootstrap image to ensure correct uid/gid. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
@@ -111,6 +111,12 @@ class bcolors:
     UNDERLINE = '\033[4m'
 
 
+# Ignore these paths when looking for diskless images.
+# For example, if /var/www/html/pxe/diskless/nfs_reference exists, then assume it is to store NFS
+# reference images, so its presence should not cause failure (it does not contain metadata.yml)
+IMAGE_DIRS_TO_IGNORE = ['images', 'nfs_reference']
+
+
 def display_image_metadata(image_metadata):
     """ Iteratively display an image metadata"""
     print("   └──── name: " + image_metadata['name'])
@@ -156,7 +162,7 @@ def display_images(image_type, tool_paths):
         gathered_reference = []
         logging.info(bcolors.OKBLUE + "Checking reference images in " + tool_paths['http_pxe_diskless'] + bcolors.ENDC)
         for it in os.scandir(tool_paths['http_pxe_diskless']):
-            if it.is_dir() and not os.path.exists(it.path + '/image_data.yml'):
+            if it.is_dir() and not os.path.exists(it.path + '/image_data.yml') and it.name not in IMAGE_DIRS_TO_IGNORE:
                 try:
                     with open(it.path + "/metadata.yaml", "r") as file:
                         image_metadata = yaml.safe_load(file)
@@ -185,7 +191,7 @@ def display_images(image_type, tool_paths):
         gathered_live = []
         logging.info(bcolors.OKBLUE + "Checking live images in " + tool_paths['http_pxe_diskless'] + bcolors.ENDC)
         for it in os.scandir(tool_paths['http_pxe_diskless']):
-            if it.is_dir() and not os.path.exists(it.path + '/image_data.yml'):
+            if it.is_dir() and not os.path.exists(it.path + '/image_data.yml') and it.name not in IMAGE_DIRS_TO_IGNORE:
                 try:
                     with open(it.path + "/metadata.yaml", "r") as file:
                         image_metadata = yaml.safe_load(file)

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -14,7 +14,7 @@
 # 2.1.2: (SMC feature) Use specific export file in /etc/exports.d. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.1.1: (SMC change) Remove "beta", remove links to external images. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.1.0: (SMC feature) Replace systemctl restart nfs for exportfs -a. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
-# 2.0.9: (SMC change) Replace diskless/ with diskless/images/, tolerate disklessset images. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
+# 2.0.9: (SMC fix) Tolerate disklessset images. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.0.8: (SMC change) Do not use --system to create user. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.0.7: Update boot.ipxe when cloning reference image. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
 # 2.0.6: Use --numeric-owner when extracting bootstrap image to ensure correct uid/gid. Giacomo Mc Evoy <gino.mcevoy@gmail.com>
@@ -326,7 +326,7 @@ except Exception:
 tool_paths = {}
 tool_paths['bootstrap_images'] = os.path.join(tool_parameters['sudo_user_home'], "diskless/bootstrap_images")
 tool_paths['bootstrap_images_tmp'] = os.path.join(tool_paths['bootstrap_images'], "tmp")
-tool_paths['http_pxe_diskless'] = os.path.join(tool_parameters['http_pxe_folder'], "diskless", "images")
+tool_paths['http_pxe_diskless'] = os.path.join(tool_parameters['http_pxe_folder'], "diskless")
 tool_paths['nfs'] = tool_parameters['nfs_path']
 
 
@@ -469,7 +469,7 @@ while True:
         protected_os_system("chmod 644 " + reference_image_pxe_path + "/*")
         ipxe_content = '''#!ipxe
         echo |
-        echo | Entering diskless/images/{image_name}/boot.ipxe
+        echo | Entering diskless/{image_name}/boot.ipxe
         echo |
         set image-kernel {image_kernel}
         set image-initramfs {image_initramfs}
@@ -481,9 +481,9 @@ while True:
         echo | > Additional kernel parameters: ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}}
         echo |
         echo | Loading linux ...
-        kernel http://${{next-server}}/pxe/diskless/images/{image_name}/${{image-kernel}} initrd=${{image-initramfs}} selinux=0 text=1 root=nfs:${{next-server}}:{nfs_path}/{image_name},vers=4.2,rw rw ${{eq-console}} ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}} rd.net.timeout.carrier=30 rd.net.timeout.ifup=60 rd.net.dhcp.retry=4
+        kernel http://${{next-server}}/pxe/diskless/{image_name}/${{image-kernel}} initrd=${{image-initramfs}} selinux=0 text=1 root=nfs:${{next-server}}:{nfs_path}/{image_name},vers=4.2,rw rw ${{eq-console}} ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}} rd.net.timeout.carrier=30 rd.net.timeout.ifup=60 rd.net.dhcp.retry=4
         echo | Loading initial ramdisk ...
-        initrd http://${{next-server}}/pxe/diskless/images/{image_name}/${{image-initramfs}}
+        initrd http://${{next-server}}/pxe/diskless/{image_name}/${{image-initramfs}}
         echo | ALL DONE! We are ready.
         echo | Booting in 4s ...
         echo |
@@ -664,7 +664,7 @@ while True:
         image_selected_metadata['name'] = image_clone_input
         ipxe_content = '''#!ipxe
         echo |
-        echo | Entering diskless/images/{image_name}/boot.ipxe
+        echo | Entering diskless/{image_name}/boot.ipxe
         echo |
         set image-kernel {image_kernel}
         set image-initramfs {image_initramfs}
@@ -676,9 +676,9 @@ while True:
         echo | > Additional kernel parameters: ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}}
         echo |
         echo | Loading linux ...
-        kernel http://${{next-server}}/pxe/diskless/images/{image_name}/${{image-kernel}} initrd=${{image-initramfs}} selinux=0 text=1 root=nfs:${{next-server}}:{nfs_path}/{image_name},vers=4.2,rw rw ${{eq-console}} ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}} rd.net.timeout.carrier=30 rd.net.timeout.ifup=60 rd.net.dhcp.retry=4
+        kernel http://${{next-server}}/pxe/diskless/{image_name}/${{image-kernel}} initrd=${{image-initramfs}} selinux=0 text=1 root=nfs:${{next-server}}:{nfs_path}/{image_name},vers=4.2,rw rw ${{eq-console}} ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}} rd.net.timeout.carrier=30 rd.net.timeout.ifup=60 rd.net.dhcp.retry=4
         echo | Loading initial ramdisk ...
-        initrd http://${{next-server}}/pxe/diskless/images/{image_name}/${{image-initramfs}}
+        initrd http://${{next-server}}/pxe/diskless/{image_name}/${{image-initramfs}}
         echo | ALL DONE! We are ready.
         echo | Booting in 4s ...
         echo |
@@ -864,7 +864,7 @@ WantedBy=multi-user.target
 
         ipxe_content = '''#!ipxe
         echo |
-        echo | Entering diskless/images/{image_name}/boot.ipxe
+        echo | Entering diskless/{image_name}/boot.ipxe
         echo |
         set image-kernel {image_kernel}
         set image-initramfs {image_initramfs}
@@ -876,9 +876,9 @@ WantedBy=multi-user.target
         echo | > Additional kernel parameters: ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}}
         echo |
         echo | Loading linux ...
-        kernel http://${{next-server}}/pxe/diskless/images/{image_name}/${{image-kernel}} initrd=${{image-initramfs}} {selinux_parameter} text=1 root=live:http://${{next-server}}/preboot_execution_environment/diskless/images/{image_name}/squashfs.img rw ${{eq-console}} ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}} rd.net.timeout.carrier=30 rd.net.timeout.ifup=60 rd.net.dhcp.retry=4
+        kernel http://${{next-server}}/pxe/diskless/{image_name}/${{image-kernel}} initrd=${{image-initramfs}} {selinux_parameter} text=1 root=live:http://${{next-server}}/preboot_execution_environment/diskless/{image_name}/squashfs.img rw ${{eq-console}} ${{eq-kernel-parameters}} ${{dedicated-kernel-parameters}} rd.net.timeout.carrier=30 rd.net.timeout.ifup=60 rd.net.dhcp.retry=4
         echo | Loading initial ramdisk ...
-        initrd http://${{next-server}}/pxe/diskless/images/{image_name}/${{image-initramfs}}
+        initrd http://${{next-server}}/pxe/diskless/{image_name}/${{image-initramfs}}
         echo | ALL DONE! We are ready.
         echo | Booting in 4s ...
         echo |
@@ -1179,7 +1179,7 @@ This however could lead to issues, so in case of crash, remember to check the fo
 
 * /var/lib/bluebanquise/diskless/bootstrap_images/
 * /var/lib/bluebanquise/diskless/bootstrap_images/tmp/
-* /var/www/html/pxe/diskless/images/
+* /var/www/html/pxe/diskless/
 * /nfs/diskless/
 
 ## Conclusion


### PR DESCRIPTION
- Revert change done on images path, now use standard /var/www/html/pxe/diskless  
- Tolerate legacy paths inside tool (diskless/images, diskless/nfs_reference)