### PR TITLE
Set galaxy version for SMC 2.0.0 release

### DIFF
--- a/collections/infrastructure/galaxy.yml
+++ b/collections/infrastructure/galaxy.yml
@@ -4,7 +4,7 @@ namespace: bluebanquise
 name: infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.3.0
+version: 3.2.5-smc
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Abusing semantic versioning:
- We want to point out this released is based on 3.2.5
- We should not use "3.2.5" as we have made changes to BB official release
- We don't want to create a non-existent release 3.3.0
- We cannot ask for 3.2.6 with our custom changes
- Idea is to add a "pre-release description" to 3.2.5
- Original idea was "3.2.5-smc", but we may need another release for SMC 2.0.1
- Final solution is "3.2.5-smc2.0.0"

Edit: for release SMC 2.0.1, we will be able to release "3.2.6-smc".
With this possibility, we will release as "3.2.5-smc"