### PR TITLE
Update compute_configfull.yml

### DIFF
--- a/collections/infrastructure/roles/slurm/tasks/compute_configfull.yml
+++ b/collections/infrastructure/roles/slurm/tasks/compute_configfull.yml
@@ -22,7 +22,7 @@
     - template
   loop:
     - gres.conf
-  when: slurm_grestypes is defined and slurm_gresTypes == 'gpu' and hw_specs['gpu'] is defined
+  when: slurm_grestypes is defined and slurm_grestypes == 'gpu' and hw_specs['gpu'] is defined
 
 - name: "template <|> Generate acct_gather.conf in {{ slurm_home_path }}"
   ansible.builtin.template:

--- a/collections/infrastructure/roles/slurm/templates/cgroup.conf.j2
+++ b/collections/infrastructure/roles/slurm/templates/cgroup.conf.j2
@@ -13,7 +13,7 @@
 # CgroupAutomount=yes # deprecated
 ConstrainCores=yes
 ConstrainRAMSpace=yes
-  {% if slurm_grestypes is defined and slurm_gresTypes is not none %}
+  {% if slurm_grestypes is defined and slurm_grestypes is not none %}
 ConstrainDevices=yes
   {% endif %}
 


### PR DESCRIPTION
Typo in Case grestypes

## Describe your changes
There is a bug in enabling GPU support to slurm.

`The conditional check 'slurm_grestypes is defined and slurm_gresTypes == 'gpu' and hw_specs['gpu'] is defined' failed.`

Here the condition looks for slurm_gres**t**ypes and slurm_gres**T**ypes 

## Issue ticket number and link if any

## Checklist before requesting a review
- [ ] Document introduced changes / variables in role README.md if any
- [ ] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml
- [ ] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG
