### PR TITLE
Fix: grafana - service management timeout

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # 3.2.5
 
+* 3/16/25: - thiagocardozo - [grafana] Retry service management a few times;fixed handler variables.
 * 3/25/25: - santos-lucas - [gpu] force gather facts on the beginning of execution.
 * 3/25/25: - santos-lucas - [gpu] Add support for AMD gpus.
 * 3/25/25: - hmeScaler - [users] Role enhancement and bug fixing

--- a/collections/infrastructure/roles/grafana/README.md
+++ b/collections/infrastructure/roles/grafana/README.md
@@ -151,6 +151,9 @@ Note: if you try to add dashboards, the role will alwats at checking if the data
 
 ## Changelog
 
+**Please now update CHANGELOG file at repository root instead of adding logs in this file.
+These logs bellow are only kept for archive.**
+
 * 2.2.3: Fixed service start and user creation. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.2: Reuse better variable for output;Don't print admin password at end. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.1: Missing default port reference. Thiago Cardozo <boubee.thiago@gmail.com>

--- a/collections/infrastructure/roles/grafana/README.md
+++ b/collections/infrastructure/roles/grafana/README.md
@@ -151,6 +151,7 @@ Note: if you try to add dashboards, the role will alwats at checking if the data
 
 ## Changelog
 
+* 2.2.4: Retry service management a few times;fixed handler variables. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.3: Fixed service start and user creation. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.2: Reuse better variable for output;Don't print admin password at end. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.1: Missing default port reference. Thiago Cardozo <boubee.thiago@gmail.com>

--- a/collections/infrastructure/roles/grafana/handlers/main.yml
+++ b/collections/infrastructure/roles/grafana/handlers/main.yml
@@ -6,7 +6,7 @@
   with_items: "{{ grafana_services_to_start }}"
   when:
     - "'service' not in ansible_skip_tags"
-    - (bb_start_services | bool)
+    - (grafana_start_services | default(bb_start_services) | default(true) | bool)
 
 - name: Set privileges on provisioned dashboards
   ansible.builtin.file:

--- a/collections/infrastructure/roles/grafana/tasks/install.yml
+++ b/collections/infrastructure/roles/grafana/tasks/install.yml
@@ -88,5 +88,9 @@
     enabled: "{{ (grafana_enable_services | default(bb_enable_services) | default(true) | bool) | ternary('yes', 'no') }}"
     state: "{{ (grafana_start_services | default(bb_start_services) | default(true) | bool) | ternary('started', omit) }}"
   loop: "{{ grafana_services_to_start }}"
+  register: service_results
+  retries: 5
+  delay: 10
+  until: service_results is not failed
   tags:
     - service

--- a/collections/infrastructure/roles/grafana/vars/main.yml
+++ b/collections/infrastructure/roles/grafana/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-grafana_role_version: 2.2.3
+grafana_role_version: 2.2.4
 grafana_default_port: 3000


### PR DESCRIPTION
A task that manages Grafana service might fail in timeout when using an external database.
This is due to extensive operations performed by Grafana before it returns a positive feedback.

Also fixed restart service handler variables.