### PR TITLE
Fix: grafana - service management timeout

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,15 +2,18 @@
 
 Format: <date> - <author (username or mail or both)> - [role] <change description>
 
-# To 3.3.0
+# 3.2.5
 
-* 3/28/25 - thiagocardozo - [podman] Add support for TLS encryption in local registry.
-* 3/27/25 - thiagocardozo - [dhcp-server] Ported patterns from advanced_dhcp_server role.
-* 3/27/25 - thiagocardozo - [dns_server] Option to sign zones.
-* 3/21/25 - thiagocardozo - [grafana] Fixed service start and user creation.
-* 3/21/25 - thiagocardozo - [grafana] Fixed service start and user creation.
-* 3/18/25 - thiagocardozo - [dns_server] DNS server dnssec
-* 3/17/25 - thiagocardozo - [grafana] Reuse better variable for output;Don't print admin password at end.
+* 4/16/25: - thiagocardozo - [grafana] Retry service management a few times;fixed handler variables.
+* 3/25/25: - santos-lucas - [gpu] force gather facts on the beginning of execution.
+* 3/25/25: - santos-lucas - [gpu] Add support for AMD gpus.
+* 3/25/25: - hmeScaler - [users] Role enhancement and bug fixing
+* 3/25/25: - aolloh - [custom_packages] Remove braces on item.
+* 3/25/25: - lmagdanello - [pxe_stack] Fix Formatting for Kernel Parameters in iPXE Template.
+* 3/25/25: - thiagocardozo - [grafana] Fixed service start and user creation.
+* 3/25/25: - thiagocardozo - [grafana] Reuse better variable for output;Don't print admin password at end.
+* 3/21/25 - oxedions - [CORE] Fix a critical error for main interface an main address j2_
+* 3/18/25 - fonseca-rm - [podman] update podman configurations for compatibility with new RHEL version
 * 3/13/25 - oxedions - [INFRA] Updated slurm to 24.05.6
 * 3/13/25 - oxedions - [INFRA] Updated atftp to 0.8.0
 * 3/13/25 - thiagocardozo - [grafana] Missing default port reference.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,14 +4,21 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # 3.2.5
 
-* 4/16/25: - thiagocardozo - [grafana] Retry service management a few times;fixed handler variables.
-* 3/25/25: - santos-lucas - [gpu] force gather facts on the beginning of execution.
-* 3/25/25: - santos-lucas - [gpu] Add support for AMD gpus.
-* 3/25/25: - hmeScaler - [users] Role enhancement and bug fixing
-* 3/25/25: - aolloh - [custom_packages] Remove braces on item.
-* 3/25/25: - lmagdanello - [pxe_stack] Fix Formatting for Kernel Parameters in iPXE Template.
-* 3/25/25: - thiagocardozo - [grafana] Fixed service start and user creation.
-* 3/25/25: - thiagocardozo - [grafana] Reuse better variable for output;Don't print admin password at end.
+* 4/16/25 - thiagocardozo - [grafana] Retry service management a few times;fixed handler variables.
+* 3/28/25 - thiagocardozo - [podman] Add support for TLS encryption in local registry.
+* 3/27/25 - thiagocardozo - [dhcp-server] Ported patterns from advanced_dhcp_server role.
+* 3/27/25 - thiagocardozo - [dns_server] Option to sign zones.
+* 3/21/25 - thiagocardozo - [grafana] Fixed service start and user creation.
+* 3/21/25 - thiagocardozo - [grafana] Fixed service start and user creation.
+* 3/18/25 - thiagocardozo - [dns_server] DNS server dnssec
+* 3/17/25 - thiagocardozo - [grafana] Reuse better variable for output;Don't print admin password at end.
+* 3/25/25 - santos-lucas - [gpu] force gather facts on the beginning of execution.
+* 3/25/25 - santos-lucas - [gpu] Add support for AMD gpus.
+* 3/25/25 - hmeScaler - [users] Role enhancement and bug fixing
+* 3/25/25 - aolloh - [custom_packages] Remove braces on item.
+* 3/25/25 - lmagdanello - [pxe_stack] Fix Formatting for Kernel Parameters in iPXE Template.
+* 3/25/25 - thiagocardozo - [grafana] Fixed service start and user creation.
+* 3/25/25 - thiagocardozo - [grafana] Reuse better variable for output;Don't print admin password at end.
 * 3/21/25 - oxedions - [CORE] Fix a critical error for main interface an main address j2_
 * 3/18/25 - fonseca-rm - [podman] update podman configurations for compatibility with new RHEL version
 * 3/13/25 - oxedions - [INFRA] Updated slurm to 24.05.6

--- a/collections/infrastructure/roles/grafana/README.md
+++ b/collections/infrastructure/roles/grafana/README.md
@@ -151,8 +151,6 @@ Note: if you try to add dashboards, the role will alwats at checking if the data
 
 ## Changelog
 
-* 2.2.4: Fixed service start and user creation. Thiago Cardozo <boubee.thiago@gmail.com>
-* 2.2.3: Wait for external db when in ha mode. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.4: Retry service management a few times;fixed handler variables. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.3: Fixed service start and user creation. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.2: Reuse better variable for output;Don't print admin password at end. Thiago Cardozo <boubee.thiago@gmail.com>

--- a/collections/infrastructure/roles/grafana/README.md
+++ b/collections/infrastructure/roles/grafana/README.md
@@ -153,6 +153,8 @@ Note: if you try to add dashboards, the role will alwats at checking if the data
 
 * 2.2.4: Fixed service start and user creation. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.3: Wait for external db when in ha mode. Thiago Cardozo <boubee.thiago@gmail.com>
+* 2.2.4: Retry service management a few times;fixed handler variables. Thiago Cardozo <boubee.thiago@gmail.com>
+* 2.2.3: Fixed service start and user creation. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.2: Reuse better variable for output;Don't print admin password at end. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.1: Missing default port reference. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.0: Optional uid/gid;Custom firewall port. Thiago Cardozo <boubee.thiago@gmail.com>

--- a/collections/infrastructure/roles/grafana/README.md
+++ b/collections/infrastructure/roles/grafana/README.md
@@ -151,7 +151,9 @@ Note: if you try to add dashboards, the role will alwats at checking if the data
 
 ## Changelog
 
-* 2.2.4: Retry service management a few times;fixed handler variables. Thiago Cardozo <boubee.thiago@gmail.com>
+**Please now update CHANGELOG file at repository root instead of adding logs in this file.
+These logs bellow are only kept for archive.**
+
 * 2.2.3: Fixed service start and user creation. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.2: Reuse better variable for output;Don't print admin password at end. Thiago Cardozo <boubee.thiago@gmail.com>
 * 2.2.1: Missing default port reference. Thiago Cardozo <boubee.thiago@gmail.com>

--- a/collections/infrastructure/roles/grafana/handlers/main.yml
+++ b/collections/infrastructure/roles/grafana/handlers/main.yml
@@ -6,7 +6,7 @@
   with_items: "{{ grafana_services_to_start }}"
   when:
     - "'service' not in ansible_skip_tags"
-    - (bb_start_services | bool)
+    - (grafana_start_services | default(bb_start_services) | default(true) | bool)
 
 - name: Set privileges on provisioned dashboards
   ansible.builtin.file:

--- a/collections/infrastructure/roles/grafana/tasks/install.yml
+++ b/collections/infrastructure/roles/grafana/tasks/install.yml
@@ -88,5 +88,9 @@
     enabled: "{{ (grafana_enable_services | default(bb_enable_services) | default(true) | bool) | ternary('yes', 'no') }}"
     state: "{{ (grafana_start_services | default(bb_start_services) | default(true) | bool) | ternary('started', omit) }}"
   loop: "{{ grafana_services_to_start }}"
+  register: service_results
+  retries: 5
+  delay: 10
+  until: service_results is not failed
   tags:
     - service

--- a/collections/infrastructure/roles/grafana/vars/main.yml
+++ b/collections/infrastructure/roles/grafana/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-grafana_role_version: 2.3.0
+grafana_role_version: 2.2.4
 grafana_default_port: 3000


### PR DESCRIPTION
A task that manages Grafana service might fail in timeout when using an external database.
This is due to extensive operations performed by Grafana before it returns a positive feedback.

Also fixed restart service handler variables.
