### PR TITLE
Fix: powerman - Expand powerman nodeset for ipmipower

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # 3.2.5
 
+* 4/20/25 - thiagocardozo - [powerman] Use nodeset_expand function to get around issue with ipmipower.
 * 4/16/25 - thiagocardozo - [grafana] Retry service management a few times;fixed handler variables.
 * 3/28/25 - thiagocardozo - [podman] Add support for TLS encryption in local registry.
 * 3/27/25 - thiagocardozo - [dhcp-server] Ported patterns from advanced_dhcp_server role.

--- a/collections/infrastructure/plugins/filter/nodeset.py
+++ b/collections/infrastructure/plugins/filter/nodeset.py
@@ -22,6 +22,7 @@ def nodeset(nodes_list):
 
     return nodeset
 
+
 def nodeset_expand(nodes_list):
     '''Convert a list of nodes to expanded ClusterShell's NodeSet'''
 

--- a/collections/infrastructure/plugins/filter/nodeset.py
+++ b/collections/infrastructure/plugins/filter/nodeset.py
@@ -8,6 +8,7 @@ __metaclass__ = type
 
 from ansible.errors import AnsibleError
 from ClusterShell.NodeSet import NodeSet
+from ClusterShell.NodeSet import expand
 from ansible.module_utils.common.text.converters import to_native
 
 
@@ -21,6 +22,15 @@ def nodeset(nodes_list):
 
     return nodeset
 
+def nodeset_expand(nodes_list):
+    '''Convert a list of nodes to expanded ClusterShell's NodeSet'''
+
+    try:
+        nodeset = ",".join(expand(NodeSet(",".join(nodes_list))))
+    except Exception as e:
+        raise AnsibleError('Error joining nodeset, original exception: %s' % to_native(e))
+
+    return nodeset
 
 class FilterModule(object):
     ''' NodeSet Jinja2 filter. '''

--- a/collections/infrastructure/plugins/filter/nodeset_expand.py
+++ b/collections/infrastructure/plugins/filter/nodeset_expand.py
@@ -16,16 +16,16 @@ def nodeset_expand(nodes_list):
     '''Convert a list of nodes to expanded ClusterShell's NodeSet'''
 
     try:
-        nodeset = ",".join(expand(NodeSet(",".join(nodes_list))))
+        nodeset_expand = ",".join(expand(NodeSet(",".join(nodes_list))))
     except Exception as e:
         raise AnsibleError('Error joining nodeset, original exception: %s' % to_native(e))
 
-    return nodeset
+    return nodeset_expand
 
 class FilterModule(object):
     ''' NodeSet Jinja2 filter. '''
 
     def filters(self):
         return {
-            'nodeset': nodeset,
+            'nodeset_expand': nodeset_expand,
         }

--- a/collections/infrastructure/plugins/filter/nodeset_expand.py
+++ b/collections/infrastructure/plugins/filter/nodeset_expand.py
@@ -12,16 +12,15 @@ from ClusterShell.NodeSet import expand
 from ansible.module_utils.common.text.converters import to_native
 
 
-def nodeset(nodes_list):
-    '''Convert a list of nodes to ClusterShell's NodeSet'''
+def nodeset_expand(nodes_list):
+    '''Convert a list of nodes to expanded ClusterShell's NodeSet'''
 
     try:
-        nodeset = NodeSet(",".join(nodes_list))
+        nodeset = ",".join(expand(NodeSet(",".join(nodes_list))))
     except Exception as e:
         raise AnsibleError('Error joining nodeset, original exception: %s' % to_native(e))
 
     return nodeset
-
 
 class FilterModule(object):
     ''' NodeSet Jinja2 filter. '''

--- a/collections/infrastructure/roles/powerman/templates/powerman.conf.j2
+++ b/collections/infrastructure/roles/powerman/templates/powerman.conf.j2
@@ -45,9 +45,9 @@ include "/etc/powerman/ipmipower.dev"
       {# Name device for each set of credentials, using index #}
       {% set device_suffix = loop.index | string %}
       {% if powerman_enable_ipmi_lan_2_0 is defined and powerman_enable_ipmi_lan_2_0 %}
-device "{{ equipment }}{{ device_suffix }}" "ipmipower" "/usr/sbin/ipmipower --wait-until-on --wait-until-off -h {{ bmcs|bluebanquise.infrastructure.nodeset }} -u {{ host_bmc_user }} -p {{ host_bmc_password }} -D LAN_2_0 |&"
+device "{{ equipment }}{{ device_suffix }}" "ipmipower" "/usr/sbin/ipmipower --wait-until-on --wait-until-off -h {{ bmcs|bluebanquise.infrastructure.nodeset_expand }} -u {{ host_bmc_user }} -p {{ host_bmc_password }} -D LAN_2_0 |&"
       {% else %}
-device "{{ equipment }}{{ device_suffix }}" "ipmipower" "/usr/sbin/ipmipower --wait-until-on --wait-until-off -h {{ bmcs|bluebanquise.infrastructure.nodeset }} -u {{ host_bmc_user }} -p {{ host_bmc_password }} |&"
+device "{{ equipment }}{{ device_suffix }}" "ipmipower" "/usr/sbin/ipmipower --wait-until-on --wait-until-off -h {{ bmcs|bluebanquise.infrastructure.nodeset_expand }} -u {{ host_bmc_user }} -p {{ host_bmc_password }} |&"
       {% endif %}
 node "{{ hosts|bluebanquise.infrastructure.nodeset }}" "{{ equipment }}{{ device_suffix }}" "{{ bmcs|bluebanquise.infrastructure.nodeset }}"
     {% endfor %}

--- a/collections/infrastructure/roles/powerman/vars/main.yml
+++ b/collections/infrastructure/roles/powerman/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-powerman_role_version: 1.4.0
+powerman_role_version: 1.4.1


### PR DESCRIPTION
ipimipower isn't expanding nodesets with multiple intervals properly, ex:

ipmipower -h head_[0-1]-tail_[0,1]
head_0-tail_[0
head_1-tail_[0

A workaround is to do a prior expansion in powerman config:

ipmipower -h head_0-tail_0,head_0-tail_1,head_1-tail_0,head_1-tail_1
head_0-tail_0
head_0-tail_1
head_1-tail_0
head_1-tail_1

For that purpose a nodeset_expand function was added to nodeset.py.
