### PR TITLE
Fix services running in both nodes in HA

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,10 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # 3.2.5
 
+* 4/21/25 - ginomcevoy - [auditd] Avoid having service running on both nodes in HA.
+* 4/21/25 - ginomcevoy - [powerman] Avoid having service running on both nodes in HA.
+* 4/21/25 - ginomcevoy - [http_server] Avoid having service running on both nodes in HA.
+* 4/21/25 - ginomcevoy - [conman] Avoid having service running on both nodes in HA.
 * 4/20/25 - thiagocardozo - [powerman] Use nodeset_expand function to get around issue with ipmipower.
 * 4/16/25 - thiagocardozo - [grafana] Retry service management a few times;fixed handler variables.
 * 3/28/25 - thiagocardozo - [podman] Add support for TLS encryption in local registry.

--- a/collections/infrastructure/roles/auditd/handlers/main.yml
+++ b/collections/infrastructure/roles/auditd/handlers/main.yml
@@ -2,12 +2,12 @@
 - name: service <|> Restart auditd service
   ansible.builtin.service:
     name: "{{ item }}"
-    state: "{{ (repositories_server_start_services | default(bb_start_services) | default(true, true) | bool) | ternary('restarted', omit) }}"
+    state: "{{ (repositories_server_start_services | default(bb_start_services) | default(true) | bool) | ternary('restarted', omit) }}"
     use: service  # systemctl can't restart auditd, service can: https://access.redhat.com/solutions/2664811
   loop: "{{ auditd_services_to_start }}"
   when:
     - "'service' not in ansible_skip_tags"
-    - auditd_start_services | default(bb_start_services) | default(true, true)
+    - auditd_start_services | default(bb_start_services) | default(true)
 
 - name: service █ Restart rsyslog service
   ansible.builtin.service:

--- a/collections/infrastructure/roles/auditd/handlers/main.yml
+++ b/collections/infrastructure/roles/auditd/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: service <|> Restart auditd service
   ansible.builtin.service:
     name: "{{ item }}"
-    state: "{{ (repositories_server_start_services | default(bb_start_services) | default(true) | bool) | ternary('restarted', omit) }}"
+    state: "{{ (auditd_start_services | default(bb_start_services) | default(true) | bool) | ternary('restarted', omit) }}"
     use: service  # systemctl can't restart auditd, service can: https://access.redhat.com/solutions/2664811
   loop: "{{ auditd_services_to_start }}"
   when:

--- a/collections/infrastructure/roles/auditd/tasks/main.yml
+++ b/collections/infrastructure/roles/auditd/tasks/main.yml
@@ -59,8 +59,8 @@
 - name: "service <|> Manage {{ auditd_services_to_start | join(' ') }} state"
   ansible.builtin.service:
     name: "{{ item }}"
-    enabled: "{{ (auditd_enable_services | default(bb_enable_services) | default(true, true) | bool) | ternary('yes', 'no') }}"
-    state: "{{ (auditd_start_services | default(bb_start_services) | default(true, true) | bool) | ternary('started', omit) }}"
+    enabled: "{{ (auditd_enable_services | default(bb_enable_services) | default(true) | bool) | ternary('yes', 'no') }}"
+    state: "{{ (auditd_start_services | default(bb_start_services) | default(true) | bool) | ternary('started', omit) }}"
   loop: "{{ auditd_services_to_start }}"
   tags:
     - service

--- a/collections/infrastructure/roles/auditd/vars/main.yml
+++ b/collections/infrastructure/roles/auditd/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-auditd_role_version: 1.2.0
+auditd_role_version: 1.2.1
 
 auditd_services_to_start:
   - auditd

--- a/collections/infrastructure/roles/conman/handlers/main.yml
+++ b/collections/infrastructure/roles/conman/handlers/main.yml
@@ -2,10 +2,10 @@
 - name: service <|> Restart conman
   ansible.builtin.service:
     name: conman
-    state: "{{ (conman_start_services | default(bb_start_services) | default(true, true) | bool) | ternary('restarted', omit) }}"
+    state: "{{ (conman_start_services | default(bb_start_services) | default(true) | bool) | ternary('restarted', omit) }}"
   when:
     - "'service' not in ansible_skip_tags"
-    - conman_start_services | default(bb_start_services) | default(true, true)
+    - conman_start_services | default(bb_start_services) | default(true)
 
 - name: systemd <|> Reload systemd configuration
   ansible.builtin.systemd:

--- a/collections/infrastructure/roles/conman/tasks/main.yml
+++ b/collections/infrastructure/roles/conman/tasks/main.yml
@@ -154,7 +154,7 @@
 - name: service <|> Manage conman state
   ansible.builtin.service:
     name: conman
-    enabled: "{{ (conman_enable_services | default(bb_enable_services) | default(true, true) | bool) | ternary('yes', 'no') }}"
-    state: "{{ (conman_start_services | default(bb_start_services) | default(true, true) | bool) | ternary('started', omit) }}"
+    enabled: "{{ (conman_enable_services | default(bb_enable_services) | default(true) | bool) | ternary('yes', 'no') }}"
+    state: "{{ (conman_start_services | default(bb_start_services) | default(true) | bool) | ternary('started', omit) }}"
   tags:
     - service

--- a/collections/infrastructure/roles/conman/vars/main.yml
+++ b/collections/infrastructure/roles/conman/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-conman_role_version: 1.7.0
+conman_role_version: 1.7.1
 
 conman_execpath: "/usr/lib/conman/exec"
 

--- a/collections/infrastructure/roles/http_server/handlers/main.yml
+++ b/collections/infrastructure/roles/http_server/handlers/main.yml
@@ -3,11 +3,11 @@
 - name: service <|> Restart http server service
   ansible.builtin.service:
     name: "{{ item }}"
-    state: "{{ (http_server_start_services | default(bb_start_services) | default(true, true) | bool) | ternary('restarted', omit) }}"
+    state: "{{ (http_server_start_services | default(bb_start_services) | default(true) | bool) | ternary('restarted', omit) }}"
   loop: "{{ http_server_services_to_start }}"
   when:
     - "'service' not in ansible_skip_tags"
-    - http_server_start_services | default(bb_start_services) | default(true, true)
+    - http_server_start_services | default(bb_start_services) | default(true)
 
 - name: lineinfile <|> Disable default listen on all interfaces
   ansible.builtin.lineinfile:

--- a/collections/infrastructure/roles/http_server/tasks/main.yml
+++ b/collections/infrastructure/roles/http_server/tasks/main.yml
@@ -109,8 +109,8 @@
 - name: "service <|> Manage {{ http_server_services_to_start | join(' ') }} state"
   ansible.builtin.service:
     name: "{{ item }}"
-    enabled: "{{ (http_server_enable_services | default(bb_enable_services) | default(true, true) | bool) | ternary('yes', 'no') }}"
-    state: "{{ (http_server_start_services | default(bb_start_services) | default(true, true) | bool) | ternary('started', omit) }}"
+    enabled: "{{ (http_server_enable_services | default(bb_enable_services) | default(true) | bool) | ternary('yes', 'no') }}"
+    state: "{{ (http_server_start_services | default(bb_start_services) | default(true) | bool) | ternary('started', omit) }}"
   loop: "{{ http_server_services_to_start }}"
   tags:
     - service

--- a/collections/infrastructure/roles/http_server/vars/main.yml
+++ b/collections/infrastructure/roles/http_server/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-http_server_role_version: 1.3.2
+http_server_role_version: 1.3.3

--- a/collections/infrastructure/roles/powerman/handlers/main.yml
+++ b/collections/infrastructure/roles/powerman/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: service <|> Restart powerman
   ansible.builtin.service:
     name: powerman
-    state: "{{ (powerman_start_services | default(bb_start_services) | default(true, true) | bool) | ternary('restarted', omit) }}"
+    state: "{{ (powerman_start_services | default(bb_start_services) | default(true) | bool) | ternary('restarted', omit) }}"
   when:
     - "'service' not in ansible_skip_tags"
-    - powerman_start_services | default(bb_start_services) | default(true, true)
+    - powerman_start_services | default(bb_start_services) | default(true)

--- a/collections/infrastructure/roles/powerman/tasks/main.yml
+++ b/collections/infrastructure/roles/powerman/tasks/main.yml
@@ -42,7 +42,7 @@
 - name: service <|> Manage powerman state
   ansible.builtin.service:
     name: powerman
-    enabled: "{{ (powerman_enable_services | default(bb_enable_services) | default(true, true) | bool) | ternary('yes', 'no') }}"
-    state: "{{ (powerman_start_services | default(bb_start_services) | default(true, true) | bool) | ternary('started', omit) }}"
+    enabled: "{{ (powerman_enable_services | default(bb_enable_services) | default(true) | bool) | ternary('yes', 'no') }}"
+    state: "{{ (powerman_start_services | default(bb_start_services) | default(true) | bool) | ternary('started', omit) }}"
   tags:
     - service


### PR DESCRIPTION
Issue detected with some services in High Availability due to a different implementation of the logic to start/enable services.

Seems that `default(true, true)` was causing the task to be executed twice, once with "bb_start_services" false (as intended) and another with "bb_start_services" true (undesired).

The issue has the potential to trigger STONITH if fencing is enabled.