### PR TITLE
Fix bluebanquise diskless lost found

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # 3.2.5
 
+* 4/21/25 - ginomcevoy - [pxe_stack] Fix bluebanquise-diskless to tolerate lost+found directory.
 * 4/21/25 - ginomcevoy - [pcs] Use --config to avoid error when pushing to the CIB.
 * 4/21/25 - ginomcevoy - [auditd] Avoid having service running on both nodes in HA.
 * 4/21/25 - ginomcevoy - [powerman] Avoid having service running on both nodes in HA.

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -7,6 +7,7 @@
 # ██████╔╝███████╗╚██████╔╝███████╗██████╔╝██║  ██║██║ ╚████║╚██████╔╝╚██████╔╝██║███████║███████╗
 # ╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═══╝ ╚══▀▀═╝  ╚═════╝ ╚═╝╚══════╝╚══════╝
 #
+# 2.2.2: (SMC fix) Tolerate lost+found path inside /var/www/html/pxe/diskless. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.2.1: (SMC fix) Fix check of user presence in image for cross-arch images. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.2.0: (SMC feature) Add SELinux support to live images. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.1.4: (SMC fix) Restore SELinux context before creating live image. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
@@ -114,7 +115,7 @@ class bcolors:
 # Ignore these paths when looking for diskless images.
 # For example, if /var/www/html/pxe/diskless/nfs_reference exists, then assume it is to store NFS
 # reference images, so its presence should not cause failure (it does not contain metadata.yml)
-IMAGE_DIRS_TO_IGNORE = ['images', 'nfs_reference']
+IMAGE_DIRS_TO_IGNORE = ['lost+found', 'images', 'nfs_reference']
 
 
 def display_image_metadata(image_metadata):

--- a/collections/infrastructure/roles/pxe_stack/vars/main.yml
+++ b/collections/infrastructure/roles/pxe_stack/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pxe_stack_role_version: 1.18.4
+pxe_stack_role_version: 1.18.5
 
 pxe_stack_supported_os:
   redhat:


### PR DESCRIPTION
bluebanquise-diskless fails if images path (default /var/www/html/pxe/diskless) contains "lost+found" directory:

```
[INFO] Checking reference images in /var/www/html/pxe/diskless
 File /var/www/html/pxe/diskless/lost+found/metadata.yaml does not exist, please re-run pxe_stack role before using the tool.
```

Solution is to add "lost+found" to a list that gets filtered when searching for reference/live images.