### PR TITLE
Slurm role fails to deploy and initialize a local mysql database on the management node for accounting.  

### DIFF
--- a/collections/infrastructure/roles/slurm/tasks/accounting.yml
+++ b/collections/infrastructure/roles/slurm/tasks/accounting.yml
@@ -40,16 +40,16 @@
     state: present
     login_host: "{{ slurm_accounting_mysql_login_host | default(omit, true) }}"
     login_port: "{{ slurm_accounting_mysql_login_port | default(omit, true) }}"
-    login_user: "{{ slurm_accounting_mysql_login_user | default(slurm_accounting_storage_user, true) | default(omit, true) }}"
-    login_password: "{{ slurm_accounting_mysql_login_password | default(slurm_accounting_storage_pass, true) | default(omit, true) }}"
+    login_user: "{{ slurm_accounting_mysql_login_user | default(omit, true) }}"
+    login_password: "{{ slurm_accounting_mysql_login_password | default(omit, true) }}"
   when: slurm_accounting_mysql_create_database
   tags:
     - service
 
 - name: mysql_user <|> setup slurm db user # noqa no-tabs
   community.mysql.mysql_user:
-    name: "{{ slurm_accounting_mysql_login_user | default(slurm_accounting_storage_user, true) }}"
-    password: "{{ slurm_accounting_mysql_login_password | default(slurm_accounting_storage_pass, true) }}"
+    name: "{{ slurm_accounting_storage_user | default(slurm_accounting_mysql_login_user, true) }}"
+    password: "{{ slurm_accounting_storage_pass | default(slurm_accounting_mysql_login_password, true) }}"
     priv: 'slurm_acct_db.*:ALL'
     state: present
     login_host: "{{ slurm_accounting_mysql_login_host | default(omit, true) }}"


### PR DESCRIPTION
To create the Slurm database, connection is made with slurm_accounting_mysql_login_user/slurm_accounting_mysql_login_password on a remote database server or via socket access from root on the local node without login/password required (when deploying localy the database) but not with slurm_accounting_storage_user/slurm_accounting_storage_pass

When creating the storage user in the database use first slurm_accounting_storage_user/slurm_accounting_storage_pass if they are set.

## Describe your changes
Changes in the login/password to use for creating and initializing the database for Slurm.
With a local database no login/password are required as via socket access only root can do this on the management node.

Moreover the database access must be grant to  slurm_accounting_storage_user with slurm_accounting_storage_pass when they are set instead of slurm_accounting_mysql_login_user with lurm_accounting_mysql_login_password.

To be discussed.... but required in my deployement of a small cluster.

## Issue ticket number and link if any

## Checklist before requesting a review
- [ ] Document introduced changes / variables in role README.md if any
- [ ] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml
- [ ] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG
