### PR TITLE
FIX: pxe_stack - when conditional defaulting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # 3.2.5
 
+* 4/25/25 - thiagocardozo - [pxe_stack] Fixed when conditional check.
 * 4/21/25 - ginomcevoy - [pxe_stack] Fix bluebanquise-diskless to tolerate lost+found directory.
 * 4/21/25 - ginomcevoy - [pcs] Use --config to avoid error when pushing to the CIB.
 * 4/21/25 - ginomcevoy - [auditd] Avoid having service running on both nodes in HA.

--- a/collections/infrastructure/plugins/filter/nodeset_expand.py
+++ b/collections/infrastructure/plugins/filter/nodeset_expand.py
@@ -22,6 +22,7 @@ def nodeset_expand(nodes_list):
 
     return nodeset_expand
 
+
 class FilterModule(object):
     ''' NodeSet Jinja2 filter. '''
 

--- a/collections/infrastructure/roles/pxe_stack/defaults/main.yml
+++ b/collections/infrastructure/roles/pxe_stack/defaults/main.yml
@@ -33,7 +33,7 @@ pxe_stack_preserve_repositories: true
 ############################################################
 ### Default equipment profile parameters
 
-pxe_stack_hw_equipment_type: none
+pxe_stack_hw_equipment_type: server
 pxe_stack_os_operating_system:
   distribution: ubuntu
   distribution_version: 22.04

--- a/collections/infrastructure/roles/pxe_stack/defaults/main.yml
+++ b/collections/infrastructure/roles/pxe_stack/defaults/main.yml
@@ -33,7 +33,7 @@ pxe_stack_preserve_repositories: true
 ############################################################
 ### Default equipment profile parameters
 
-pxe_stack_hw_equipment_type: server
+pxe_stack_hw_equipment_type: none
 pxe_stack_os_operating_system:
   distribution: ubuntu
   distribution_version: 22.04

--- a/collections/infrastructure/roles/pxe_stack/tasks/diskful/Debian.yml
+++ b/collections/infrastructure/roles/pxe_stack/tasks/diskful/Debian.yml
@@ -34,7 +34,7 @@
     equipment: "{{ bb_equipments[item] | default({}, true) }}"
   with_items: "{{ bb_equipments | default({}, true) }}"
   when:
-    - (bb_equipments[item]['type'] | default(pxe_stack_hw_equipment_type)) == "server"
+    - (bb_equipments[item]['hw']['hw_equipment_type'] | default(pxe_stack_hw_equipment_type)) == "server"
     - (bb_equipments[item]['os']['os_operating_system']['distribution'] | default(pxe_stack_os_operating_system.distribution) | lower) in ['debian']
     - (bb_equipments[item]['os']['os_operating_system']['distribution_major_version'] | default(pxe_stack_os_operating_system.distribution_major_version) | int) in [11, 12]
   tags:
@@ -51,7 +51,7 @@
     equipment: "{{ bb_equipments[item] | default({}, true) }}"
   with_items: "{{ bb_equipments | default({}, true) }}"
   when:
-    - (bb_equipments[item]['type'] | default(pxe_stack_hw_equipment_type)) == "server"
+    - (bb_equipments[item]['hw']['hw_equipment_type'] | default(pxe_stack_hw_equipment_type)) == "server"
     - (bb_equipments[item]['os']['os_operating_system']['distribution'] | default(pxe_stack_os_operating_system.distribution) | lower) in ['debian']
     - (bb_equipments[item]['os']['os_operating_system']['distribution_major_version'] | default(pxe_stack_os_operating_system.distribution_major_version) | int) in [11, 12]
   tags:

--- a/collections/infrastructure/roles/pxe_stack/tasks/diskful/RedHat.yml
+++ b/collections/infrastructure/roles/pxe_stack/tasks/diskful/RedHat.yml
@@ -32,7 +32,7 @@
     equipment: "{{ bb_equipments[item] | default({}, true) }}"
   with_items: "{{ bb_equipments | default({}, true) }}"
   when:
-    - (bb_equipments[item]['type'] | default(pxe_stack_hw_equipment_type, true)) == "server"
+    - (bb_equipments[item]['hw']['hw_equipment_type'] | default(pxe_stack_hw_equipment_type, true)) == "server"
     - (bb_equipments[item]['os']['os_operating_system']['distribution'] | default(pxe_stack_os_operating_system.distribution, true) | lower) in ['redhat', 'rhel', 'centos', 'centosstream', 'rockylinux', 'cloudlinux', 'oraclelinux', 'almalinux']
   tags:
     - template
@@ -48,7 +48,7 @@
     equipment: "{{ bb_equipments[item] | default({}, true) }}"
   with_items: "{{ bb_equipments | default({}, true) }}"
   when:
-    - (bb_equipments[item]['type'] | default(pxe_stack_hw_equipment_type, true)) == "server"
+    - (bb_equipments[item]['hw']['hw_equipment_type'] | default(pxe_stack_hw_equipment_type, true)) == "server"
     - (bb_equipments[item]['os']['os_operating_system']['distribution'] | default(pxe_stack_os_operating_system.distribution, true) | lower) in ['redhat', 'rhel', 'centos', 'centosstream', 'rockylinux', 'cloudlinux', 'oraclelinux', 'almalinux']
   tags:
     - template

--- a/collections/infrastructure/roles/pxe_stack/tasks/diskful/Suse.yml
+++ b/collections/infrastructure/roles/pxe_stack/tasks/diskful/Suse.yml
@@ -45,7 +45,7 @@
     equipment: "{{ bb_equipments[item] | default({}, true) }}"
   with_items: "{{ bb_equipments | default({}, true) }}"
   when:
-    - (bb_equipments[item]['type'] | default(pxe_stack_hw_equipment_type)) == "server"
+    - (bb_equipments[item]['hw']['hw_equipment_type'] | default(pxe_stack_hw_equipment_type)) == "server"
     - (bb_equipments[item]['os']['os_operating_system']['distribution'] | default(pxe_stack_os_operating_system.distribution) | lower) in ['opensuse','sles']
     - (bb_equipments[item]['os']['os_operating_system']['distribution_major_version'] | default(pxe_stack_os_operating_system.distribution_major_version) | int) in [15]
   tags:
@@ -62,7 +62,7 @@
     equipment: "{{ bb_equipments[item] | default({}, true) }}"
   with_items: "{{ bb_equipments | default({}, true) }}"
   when:
-    - (bb_equipments[item]['type'] | default(pxe_stack_hw_equipment_type)) == "server"
+    - (bb_equipments[item]['hw']['hw_equipment_type'] | default(pxe_stack_hw_equipment_type)) == "server"
     - (bb_equipments[item]['os']['os_operating_system']['distribution'] | default(pxe_stack_os_operating_system.distribution) | lower) in ['opensuse','sles']
   tags:
     - template

--- a/collections/infrastructure/roles/pxe_stack/tasks/diskful/Ubuntu.yml
+++ b/collections/infrastructure/roles/pxe_stack/tasks/diskful/Ubuntu.yml
@@ -73,7 +73,7 @@
     equipment: "{{ bb_equipments[item] | default({}, true) }}"
   with_items: "{{ bb_equipments | default({}, true) }}"
   when:
-    - (bb_equipments[item]['type'] | default(pxe_stack_hw_equipment_type)) == "server"
+    - (bb_equipments[item]['hw']['hw_equipment_type'] | default(pxe_stack_hw_equipment_type)) == "server"
     - (bb_equipments[item]['os']['os_operating_system']['distribution'] | default(pxe_stack_os_operating_system.distribution) | lower) in ['ubuntu']
     - (bb_equipments[item]['os']['os_operating_system']['distribution_major_version'] | default(pxe_stack_os_operating_system.distribution_major_version) | int) in [20, 22, 24]
   tags:
@@ -90,7 +90,7 @@
     equipment: "{{ bb_equipments[item] | default({}, true) }}"
   with_items: "{{ bb_equipments | default({}, true) }}"
   when:
-    - (bb_equipments[item]['type'] | default(pxe_stack_hw_equipment_type)) == "server"
+    - (bb_equipments[item]['hw']['hw_equipment_type'] | default(pxe_stack_hw_equipment_type)) == "server"
     - (bb_equipments[item]['os']['os_operating_system']['distribution'] | default(pxe_stack_os_operating_system.distribution) | lower) in ['ubuntu']
     - (bb_equipments[item]['os']['os_operating_system']['distribution_major_version'] | default(pxe_stack_os_operating_system.distribution_major_version) | int) in [20, 22, 24]
   tags:
@@ -107,7 +107,7 @@
     equipment: "{{ bb_equipments[item] | default({}, true) }}"
   with_items: "{{ bb_equipments | default({}, true) }}"
   when:
-    - (bb_equipments[item]['type'] | default(pxe_stack_hw_equipment_type)) == "server"
+    - (bb_equipments[item]['hw']['hw_equipment_type'] | default(pxe_stack_hw_equipment_type)) == "server"
     - (bb_equipments[item]['os']['os_operating_system']['distribution'] | default(pxe_stack_os_operating_system.distribution) | lower) in ['ubuntu']
     - (bb_equipments[item]['os']['os_operating_system']['distribution_major_version'] | default(pxe_stack_os_operating_system.distribution_major_version) | int) in [20, 22, 24]
   tags:
@@ -124,7 +124,7 @@
     equipment: "{{ bb_equipments[item] | default({}, true) }}"
   with_items: "{{ bb_equipments | default({}, true) }}"
   when:
-    - (bb_equipments[item]['type'] | default(pxe_stack_hw_equipment_type)) == "server"
+    - (bb_equipments[item]['hw']['hw_equipment_type'] | default(pxe_stack_hw_equipment_type)) == "server"
     - (bb_equipments[item]['os']['os_operating_system']['distribution'] | default(pxe_stack_os_operating_system.distribution) | lower) in ['ubuntu']
     - (bb_equipments[item]['os']['os_operating_system']['distribution_major_version'] | default(pxe_stack_os_operating_system.distribution_major_version) | int) in [20, 22, 24]
   tags:

--- a/collections/infrastructure/roles/pxe_stack/vars/main.yml
+++ b/collections/infrastructure/roles/pxe_stack/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pxe_stack_role_version: 1.18.5
+pxe_stack_role_version: 1.18.6
 
 pxe_stack_supported_os:
   redhat:


### PR DESCRIPTION
Was getting an undefined variable with `bb_equipments[item]['type'] `, which led to always ending in the default
condition of `pxe_stack_hw_equipment_type`.