### PR TITLE
Fix registry failed after stop

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # 3.2.5
 
+* 4/29/25 - ginomcevoy - [podman] fix systemd for registry service to allow rc=2, use recommended Type=forking
 * 4/25/25 - thiagocardozo - [pxe_stack] Fixed when conditional check.
 * 4/21/25 - ginomcevoy - [pxe_stack] Fix bluebanquise-diskless to tolerate lost+found directory.
 * 4/21/25 - ginomcevoy - [pcs] Use --config to avoid error when pushing to the CIB.

--- a/collections/infrastructure/roles/podman/README.md
+++ b/collections/infrastructure/roles/podman/README.md
@@ -140,6 +140,7 @@ where the paths in `podman_registry_crt_path` and `podman_registry_key_path` mus
 
 ## Changelog
 
+* 2.1.1: Fix systemd for registry service to allow rc=2, use recommended Type=forking
 * 2.1.0: Add support for TLS encryption in local registry. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 * 2.0.0: Updated registry format;Use handlers;Replace libpod.conf. Thiago Cardozo <boubee.thiago@gmail.com>
 * 1.0.3: Adapt to hw os split. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/podman/templates/registry.service.j2
+++ b/collections/infrastructure/roles/podman/templates/registry.service.j2
@@ -9,19 +9,22 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=62
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --net=slirp4netns --cidfile=%t/%n.ctr-id --sdnotify=conmon --cgroups=no-conmon \
- --rm --replace --name=registry --privileged -p {{ podman_local_registry_port }}:5000 \
--v /var/lib/registry:{{ podman_local_registry_dir }} \
+ExecStart=/usr/bin/podman run --net=slirp4netns --cidfile=%t/%n.ctr-id --conmon-pidfile %t/podman_registry.pid \
+ --detach --rm --replace --name=registry --privileged -p {{ podman_local_registry_port }}:5000 \
+ -v /var/lib/registry:{{ podman_local_registry_dir }} \
 {% if podman_registry_enable_encryption %}
  --secret smc_registry_key --secret smc_registry_crt \
  -e REGISTRY_HTTP_TLS_KEY=/run/secrets/smc_registry_key \
  -e REGISTRY_HTTP_TLS_CERTIFICATE=/run/secrets/smc_registry_crt \
 {% endif %}
 {{ podman_registry_container }}:{{ podman_registry_container_tag }}
-ExecStop=/usr/bin/podman stop -t 2 --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop -t 5 --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
-Type=notify
-NotifyAccess=all
+# registry container exits with rc=2 when stopped, allow this
+SuccessExitStatus=2
+TimeoutSec=480
+Type=forking
+PIDFile=%t/podman_registry.pid
 
 [Install]
 WantedBy=multi-user.target default.target

--- a/collections/infrastructure/roles/podman/vars/main.yml
+++ b/collections/infrastructure/roles/podman/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-podman_role_version: 2.1.0
+podman_role_version: 2.1.1


### PR DESCRIPTION
## Describe your changes
Registry service managed by podman role returns rc=2 when stopped. Update systemd template to show normal deactivation instead of failure when service is stopped.

Tested in RHEL 9.

## Checklist before requesting a review
- [x] Document introduced changes / variables in role README.md if any
- [X] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml
- [X] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG
