### PR TITLE
fix(prometheus): prometheus.yml template

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # 3.2.5
 
+* 4/30/25 - lmagdanello - [prometheus] Fix Prometheus Job template.
 * 4/25/25 - thiagocardozo - [pxe_stack] Fixed when conditional check.
 * 4/21/25 - ginomcevoy - [pxe_stack] Fix bluebanquise-diskless to tolerate lost+found directory.
 * 4/21/25 - ginomcevoy - [pcs] Use --config to avoid error when pushing to the CIB.

--- a/collections/infrastructure/roles/prometheus/README.md
+++ b/collections/infrastructure/roles/prometheus/README.md
@@ -856,6 +856,7 @@ prometheus_server_prometheus_launch_parameters: |
 
 ## Changelog
 
+* 1.6.2: Fix Prometheus Job template. Leonardo Magdanello <lmagdanello40@gmail.com>
 * 1.6.1: Fix TYPO prometheus template. Leonardo Magdanello <lmagdanello40@gmail.com>
 * 1.6.0: Monitoring HA with Basic Auth. Leonardo Magdanello <lmagdanello40@gmail.com>
 * 1.5.0: Add small features for Monitoring. Leonardo Magdanello <lmagdanello40@gmail.com>

--- a/collections/infrastructure/roles/prometheus/templates/prometheus.yml.j2
+++ b/collections/infrastructure/roles/prometheus/templates/prometheus.yml.j2
@@ -44,39 +44,30 @@ alerting:
 {% endif %}
 
 {{ prometheus_server_prometheus_raw_configuration }}
-{% if prometheus_ha_enabled is defined and prometheus_ha_enabled %}
- {% if prometheus_server_alertmanager_cluster_peers is defined and prometheus_server_alertmanager_cluster_peers|length > 0 %}
+{% if prometheus_ha_enabled is defined and prometheus_ha_enabled and prometheus_server_alertmanager_cluster_peers is defined and prometheus_server_alertmanager_cluster_peers|length > 0 %}
 # High Availability configuration
-scrape_configs:
-  - job_name: 'prometheus_ha'
-    scrape_interval: 30s
-    metrics_path: "{{ prometheus_server_prometheus_prefix }}/metrics"
-    static_configs:
-    - targets:
-      {% for alertmanager_cluster_node in prometheus_server_alertmanager_cluster_peers %}
-      {% set alertmanager_cluster_ip = alertmanager_cluster_node.addrs[0] %}
-      - {{ alertmanager_cluster_ip }}:{{ prometheus_server_prometheus_port }}
-      {% endfor %}
-{% if prometheus_server_alertmanager_password is defined and prometheus_server_alertmanager_password %}
-    basic_auth:
-      username: "{{ prometheus_server_alertmanager_username }}"
-      password: "{{ prometheus_server_alertmanager_password }}"
-{% endif %}
- {% endif %}
- {% else %}
+{% set job_name = 'prometheus_ha' %}
+{% else %}
 # Default AlertManager configuration
+{% set job_name = 'prometheus_master' %}
+{% endif %}
 scrape_configs:
-  - job_name: 'prometheus_master'
-    metrics_path: "{{ prometheus_server_prometheus_prefix }}/metrics"
+  - job_name: '{{ job_name }}'
     scrape_interval: 30s
+    metrics_path: "{{ prometheus_server_prometheus_prefix }}/metrics"
     static_configs:
     - targets:
-      - {{ prometheus_server_prometheus_host }}:{{ prometheus_server_prometheus_port }}
-{% if prometheus_server_alertmanager_password is defined and prometheus_server_alertmanager_password %}
+        - {{ prometheus_server_prometheus_host }}:{{ prometheus_server_prometheus_port }}
+    {% if prometheus_server_alertmanager_password is defined and prometheus_server_alertmanager_password %}
     basic_auth:
       username: "{{ prometheus_server_alertmanager_username }}"
       password: "{{ prometheus_server_alertmanager_password }}"
-{% endif %}
+      {% if prometheus_server_enable_tls is defined and prometheus_server_enable_tls %}
+    scheme: https
+    tls_config:
+      cert_file: "{{ prometheus_server_tls_cert_file }}"
+      key_file: "{{ prometheus_server_tls_key_file }}"
+    {% endif %}
 {% endif %}
 
 {% if prometheus_server_prometheus_raw_jobs is defined and prometheus_server_prometheus_raw_jobs is not none %}

--- a/collections/infrastructure/roles/prometheus/vars/main.yml
+++ b/collections/infrastructure/roles/prometheus/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-prometheus_role_version: 1.6.1
+prometheus_role_version: 1.6.2


### PR DESCRIPTION
## Describe your changes

- There was an error in the Prometheus template that considered Alertmanager peers within scrape_configs, which resulted in an attempt by the Prometheus job to access the cluster peers on port 9090 to scrape for metrics. In this case, in an environment with HA, Prometheus is running on only one host through the VIP and it is through it that we must search for metrics.

Wrong:
```yaml
  - job_name: 'prometheus_ha'
    scrape_interval: 30s
    metrics_path: "/prometheus/metrics"
    static_configs:
    - targets:
        - mgt1-ptp:9090
        - mgt2-ptp:9090
```

Correct:
```yaml
scrape_configs:
  - job_name: 'prometheus_ha'
    scrape_interval: 30s
    metrics_path: "/prometheus/metrics"
    static_configs:
    - targets:
        - prometheus.example.com:9090
```

- I added HTTPs support in scrape_configs. To access Prometheus through VIP with HTTPS in addition to the defined basic authentication, the correct certificate and key are required.

## Checklist before requesting a review
- [x] Document introduced changes / variables in role README.md if any
- [x] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml
- [x] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG