### PR TITLE
Fix bluebanquise-diskless option 4 link nfs when node runs SELinux

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # 3.2.5
 
+* 4/30/25 - ginomcevoy - [pxe_stack] Fix issue with bluebanquise-diskless and host node running SELinux.
 * 4/30/25 - lmagdanello - [prometheus] Fix Prometheus Job template.
 * 4/29/25 - ginomcevoy - [podman] fix systemd for registry service to allow rc=2, use recommended Type=forking
 * 4/25/25 - thiagocardozo - [pxe_stack] Fixed when conditional check.

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -99,6 +99,7 @@ import subprocess
 import crypt
 import string
 import sys
+import platform
 
 
 # Colors, from https://stackoverflow.com/questions/287871/how-to-print-colored-text-in-terminal-in-python
@@ -547,10 +548,18 @@ while True:
         # TODO add feature to support group name in pxe_stack
         protected_os_system("/usr/bin/grep -q '^smc:' " + reference_image_nfs_path + "/etc/group || /usr/sbin/groupadd -R " + reference_image_nfs_path + "/ smc")
 
+        # useradd should use "-g", but this fails in RHEL8 hosts
+        # check if we are running RHEL 8
+        running_rhel8 = "el8" in platform.release()
+        group_str = ""
+        if not running_rhel8:
+            # SMC: -g smc is hard-coded, see block above
+            group_str = "-g smc"
+
         # create user in image, skip if already created
         # SMC: -g smc is hard-coded, see block above
         # SMC: not using --system
-        protected_os_system("/usr/bin/grep -q '^" + tool_parameters['sudo_user'] + ":' " + reference_image_nfs_path + "/etc/passwd || /usr/sbin/useradd  -R " + reference_image_nfs_path + "/ -m -c 'SMC user' -g smc -d " + tool_parameters['sudo_user_home'] + " -s /bin/bash -p '" + image_selected_user_password + "' " + tool_parameters['sudo_user'])
+        protected_os_system("/usr/bin/grep -q '^" + tool_parameters['sudo_user'] + ":' " + reference_image_nfs_path + "/etc/passwd || /usr/sbin/useradd  -R " + reference_image_nfs_path + "/ -m -c 'SMC user' " + group_str + " -d " + tool_parameters['sudo_user_home'] + " -s /bin/bash -p '" + image_selected_user_password + "' " + tool_parameters['sudo_user'])
 
         # update of user password in image, useful if previous command was skipped
         logging.info(bcolors.OKBLUE + "Setting password of " + tool_parameters['sudo_user'] + " user in image..." + bcolors.ENDC)

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -538,10 +538,14 @@ while True:
         protected_os_system("mkdir -p " + reference_image_nfs_path + os.path.dirname(tool_parameters['sudo_user_home']))
 
         # create group in image, skip if already created
-        protected_os_system("/usr/bin/grep -q '^" + tool_parameters['sudo_user'] + ":' " + reference_image_nfs_path + "/etc/group || /usr/sbin/groupadd -R " + reference_image_nfs_path + "/ " + tool_parameters['sudo_user'])
+        # SMC: group name is hard-coded as "smc"
+        # TODO add feature to support group name in pxe_stack
+        protected_os_system("/usr/bin/grep -q '^smc:' " + reference_image_nfs_path + "/etc/group || /usr/sbin/groupadd -R " + reference_image_nfs_path + "/ smc")
 
         # create user in image, skip if already created
-        protected_os_system("/usr/bin/grep -q '^" + tool_parameters['sudo_user'] + ":' " + reference_image_nfs_path + "/etc/passwd || /usr/sbin/useradd  -R " + reference_image_nfs_path + "/ -m -c 'SMC user' -d " + tool_parameters['sudo_user_home'] + " -s /bin/bash -p '" + image_selected_user_password + "' " + tool_parameters['sudo_user'])
+        # SMC: -g smc is hard-coded, see block above
+        # SMC: not using --system
+        protected_os_system("/usr/bin/grep -q '^" + tool_parameters['sudo_user'] + ":' " + reference_image_nfs_path + "/etc/passwd || /usr/sbin/useradd  -R " + reference_image_nfs_path + "/ -m -c 'SMC user' -g smc -d " + tool_parameters['sudo_user_home'] + " -s /bin/bash -p '" + image_selected_user_password + "' " + tool_parameters['sudo_user'])
 
         # update of user password in image, useful if previous command was skipped
         logging.info(bcolors.OKBLUE + "Setting password of " + tool_parameters['sudo_user'] + " user in image..." + bcolors.ENDC)

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -537,6 +537,10 @@ while True:
         logging.info(bcolors.OKBLUE + "Adding " + tool_parameters['sudo_user'] + " user to image..." + bcolors.ENDC)
         protected_os_system("mkdir -p " + reference_image_nfs_path + os.path.dirname(tool_parameters['sudo_user_home']))
 
+        # Required if host node is running SELinux in enforcing mode
+        protected_os_system("mkdir -p " + reference_image_nfs_path + "/sys/fs/selinux")
+        protected_os_system("echo '0' > " + reference_image_nfs_path + "/sys/fs/selinux/enforce")
+
         # create group in image, skip if already created
         # SMC: group name is hard-coded as "smc"
         # TODO add feature to support group name in pxe_stack

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -7,6 +7,7 @@
 # ██████╔╝███████╗╚██████╔╝███████╗██████╔╝██║  ██║██║ ╚████║╚██████╔╝╚██████╔╝██║███████║███████╗
 # ╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═══╝ ╚══▀▀═╝  ╚═════╝ ╚═╝╚══════╝╚══════╝
 #
+# 2.2.3: (SMC fix) Fix user creation when host node is running SELinux in enforcing mode, force smc group. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.2.2: (SMC fix) Tolerate lost+found path inside /var/www/html/pxe/diskless. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.2.1: (SMC fix) Fix check of user presence in image for cross-arch images. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.2.0: (SMC feature) Add SELinux support to live images. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
@@ -297,7 +298,7 @@ print("""\
       (o_  (o_  //\\
       (/)_ (/)_ V_/_
    BlueBanquise diskless
-   v2.2.1
+   v2.2.3
    Patched for SMC
 
 """)

--- a/collections/infrastructure/roles/pxe_stack/vars/main.yml
+++ b/collections/infrastructure/roles/pxe_stack/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pxe_stack_role_version: 1.18.6
+pxe_stack_role_version: 1.18.7
 
 pxe_stack_supported_os:
   redhat:


### PR DESCRIPTION
- Fix bluebanquise-diskless option 4 link nfs when node runs SELinux ,error were:

```
ERROR: command /usr/bin/grep -q '^smc:' /var/www/html/pxe/diskless/nfs_reference/rhel_9.5_aarch64-ref-standard/etc/passwd || /usr/sbin/useradd  -R /var/www/html/pxe/diskless/nfs_reference/rhel_9.5_aarch64-ref-standard/ -m -c 'SMC user' -d /opt/smc/home -s /bin/bash -p '$6$wDehqATpDnyU8il3$jGFLpIeN4F74xtdFAQfS7n3as9.FkONxpp4wNrNPYrzafdZW0GB3duYXAI95.AhFQEa.lr.3VFwoGL0dj9sDU0' smc failed :(
 Report:
 Error code: 9
 stdout: b'useradd: group smc exists - if you want to add this user to that group, use -g.\n'
```

This error can be fixed by creating "/sys/fs/selinux/enforce" in NFS image with contents "0".

- Second error appeared right after first fix
```
 ERROR: command /usr/bin/grep -q '^smc:' /var/www/html/pxe/diskless/nfs_reference/rhel_9.5_aarch64-ref-standard/etc/passwd || /usr/sbin/useradd  -R /var/www/html/pxe/diskless/nfs_reference/rhel_9.5_aarch64-ref-standard/ -m -c 'SMC user' -d /opt/smc/home -s /bin/bash -p '$6$wDehqATpDnyU8il3$jGFLpIeN4F74xtdFAQfS7n3as9.FkONxpp4wNrNPYrzafdZW0GB3duYXAI95.AhFQEa.lr.3VFwoGL0dj9sDU0' smc failed :(
 Report:
 Error code: 9
 stdout: b'useradd: group smc exists - if you want to add this user to that group, use -g.\n'
```

Fix now is to pass "-g" parameter to adduser.

- SMC ONLY: we are hard-coding the group to "smc" instead of a group with the same name as "sudo_user_home".
 Fix to master branch will  have to use "sudo_user_home".