### PR TITLE
Fix: nfs - Fixed unresolvable server name in mount

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # To 3.2.6
 
+* 4/30/25 - thiagocardozo - [nfs] Fixed server name in client when using IP.
 * 4/26/25 - oxedions - [dns_server] CLean old variable, disable ipv6 listen, allow forward only. (#1050, from aolloh)
 * 4/26/25 - oxedions - [repositories] Fix support of missing bb_repositories variable. (#1006, from sopalain)
 * 4/25/25 - oxedions - [nfs] Fix id in export, add subnet parameter. (#1004, from levaillx)

--- a/collections/infrastructure/roles/nfs/tasks/client.yml
+++ b/collections/infrastructure/roles/nfs/tasks/client.yml
@@ -41,7 +41,7 @@
 - name: mount <|> Mount exported NFS into directories
   ansible.posix.mount:
     path: "{{ item.0.mount }}"
-    src: "{{ item.0.server }}{% if item.0.network is defined and item.0.network is not none %}-{{ item.0.network }}{% endif %}:{{ item.0.export }}"
+    src: "{{ item.0.server }}{% if item.0.server is not in ansible_all_ipv4_addresses and item.0.network is defined and item.0.network is not none %}-{{ item.0.network }}{% endif %}:{{ item.0.export }}"
     fstype: nfs
     opts: "{{ item.0.mount_options | default('rw,fsc,nfsvers=4.2,bg,nosuid,nodev',true) }}"
     state: "{{ nfs_client_directories_state }}"

--- a/collections/infrastructure/roles/nfs/vars/main.yml
+++ b/collections/infrastructure/roles/nfs/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-nfs_role_version: 1.5.0
+nfs_role_version: 1.5.1


### PR DESCRIPTION
If network is defined in nfs share, client will always add {server}-{network} to mount list.
This will work if server is a name as this entry will be added to /etc/hosts,
but not if it's an IP as it renders something like 10.0.0.1-net1.

This PR adds a check to verify if server name is an IP before appending network name.