### PR TITLE
Fix: grafana - Added retry to service handler

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # 3.2.5
 
+* 5/2/25 - thiagocardozo - [grafana] Service handler retries;Show imported dashboards.
 * 4/30/25 - ginomcevoy - [pxe_stack] Fix issue with bluebanquise-diskless and host node running SELinux.
 * 4/30/25 - lmagdanello - [prometheus] Fix Prometheus Job template.
 * 4/29/25 - ginomcevoy - [podman] fix systemd for registry service to allow rc=2, use recommended Type=forking

--- a/collections/infrastructure/roles/grafana/handlers/main.yml
+++ b/collections/infrastructure/roles/grafana/handlers/main.yml
@@ -4,6 +4,10 @@
     name: "{{ item  }}"
     state: restarted
   with_items: "{{ grafana_services_to_start }}"
+  register: service_results
+  retries: 5
+  delay: 10
+  until: service_results is not failed
   when:
     - "'service' not in ansible_skip_tags"
     - (grafana_start_services | default(bb_start_services) | default(true) | bool)

--- a/collections/infrastructure/roles/grafana/tasks/dashboards.yml
+++ b/collections/infrastructure/roles/grafana/tasks/dashboards.yml
@@ -51,7 +51,6 @@
         "overwrite": true,
         "message": "Updated by ansible"
       }
-  no_log: true
   with_fileglob:
     - "{{ _tmp_dashboards.path }}/*"
     - "{{ grafana_dashboards_dir }}/*.json"

--- a/collections/infrastructure/roles/grafana/vars/main.yml
+++ b/collections/infrastructure/roles/grafana/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-grafana_role_version: 2.2.4
+grafana_role_version: 2.2.5
 grafana_default_port: 3000


### PR DESCRIPTION
This is complementary to https://github.com/bluebanquise/bluebanquise/pull/1071.

Also remove no_log to show imported dashboards.