### PR TITLE
Fix: grafana - Added retry to service handler

### DIFF
--- a/collections/infrastructure/roles/grafana/handlers/main.yml
+++ b/collections/infrastructure/roles/grafana/handlers/main.yml
@@ -4,6 +4,10 @@
     name: "{{ item  }}"
     state: restarted
   with_items: "{{ grafana_services_to_start }}"
+  register: service_results
+  retries: 5
+  delay: 10
+  until: service_results is not failed
   when:
     - "'service' not in ansible_skip_tags"
     - (grafana_start_services | default(bb_start_services) | default(true) | bool)


### PR DESCRIPTION
This is complementary to https://github.com/bluebanquise/bluebanquise/pull/1071.

Also remove no_log to show imported dashboards.