### PR TITLE
Fix conman powerman bmc credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # 3.2.5
 
+* 5/2/25 - ginomcevoy - [conman] Restore feature to inform credentials via BMC ansible hosts
+* 5/2/25 - ginomcevoy - [powerman] Restore feature to inform credentials via BMC ansible hosts
 * 5/2/25 - thiagocardozo - [grafana] Service handler retries;Show imported dashboards.
 * 4/30/25 - thiagocardozo - [nfs] Fixed server name in client when using IP.
 * 4/30/25 - ginomcevoy - [pxe_stack] Fix issue with bluebanquise-diskless and host node running SELinux.

--- a/collections/infrastructure/roles/conman/templates/conman.conf.j2
+++ b/collections/infrastructure/roles/conman/templates/conman.conf.j2
@@ -10,25 +10,37 @@ SERVER timestamp=1h
 GLOBAL logopts="timestamp"
 
 {% for host in (j2_hosts_range | sort) -%}
-  {% if (hostvars[host]['hw_equipment_type'] | default("server")) == "server" and hostvars[host]['hw_board_authentication'] is defined %}
+  {% if (hostvars[host]['hw_equipment_type'] | default("server")) == "server" %}
     {% if hostvars[host]['bmc'] is defined and hostvars[host]['bmc']['name'] is defined %}
+      {# Gather BMC network settings #}
+      {% if hostvars[host]['bmc']['ip4'] is defined %}{# BMC is defined inside host #}
+        {% set host_bmc = hostvars[host]['bmc'] %}
+        {% set credentials_host = host %}{# Define host as credentials source #}
+      {% else %}{# BMC is defined outside host #}
+        {% set host_bmc = hostvars[hostvars[host]['bmc']['name']]['network_interfaces'][0] %}
+        {% set credentials_host = hostvars[host]['bmc']['name'] %}{# Define external bmc as credentials source #}
+      {% endif %}
+      {# Check if no authentication found #}
+      {% if hostvars[credentials_host]['hw_board_authentication'] is not defined %}
+      {% continue %}
+      {% endif %}
       {# Identify protocol to be used #}
       {# IPMI #}
-      {% if (hostvars[host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','IPMI') | list | length) >= 1 %}
+      {% if (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','IPMI') | list | length) >= 1 %}
         {# Gather BMC credentials settings #}
-        {% set host_bmc_user = (hostvars[host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','IPMI') | map(attribute='user') | list | first | default(none)) %}
-        {% set host_bmc_password = (hostvars[host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','IPMI') | map(attribute='password') | list | first | default(none)) %}
+        {% set host_bmc_user = (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','IPMI') | map(attribute='user') | list | first | default(none)) %}
+        {% set host_bmc_password = (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','IPMI') | map(attribute='password') | list | first | default(none)) %}
         {% if host_bmc_user is defined and host_bmc_user is not none and host_bmc_password is defined and host_bmc_password is not none %}
-console name="{{ host }}" dev="ipmitool.exp {{ hostvars[host]['bmc']['name'] }} {{ host_bmc_user }} {{ host_bmc_password }}"
+console name="{{ host }}" dev="ipmitool.exp {{ host_bmc['ip4'] }} {{ host_bmc_user }} {{ host_bmc_password }}"
         {% endif %}
       {# REDFISH #}
-      {% elif (hostvars[host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','REDFISH') | list | length) >= 1  %}
+      {% elif (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','REDFISH') | list | length) >= 1  %}
         {# Gather BMC credentials settings #}
-        {% set host_bmc_user = (hostvars[host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','REDFISH') | map(attribute='user') | list | first | default(none)) %}
-        {% set host_bmc_password = (hostvars[host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','REDFISH') | map(attribute='password') | list | first | default(none)) %}
-        {% set host_bmc_console_port = (hostvars[host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','REDFISH') | map(attribute='console_port') | list | first | default(none)) %}
+        {% set host_bmc_user = (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','REDFISH') | map(attribute='user') | list | first | default(none)) %}
+        {% set host_bmc_password = (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','REDFISH') | map(attribute='password') | list | first | default(none)) %}
+        {% set host_bmc_console_port = (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','REDFISH') | map(attribute='console_port') | list | first | default(none)) %}
         {% if host_bmc_user is defined and host_bmc_user is not none and host_bmc_password is defined and host_bmc_password is not none %}
-console name="{{ host }}" dev="ssh.exp {{ hostvars[host]['bmc']['name'] }} {{ host_bmc_console_port | default(conman_redfish_console_port, true) }} {{ host_bmc_user }} {{ host_bmc_password }}"
+console name="{{ host }}" dev="ssh.exp {{ host_bmc['ip4'] }} {{ host_bmc_console_port | default(conman_redfish_console_port, true) }} {{ host_bmc_user }} {{ host_bmc_password }}"
         {% endif %}
       {% endif %}
     {% endif %}

--- a/collections/infrastructure/roles/conman/vars/main.yml
+++ b/collections/infrastructure/roles/conman/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-conman_role_version: 1.7.2
+conman_role_version: 1.8.0
 
 conman_execpath: "/usr/lib/conman/exec"
 

--- a/collections/infrastructure/roles/conman/vars/main.yml
+++ b/collections/infrastructure/roles/conman/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-conman_role_version: 1.7.1
+conman_role_version: 1.7.2
 
 conman_execpath: "/usr/lib/conman/exec"
 

--- a/collections/infrastructure/roles/powerman/templates/powerman.conf.j2
+++ b/collections/infrastructure/roles/powerman/templates/powerman.conf.j2
@@ -7,43 +7,65 @@ include "/etc/powerman/ipmipower.dev"
 {% set range = (j2_hosts_range | sort) %}
 
 {% for equipment in bb_equipments %}
-  {# Detect protocol #}
   {% set hosts = [] %}
   {% set bmcs = [] %}
   {# Structure to gather hosts by their BMC credentials: user -> pass -> hosts nested dict #}
   {% set credentials_dict = {} %}
   {% for host in bb_equipments[equipment]['nodes'] %}
     {% if host in range and hostvars[host]['bmc']['name'] is defined -%}
+      {# Gather BMC network settings for current host #}
+      {% if hostvars[host]['bmc']['ip4'] is defined %}{# BMC is defined inside host #}
+        {% set credentials_host = host %}{# Define host as credentials source #}
+      {% else %}{# BMC is defined outside host #}
+        {% set credentials_host = hostvars[host]['bmc']['name'] %}{# Define external bmc as credentials source #}
+      {% endif %}
       {# Look for BMC credentials #}
-      {% if hostvars[host]['hw_board_authentication'] is defined %}
-        {% set host_bmc_user = (hostvars[host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','IPMI') | map(attribute='user') | list | first | default(none)) %}
-        {% set host_bmc_password = (hostvars[host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','IPMI') | map(attribute='password') | list | first | default(none)) %}
-        {% if host_bmc_user is defined and host_bmc_user is not none and host_bmc_password is defined and host_bmc_password is not none -%}
-          {# Check if this set of credentials have been used before in a previous host #}
-          {% if host_bmc_user not in credentials_dict -%}
-            {# new user credential, create a dictionary entry for it #}
-            {{ credentials_dict.update({host_bmc_user: {}}) }}
-          {%- endif %}
-          {% if host_bmc_password not in credentials_dict[host_bmc_user] -%}
-           {# new password credential, create an inner dictionary entry for it #}
-           {{ credentials_dict[host_bmc_user].update({host_bmc_password: []}) }}
-          {%- endif %}
-          {# Add this host to the set of hosts with the same credentials #}
+      {% if hostvars[credentials_host]['hw_board_authentication'] is defined %}
+        {# Found hw_board_authentication settings, detect protocol #}
+        {% set ipmi_credentials = (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','match','IPMI')) %}
+        {% if ipmi_credentials | length > 0 %}
+          {# Found IPMI credentials from hw_board_authentication, save first entry #}
+          {% set host_bmc_user = (ipmi_credentials | map(attribute='user') | list | first) %}
+          {% set host_bmc_password = (ipmi_credentials | map(attribute='password') | list | first) %}
+        {% else %}
+          {# Did not find IPMI credentials, will not add this BMC #}
+          {% set host_bmc_user = '' %}
+          {% set host_bmc_password = '' %}
+        {% endif %}
+        {# Check if this set of credentials have been used before in a previous host #}
+        {% if host_bmc_user and host_bmc_user not in credentials_dict -%}
+          {# new user credential, create a dictionary entry for it #}
+          {{ credentials_dict.update({host_bmc_user: {}}) }}
+        {%- endif %}
+        {% if host_bmc_password and host_bmc_password not in credentials_dict[host_bmc_user] -%}
+          {# new password credential, create an inner dictionary entry for it #}
+          {{ credentials_dict[host_bmc_user].update({host_bmc_password: []}) }}
+        {%- endif %}
+        {# Add this host to the set of hosts with the same credentials #}
+        {% if host_bmc_user and host_bmc_password -%}
           {{ credentials_dict[host_bmc_user][host_bmc_password].append(host) }}
         {%- endif %}
       {% endif %}
     {%- endif %}
   {% endfor %}
   {# Render entries for each set of nodes with the same credentials #}
+  {# The credentials_count variable is used to keep track of the set count within each equipment #}
+  {% set credentials_count = [] %}
   {% for host_bmc_user in credentials_dict %}
     {% for host_bmc_password in credentials_dict[host_bmc_user] %}
       {% set hosts = credentials_dict[host_bmc_user][host_bmc_password] %}
       {% set bmcs = [] %}
+      {# Increase the count of sets in this equipment #}
+      {{ credentials_count.append(1) }}
       {% for host in hosts -%}
         {{ bmcs.append(hostvars[host]['bmc']['name']) }}
       {%- endfor %}
-      {# Name device for each set of credentials, using index #}
-      {% set device_suffix = loop.index | string %}
+      {# Name device for each set of credentials: first device has equipment name, next ones are indexed #}
+      {% if credentials_count | length > 1 %}
+        {% set device_suffix = credentials_count | length | string %}
+      {% else %}
+        {% set device_suffix = '' %}
+      {% endif %}
       {% if powerman_enable_ipmi_lan_2_0 is defined and powerman_enable_ipmi_lan_2_0 %}
 device "{{ equipment }}{{ device_suffix }}" "ipmipower" "/usr/sbin/ipmipower --wait-until-on --wait-until-off -h {{ bmcs|bluebanquise.infrastructure.nodeset_expand }} -u {{ host_bmc_user }} -p {{ host_bmc_password }} -D LAN_2_0 |&"
       {% else %}

--- a/collections/infrastructure/roles/powerman/vars/main.yml
+++ b/collections/infrastructure/roles/powerman/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-powerman_role_version: 1.4.2
+powerman_role_version: 1.5.0

--- a/collections/infrastructure/roles/powerman/vars/main.yml
+++ b/collections/infrastructure/roles/powerman/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-powerman_role_version: 1.4.1
+powerman_role_version: 1.4.2


### PR DESCRIPTION
[Fix: powerman - Restore feature to inform credentials via BMC ansible]
[Fix: conman - Restore feature to inform credentials via BMC ansible]

Tested in dev environment by checking the contents of powerman.log and conman.log with different inventories
- IPMI in host inventory
- IPMI in BMC inventory
- REDFISH in host inventory
- REDFISH in BMC inventory