### PR TITLE
Fix rsyslog ha

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # 3.2.5
 
+* 5/2/25 - ginomcevoy - [rsyslog] Allow merging rsyslog.conf into server/client confs for HA
 * 5/2/25 - ginomcevoy - [conman] Restore feature to inform credentials via BMC ansible hosts
 * 5/2/25 - ginomcevoy - [powerman] Restore feature to inform credentials via BMC ansible hosts
 * 5/2/25 - thiagocardozo - [grafana] Service handler retries;Show imported dashboards.

--- a/collections/infrastructure/roles/pcs/README.md
+++ b/collections/infrastructure/roles/pcs/README.md
@@ -565,20 +565,24 @@ one for client.
 In the playbook, use:
 
 ```yaml
-roles:
-  - role: log_server
+  - role: bluebanquise.infrastructure.rsyslog
     tags: log
     vars:
       log_server_rsyslog_custom_conf_path : /etc/rsyslog-server.conf
-  - role: log_client
+      rsyslog_integrate_rsyslog_conf: true
+...
+  - role: bluebanquise.infrastructure.rsyslog
     tags: log
     vars:
       log_client_rsyslog_custom_conf_path : /etc/rsyslog-client.conf
+      rsyslog_integrate_rsyslog_conf: true
 tasks:
   - name: Remove base rsyslog configuration
     file:
       path: /etc/rsyslog.conf
       state: absent
+    when: "'/etc/rsyslog.conf' is not link"
+    tags: log
 ```
 
 This will generate both configurations, and ensure the default configuration is

--- a/collections/infrastructure/roles/rsyslog/defaults/main.yml
+++ b/collections/infrastructure/roles/rsyslog/defaults/main.yml
@@ -2,3 +2,4 @@
 rsyslog_port: 514
 
 rsyslog_client_verbosity: "info"
+rsyslog_integrate_rsyslog_conf: false

--- a/collections/infrastructure/roles/rsyslog/tasks/main.yml
+++ b/collections/infrastructure/roles/rsyslog/tasks/main.yml
@@ -36,7 +36,9 @@
     group: root
     mode: 0644
   notify: service <|> Restart rsyslog service
-  when: "'rsyslog.conf' not in (rsyslog_configuration_files | default([]) | selectattr('name','defined') | map(attribute='name') | list)"
+  when:
+    - "'rsyslog.conf' not in (rsyslog_configuration_files | default([]) | selectattr('name','defined') | map(attribute='name') | list)"
+    - not rsyslog_integrate_rsyslog_conf | default(false) | bool
   tags:
     - template
 

--- a/collections/infrastructure/roles/rsyslog/templates/client.conf.j2
+++ b/collections/infrastructure/roles/rsyslog/templates/client.conf.j2
@@ -17,6 +17,11 @@ action(type="omfwd" target="{{ server_address }}" protocol="tcp" port="{{ server
 # ### end of the forwarding rule ###
 {% endmacro %}
 
+{# Useful with High Availability, so that this file is used as rsyslog.conf #}
+{% if rsyslog_integrate_rsyslog_conf %}
+{% include 'rsyslog.conf.j2' %}
+{% endif %}
+
 #### RULES ####
 
 # Everybody gets emergency messages

--- a/collections/infrastructure/roles/rsyslog/templates/server.conf.j2
+++ b/collections/infrastructure/roles/rsyslog/templates/server.conf.j2
@@ -1,3 +1,8 @@
+{# Useful with High Availability, so that this file is used as rsyslog.conf #}
+{% if rsyslog_integrate_rsyslog_conf %}
+{% include 'rsyslog.conf.j2' %}
+{% endif %}
+
 #### SERVER MODULES ####
 
 # Provides UDP syslog reception

--- a/collections/infrastructure/roles/rsyslog/vars/main.yml
+++ b/collections/infrastructure/roles/rsyslog/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-rsyslog_role_version: 1.6.1
+rsyslog_role_version: 1.6.2


### PR DESCRIPTION
Fix a bug with rsyslog in HA as the documentation to deploy it is flawed.
Current BlueBanquise implementation for rsyslog is as follows:

- Normal behavior:
  - for rsyslog server, create rsyslog.conf + rsyslog.d/server.conf
  - for rsyslog client,  create rsyslog.conf + rsyslog.d/client.conf
  
- HA behavior as documented in the pcs role:
  - for rsyslog server, rename rsyslog.d/server.conf to rsyslog-server.conf
  - for rsyslog client,  rename rsyslog.d/client.conf to rsyslog-client.conf
  - pacemaker links rsyslog-server.conf -> rsyslog.conf for server resource
  - pacemaker links rsyslog-client.conf -> rsyslog.conf for client resource

The problem is the approach for HA is flawed, because the original rsyslog.conf is missing. As a consequence, rsyslog stops working for both mgt1 and mgt2.

Solution is to integrate the original rsyslog.conf into rsyslog-server.conf and rsyslog-client.conf.
For this we add a new parameter "rsyslog_integrate_rsyslog_conf", false by default.

In HA conf:
```
    - role: bluebanquise.infrastructure.rsyslog
      tags: rsyslog_server
      vars:
        rsyslog_profile: server
        rsyslog_server_rsyslog_custom_conf_path: /etc/rsyslog-server.conf
        rsyslog_integrate_rsyslog_conf: true
...
    - role: bluebanquise.infrastructure.rsyslog
      tags: rsyslog_client
      vars:
        rsyslog_profile: client
        rsyslog_client_rsyslog_custom_conf_path: /etc/rsyslog-client.conf
        rsyslog_integrate_rsyslog_conf: true

  post_tasks:
     - name: Remove base rsyslog configuration
       ansible.builtin.file:
         path: /etc/rsyslog.conf
         state: absent
       when: "'/etc/rsyslog.conf' is not link"
       tags:
         - rsyslog_server
         - rsyslog_client
```

Tested in HA environment, verified logs for both nodes are generated.