### PR TITLE
Fix: grafana: wrong firewall variable name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # To 3.2.6
 
+* 5/5/25 - thiagocardozo - [grafana] Fixed old ep_firewall variable.
 * 4/30/25 - thiagocardozo - [nfs] Fixed server name in client when using IP.
 * 4/26/25 - oxedions - [dns_server] CLean old variable, disable ipv6 listen, allow forward only. (#1050, from aolloh)
 * 4/26/25 - oxedions - [repositories] Fix support of missing bb_repositories variable. (#1006, from sopalain)

--- a/collections/infrastructure/roles/grafana/tasks/install.yml
+++ b/collections/infrastructure/roles/grafana/tasks/install.yml
@@ -52,7 +52,7 @@
     state: enabled
   when:
     - ansible_facts.os_family == "RedHat"
-    - ep_firewall | default(false) | bool
+    - os_firewall | default(false) | bool
     - grafana_port != grafana_default_port
   tags:
     - firewall

--- a/collections/infrastructure/roles/grafana/vars/main.yml
+++ b/collections/infrastructure/roles/grafana/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-grafana_role_version: 2.2.4
+grafana_role_version: 2.2.5
 grafana_default_port: 3000


### PR DESCRIPTION
There's a remaining ep_firewall variable in grafana role.
