### PR TITLE
Fix: grafana: wrong firewall variable name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
 Format: <date> - <author (username or mail or both)> - [role] <change description>
 
 # 3.2.5
-
+* 5/5/25 - thiagocardozo - [grafana] Fixed old ep_firewall variable.
 * 5/2/25 - ginomcevoy - [rsyslog] Allow merging rsyslog.conf into server/client confs for HA
 * 5/2/25 - ginomcevoy - [conman] Restore feature to inform credentials via BMC ansible hosts
 * 5/2/25 - ginomcevoy - [powerman] Restore feature to inform credentials via BMC ansible hosts

--- a/collections/infrastructure/roles/grafana/tasks/install.yml
+++ b/collections/infrastructure/roles/grafana/tasks/install.yml
@@ -52,7 +52,7 @@
     state: enabled
   when:
     - ansible_facts.os_family == "RedHat"
-    - ep_firewall | default(false) | bool
+    - os_firewall | default(false) | bool
     - grafana_port != grafana_default_port
   tags:
     - firewall

--- a/collections/infrastructure/roles/grafana/vars/main.yml
+++ b/collections/infrastructure/roles/grafana/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-grafana_role_version: 2.2.5
+grafana_role_version: 2.2.6
 grafana_default_port: 3000


### PR DESCRIPTION
There's a remaining ep_firewall variable in grafana role.
