### PR TITLE
Fix: pxe_stack: Dont recursively act on folder

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # To 3.2.7
 
+* 5/15/25 - thiagocardozo - [pxe_stack] Stop folder creating task from acting on present images.
 * 5/5/25 - oxedions - [nic] Fix role for Ubuntu/Debian, ensure con name matches device name.
 
 # 3.2.6

--- a/collections/infrastructure/roles/pxe_stack/tasks/diskless.yml
+++ b/collections/infrastructure/roles/pxe_stack/tasks/diskless.yml
@@ -40,7 +40,6 @@
     mode: 0755
     owner: root
     group: root
-    recurse: yes
 
 - name: "service <|> Manage diskless services state"
   ansible.builtin.service:

--- a/collections/infrastructure/roles/pxe_stack/vars/main.yml
+++ b/collections/infrastructure/roles/pxe_stack/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pxe_stack_role_version: 1.18.4
+pxe_stack_role_version: 1.18.5
 
 pxe_stack_supported_os:
   redhat:


### PR DESCRIPTION
In pxe_stack theres a task that creates diskless nfs directories structure.
That's ok for when the role runs for the first time, but the task has a "recursive" property that will cause the module
to act on hundreds of thousands of files if a few dozen images are present. This is causing long delays and might even
break the images.

It seems that this task should create the folder and nothing else.
