### PR TITLE
Fix podman rootless configuration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 Format: <date> - <author (username or mail or both)> - [role] <change description>
 
 # 3.2.6
+* 5/22/25 - ginomcevoy - [podman] Fix configuration for rootless containers
 * 5/15/25 - thiagocardozo - [pxe_stack] Stop folder creating task from acting on present images.
 
 # 3.2.5

--- a/collections/infrastructure/roles/podman/README.md
+++ b/collections/infrastructure/roles/podman/README.md
@@ -35,7 +35,7 @@ Variables for this role:
 | podman_configure | True | boolean | use default configuration when False, write config, when True |
 | podman_configure_local_registry | False | boolean | starts a default local registry when True |
 | podman_configure_ha | False | boolean | configure podman for a HA cluster |
-| podman_users | { root: '100000:65535' } | dictionary | podman users that get uid mapping configured, those users MUST exist on the system before running this role |
+| podman_users | { root: '100000:65535' } | dictionary | podman users that get uid mapping configured
 | podman_manual_mapping | False | boolean | ansible managed /etc/subuid and /etc/subgid entries |
 | podman_sudo_user | bluebanquise | String | BlueBanquise sudo user, can get uid mapping configured if listed in podman_users
 | podman_search_registries | - 'docker.io' | items | list of registries that podman is pulling images from |

--- a/collections/infrastructure/roles/podman/README.md
+++ b/collections/infrastructure/roles/podman/README.md
@@ -37,6 +37,7 @@ Variables for this role:
 | podman_configure_ha | False | boolean | configure podman for a HA cluster |
 | podman_users | { root: '100000:65535' } | dictionary | podman users that get uid mapping configured, those users MUST exist on the system before running this role |
 | podman_manual_mapping | False | boolean | ansible managed /etc/subuid and /etc/subgid entries |
+| podman_sudo_user | bluebanquise | String | BlueBanquise sudo user, can get uid mapping configured if listed in podman_users
 | podman_search_registries | - 'docker.io' | items | list of registries that podman is pulling images from |
 | podman_insecure_registries | [] | items | non TLS registries for podman, i.e. localhost:5000 |
 | podman_blocked_registries | [] | items | blocked container registries |

--- a/collections/infrastructure/roles/podman/defaults/main.yml
+++ b/collections/infrastructure/roles/podman/defaults/main.yml
@@ -55,6 +55,7 @@ podman_storage_mountopt: 'nodev'
 # and get custom ~/.config/containers/libpod.conf
 podman_users:
  root: '100000:65535' # noqa
+podman_sudo_user: bluebanquise
 
 # if you want i.e. the user vagrant to start unprivileged containers
 # you can do the following:

--- a/collections/infrastructure/roles/podman/tasks/users.yml
+++ b/collections/infrastructure/roles/podman/tasks/users.yml
@@ -22,7 +22,7 @@
     state: directory
     owner: "{{ getent_passwd[item.key][1] | default(root) }}"
     group: "{{ getent_passwd[item.key][2] | default(root) }}"
-    mode: 0644
+    mode: 0750
   loop: "{{ podman_users|dict2items }}"
   when: getent_passwd[item.key][1]|int >= 1000
 
@@ -32,6 +32,6 @@
     dest: "{{ getent_passwd[item.key][4] }}/.config/containers/containers.conf"
     owner: "{{ getent_passwd[item.key][1] | default(root) }}"
     group: "{{ getent_passwd[item.key][2] | default(root) }}"
-    mode: 0644
+    mode: 0640
   loop: "{{ podman_users|dict2items }}"
   when: getent_passwd[item.key][1]|int >= 1000

--- a/collections/infrastructure/roles/podman/tasks/users.yml
+++ b/collections/infrastructure/roles/podman/tasks/users.yml
@@ -24,7 +24,9 @@
     group: "{{ getent_passwd[item.key][2] | default(root) }}"
     mode: 0750
   loop: "{{ podman_users|dict2items }}"
-  when: (getent_passwd[item.key][1] | int >= 1000) or (podman_sudo_user == item.key)
+  when:
+    - item.key in getent_passwd
+    - (getent_passwd[item.key][1] | int >= 1000) or (podman_sudo_user == item.key)
 
 - name: users <|> Deploy user configuration for non-root pods
   ansible.builtin.template:
@@ -34,4 +36,6 @@
     group: "{{ getent_passwd[item.key][2] | default(root) }}"
     mode: 0640
   loop: "{{ podman_users|dict2items }}"
-  when: (getent_passwd[item.key][1] | int >= 1000) or (podman_sudo_user == item.key)
+  when:
+    - item.key in getent_passwd
+    - (getent_passwd[item.key][1] | int >= 1000) or (podman_sudo_user == item.key)

--- a/collections/infrastructure/roles/podman/tasks/users.yml
+++ b/collections/infrastructure/roles/podman/tasks/users.yml
@@ -24,7 +24,7 @@
     group: "{{ getent_passwd[item.key][2] | default(root) }}"
     mode: 0750
   loop: "{{ podman_users|dict2items }}"
-  when: getent_passwd[item.key][1]|int >= 1000
+  when: (getent_passwd[item.key][1] | int >= 1000) or (podman_sudo_user == item.key)
 
 - name: users <|> Deploy user configuration for non-root pods
   ansible.builtin.template:
@@ -34,4 +34,4 @@
     group: "{{ getent_passwd[item.key][2] | default(root) }}"
     mode: 0640
   loop: "{{ podman_users|dict2items }}"
-  when: getent_passwd[item.key][1]|int >= 1000
+  when: (getent_passwd[item.key][1] | int >= 1000) or (podman_sudo_user == item.key)

--- a/collections/infrastructure/roles/podman/templates/etc/containers/containers.conf.j2
+++ b/collections/infrastructure/roles/podman/templates/etc/containers/containers.conf.j2
@@ -33,7 +33,13 @@ log_driver = "journald"
 log_size_max = -1
 
 [network]
+
+# Network backend determines what network driver will be used to set up and tear down container networks.
+# Valid values are "cni" and "netavark".
+# The default value is empty which means that it will automatically choose CNI or netavark.
+# If there are already containers/images or CNI networks preset it will choose CNI.
 network_backend = ""
+
 cni_plugin_dirs = [
                "/usr/libexec/cni",
                "/usr/lib/cni",
@@ -42,7 +48,11 @@ cni_plugin_dirs = [
 ]
 
 default_network = "podman"
-network_config_dir = "/etc/cni/net.d/"
+
+# Path to the directory where network configuration files are located.
+# For the CNI backend the default is "/etc/cni/net.d" as root
+# and "$HOME/.config/cni/net.d" as rootless.
+#network_config_dir = "/etc/cni/net.d/"
 
 [engine]
 cgroup_manager = "{{ podman_conf_cgroup_manager }}"
@@ -69,8 +79,14 @@ infra_image = "k8s.gcr.io/pause:3.1"
 namespace = "{{ podman_conf_namespace }}"
 no_pivot_root = false
 num_locks = 2048
+
+# Default runtime will be searched for on the system using the priority:
+# "crun", "runc", "runj", "kata", "runsc", "ocijail"
 runtime = ""
-tmp_dir = "/var/run/libpod"
+
+# Path to the tmp directory, for libpod runtime content.
+# Defaults to $XDG_RUNTIME_DIR/libpod/tmp as rootless and /run/libpod/tmp as rootful.
+#tmp_dir = "/var/run/libpod"
 
 [engine.runtimes]
 

--- a/collections/infrastructure/roles/podman/templates/home/containers.conf.j2
+++ b/collections/infrastructure/roles/podman/templates/home/containers.conf.j2
@@ -1,4 +1,14 @@
 {{ ansible_managed | comment }}
+# The containers configuration file specifies all of the available configuration
+# command-line options/flags for container engine tools like Podman & Buildah,
+# but in a TOML format that can be easily modified and versioned.
+
+# Please refer to containers.conf(5) for details of all configuration options.
+# Not all container engines implement all of the options.
+# All of the options have hard coded defaults and these options will override
+# the built in defaults. Users can then override these options via the command
+# line.
+
 [containers]
 default_capabilities = [
   "NET_RAW",
@@ -24,7 +34,12 @@ log_size_max = -1
 label = true
 
 [network]
-network_backend = "cni"
+
+# Network backend determines what network driver will be used to set up and tear down container networks.
+# Valid values are "cni" and "netavark".
+# The default value is empty which means that it will automatically choose CNI or netavark.
+# If there are already containers/images or CNI networks preset it will choose CNI.
+network_backend = ""
 
 cni_plugin_dirs = [
                "/usr/libexec/cni",
@@ -34,10 +49,14 @@ cni_plugin_dirs = [
 ]
 
 default_network = "podman"
-network_config_dir = "/etc/cni/net.d/"
+
+# Path to the directory where network configuration files are located.
+# For the CNI backend the default is "/etc/cni/net.d" as root
+# and "$HOME/.config/cni/net.d" as rootless.
+#network_config_dir = "/etc/cni/net.d/"
 
 [engine]
-cgroup_manager = "cgroupfs"
+cgroup_manager = "{{ podman_conf_cgroup_manager }}"
 
 conmon_env_vars = [
                 "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -54,19 +73,38 @@ conmon_path = [
             "/usr/lib/crio/bin/conmon"
 ]
 
-enable_port_reservation = true
 events_logger = "{{ podman_conf_events_logger }}"
+enable_port_reservation = true
 image_default_transport = "docker://"
 infra_command = "/pause"
 infra_image = "k8s.gcr.io/pause:3.1"
+
 no_pivot_root = false
 num_locks = 2048
-runtime = "runc"
-tmp_dir = "/var/run/libpod"
+
+# Default runtime will be searched for on the system using the priority:
+# "crun", "runc", "runj", "kata", "runsc", "ocijail"
+runtime = ""
+
+# Path to the tmp directory, for libpod runtime content.
+# Defaults to $XDG_RUNTIME_DIR/libpod/tmp as rootless and /run/libpod/tmp as rootful.
+#tmp_dir = "/var/run/libpod"
+
 static_dir = "{{ getent_passwd[item.key][4] }}/.local/share/containers/storage/libpod"
 volume_path = "{{ getent_passwd[item.key][4] }}/.local/share/containers/storage/volumes"
 
 [engine.runtimes]
+
+crun = [
+		"/usr/bin/crun",
+		"/usr/sbin/crun",
+		"/usr/local/bin/crun",
+		"/usr/local/sbin/crun",
+		"/sbin/crun",
+		"/bin/crun",
+		"/run/current-system/sw/bin/crun",
+]
+
 runc = [
             "/usr/bin/runc",
             "/usr/sbin/runc",

--- a/collections/infrastructure/roles/podman/vars/main.yml
+++ b/collections/infrastructure/roles/podman/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-podman_role_version: 2.1.1
+podman_role_version: 2.1.2


### PR DESCRIPTION
## Describe your changes

Fix to podman role:
- File and dir permissions for rootless
- Use default values for network_config_dir and tmp_dir, add comments
- Update containers.conf template for rootless
- Introduce podman_sudo_user to allow bluebanquise user (this is a feature, should be treated separately for BB PR)
- Avoid failure if user in podman_users does not exist