### PR TITLE
Fix bb diskless aarch64

### DIFF
--- a/collections/infrastructure/galaxy.yml
+++ b/collections/infrastructure/galaxy.yml
@@ -4,7 +4,7 @@ namespace: bluebanquise
 name: infrastructure
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.2.5-smc2.0.7
+version: 3.2.5-smc2.0.8
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -565,7 +565,7 @@ while True:
         # create user in image, skip if already created
         # SMC: -g smc is hard-coded, see block above
         # SMC: not using --system
-        protected_os_system("/usr/bin/grep -q '^" + tool_parameters['sudo_user'] + ":' " + reference_image_nfs_path + "/etc/passwd || /usr/sbin/useradd  -R " + reference_image_nfs_path + "/ -m -c 'SMC user' " + group_str + " -d " + tool_parameters['sudo_user_home'] + " -s /bin/bash -p '" + image_selected_user_password + "' " + tool_parameters['sudo_user'])
+        protected_os_system("/usr/bin/grep -q '^" + tool_parameters['sudo_user'] + ":' " + reference_image_nfs_path + "/etc/passwd || /usr/sbin/useradd  -R " + reference_image_nfs_path + "/ -m -c 'SMC user' " + group_str + " -d " + tool_parameters['sudo_user_home'] + " -u " + str(tool_parameters['sudo_user_uid']) + " -s /bin/bash -p '" + image_selected_user_password + "' " + tool_parameters['sudo_user'])
 
         # update of user password in image, useful if previous command was skipped
         logging.info(bcolors.OKBLUE + "Setting password of " + tool_parameters['sudo_user'] + " user in image..." + bcolors.ENDC)

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -7,6 +7,7 @@
 # ██████╔╝███████╗╚██████╔╝███████╗██████╔╝██║  ██║██║ ╚████║╚██████╔╝╚██████╔╝██║███████║███████╗
 # ╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═══╝ ╚══▀▀═╝  ╚═════╝ ╚═╝╚══════╝╚══════╝
 #
+# 2.2.5: (SMC fix) Fix NFS mount (-u uid) and SELinux (avoid chroot) in aarch64 images. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.2.4: (SMC fix) Allow + character when sanitizing user input, needed for kernel-64k in aarch64 images. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.2.3: (SMC fix) Fix user creation when host node is running SELinux in enforcing mode, force smc group. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.2.2: (SMC fix) Tolerate lost+found path inside /var/www/html/pxe/diskless. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
@@ -305,7 +306,7 @@ print("""\
       (o_  (o_  //\\
       (/)_ (/)_ V_/_
    BlueBanquise diskless
-   v2.2.4
+   v2.2.5
    Patched for SMC
 
 """)
@@ -852,8 +853,8 @@ WantedBy=multi-user.target
                 print(bcolors.FAIL + " An error occurred writing the file " + image_mountdir + "/etc/systemd/system/bb_diskless_selinux.service. Please investigate." + bcolors.ENDC)
                 quit(1)
 
-            # enable the oneshot service at boot time
-            protected_os_system("chroot " + image_mountdir + " /usr/bin/ln -s /etc/systemd/system/bb_diskless_selinux.service /etc/systemd/system/multi-user.target.wants/bb_diskless_selinux.service")
+            # enable the oneshot service at boot time using a relative link
+            protected_os_system("/usr/bin/ln -s ../bb_diskless_selinux.service " + image_mountdir + "/etc/systemd/system/multi-user.target.wants/bb_diskless_selinux.service")
 
             # (Step 1) Apply a relabel in the live image, before squashing it
             logging.info(bcolors.OKBLUE + 'Applying SELinux labels on image filesystem...' + bcolors.ENDC)

--- a/collections/infrastructure/roles/pxe_stack/templates/diskless_parameters.yml.j2
+++ b/collections/infrastructure/roles/pxe_stack/templates/diskless_parameters.yml.j2
@@ -1,5 +1,6 @@
 ---
 sudo_user: {{ pxe_stack_sudo_user }}
 sudo_user_home: {{ pxe_stack_sudo_user_home }}
+sudo_user_uid: {{ pxe_stack_sudo_user_uid }}
 http_pxe_folder: {{ pxe_stack_htdocs_path }}/pxe/
 nfs_path: {{ pxe_stack_diskless_nfs_path }}

--- a/collections/infrastructure/roles/pxe_stack/vars/main.yml
+++ b/collections/infrastructure/roles/pxe_stack/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pxe_stack_role_version: 1.18.8
+pxe_stack_role_version: 1.18.9
 
 pxe_stack_supported_os:
   redhat:


### PR DESCRIPTION
Fixes for aarch64 diskless images
- Pass -u <uid> when creating user in diskless reference image so that usermod command does not fail later
- Avoid chroot when configuring SELinux in live image