### PR TITLE
Improve node stability with configuring Slurm to keep some memory amount for the operating system

### DIFF
--- a/collections/infrastructure/roles/slurm/README.md
+++ b/collections/infrastructure/roles/slurm/README.md
@@ -241,6 +241,7 @@ hw_specs:
     sockets: 2
     threadspercore: 1
   memory: 63500
+  reserved_os_memory: 4096
   slurm_extra_nodes_parameters: Feature=XXXX Weight=YY
 ```
 

--- a/collections/infrastructure/roles/slurm/templates/slurm.conf.j2
+++ b/collections/infrastructure/roles/slurm/templates/slurm.conf.j2
@@ -126,6 +126,9 @@ AcctGatherProfileType=acct_gather_profile/{{ slurm_acct_gather_profile_type }}
     {% if buffer.memory is defined and buffer.memory is not none %}
         {% set nodes_parameters = nodes_parameters + ' RealMemory=' + (buffer.memory|string) %}
     {% endif %}
+    {% if buffer.reserved_os_memory is defined and buffer.reserved_os_memory is not none %}
+        {% set nodes_parameters = nodes_parameters + ' MemSpecLimit=' + (buffer.reserved_os_memory|string) %}
+    {% endif %}
     {% if buffer.slurm_extra_nodes_parameters is defined and buffer.slurm_extra_nodes_parameters is not none %}
         {% set nodes_parameters = nodes_parameters + ' ' +  buffer.slurm_extra_nodes_parameters %}
     {% endif %}


### PR DESCRIPTION
## Describe your changes
In Slurm, `mem_spec_limit` key is the amount of memory that Slurm must not use (minimum reservation for the OS).
When a user allocate a full node, some system instabilities can occur with OOM killer.
If in the node inventory "reserved_os_memory" (in MB) is specified, this limitation on usable amount of memory is introduced in slurm.conf 

## Issue ticket number and link if any
This is a new feature to improve the minimal Slurm setup. It is running on my cluster after some node crashes with out-of-memory problems. Still in test (waiting for some production time to check if memory related instabilities are solved).

It will be finalized if Bluebanquise team agree with this improvement.

## Checklist before requesting a review
- [X ] Document introduced changes / variables in role README.md if any
- [ ] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml
- [ ] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG
