### PR TITLE
Slurm - Fix local accounting setup + Add slurm_pam_adoption

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,8 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # To 3.2.7
 
-* 8/29/25 - santos-lucas - [slurm]  Fix slurm local accounting service state managent and support to el9
+* 6/09/25 - santos-lucas - [slurm] Added support for pam_slurm_adoption. Lucas Santos <lucassouzasantos@gmail.com> 
+* 8/29/25 - santos-lucas - [slurm]  Fix slurm local accounting service state managent and support to el9.
 * 8/18/25 - oxedions - [nic] Fix mask systemd-networkd.socket and add tag nic_os_dedicated_tasks to disable os tasks. (#1122, from vedmonds)
 * 8/18/25 - oxedions - [nic] Fix missing test when renaming interface name. (#1123, from vedmonds)
 * 7/16/25 - oxedions - [nic] Make network manager restar when package is updated. (#1114, from vedmonds)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # To 3.2.7
 
+* 8/29/25 - santos-lucas - [slurm]  Fix slurm local accounting service state managent and support to el9
 * 8/18/25 - oxedions - [nic] Fix mask systemd-networkd.socket and add tag nic_os_dedicated_tasks to disable os tasks. (#1122, from vedmonds)
 * 8/18/25 - oxedions - [nic] Fix missing test when renaming interface name. (#1123, from vedmonds)
 * 7/16/25 - oxedions - [nic] Make network manager restar when package is updated. (#1114, from vedmonds)

--- a/collections/infrastructure/roles/slurm/README.md
+++ b/collections/infrastructure/roles/slurm/README.md
@@ -323,6 +323,37 @@ And check again if the cluster exist:
 sacctmgr list cluster
 ```
 
+### Access restriction - pam_slurm_adoption
+
+pam_slurm_adoption is a pam module created to make sure that users only can access cluster resources that are allocated to them. 
+
+This means that users that dont have resources allocated on a compute node, wont be able to login into it. Also, when the user does have resources allocated, all his processes will be restricted to the same cgroup restrictions, what means that even if the user ssh into the node, it will be restricted by his allocated resources 
+
+By default, pam_slurm_adoption is disabled, to enable it, change the following variable on your inventories:
+
+```yaml
+slurm_pam_slurm_adopt_enable: true
+```
+
+example in your slurm configuration:
+
+```yaml
+slurm_cluster_name: bluebanquise
+slurm_controller_hostname: management1
+slurm_pam_slurm_adopt_enable: true
+slurm_partitions_list:
+  - computes_groups:
+      - os_debian12
+      - os_debian11
+    partition_name: debian
+    partition_configuration:
+      State: UP
+      MaxTime: "72:00:00"
+      DefaultTime: "24:00:00"
+```
+
+By default on EL8 systems, the local users on the system will not be afected by this configuration, including the root user.
+
 ### GPU Gres
 
 Unfortunately for now, this is only supported for NVIDIA GPUS.
@@ -390,6 +421,7 @@ See more explanation on https://slurm.schedmd.com/acct_gather.conf.html
 **Please now update CHANGELOG file at repository root instead of adding logs in this file.
 These logs bellow are only kept for archive.**
 
+* 1.7.0: Added support for pam_slurm_adoption. Lucas Santos <lucassouzasantos@gmail.com> 
 * 1.6.5: Fix slurm local accounting service state managent and support to el9. Lucas Santos <lucassouzasantos@gmail.com> 
 * 1.6.4: Add slurm accounting and MYSQL support on ubuntu 22.04. Hamid MERZOUKI <hamid@sesterce.com>
 * 1.6.3: Switch deb packages to official names. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/slurm/README.md
+++ b/collections/infrastructure/roles/slurm/README.md
@@ -390,7 +390,7 @@ See more explanation on https://slurm.schedmd.com/acct_gather.conf.html
 **Please now update CHANGELOG file at repository root instead of adding logs in this file.
 These logs bellow are only kept for archive.**
 
-* 1.6.5: Fix slurm local accounting service state managent and fix support to el9. Lucas Santos <lucassouzasantos@gmail.com> 
+* 1.6.5: Fix slurm local accounting service state managent and support to el9. Lucas Santos <lucassouzasantos@gmail.com> 
 * 1.6.4: Add slurm accounting and MYSQL support on ubuntu 22.04. Hamid MERZOUKI <hamid@sesterce.com>
 * 1.6.3: Switch deb packages to official names. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.6.2: Fix the way mysql databse is defined. Code from @sgaosdgr. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/slurm/README.md
+++ b/collections/infrastructure/roles/slurm/README.md
@@ -390,6 +390,7 @@ See more explanation on https://slurm.schedmd.com/acct_gather.conf.html
 **Please now update CHANGELOG file at repository root instead of adding logs in this file.
 These logs bellow are only kept for archive.**
 
+* 1.6.5: Fix slurm local accounting service state managent and fix support to el9. Lucas Santos <lucassouzasantos@gmail.com> 
 * 1.6.4: Add slurm accounting and MYSQL support on ubuntu 22.04. Hamid MERZOUKI <hamid@sesterce.com>
 * 1.6.3: Switch deb packages to official names. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.6.2: Fix the way mysql databse is defined. Code from @sgaosdgr. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/slurm/defaults/main.yml
+++ b/collections/infrastructure/roles/slurm/defaults/main.yml
@@ -45,6 +45,7 @@ slurm_accounting_mysql_slurm_user: slurm
 slurm_accounting_mysql_slurm_password: ssap_slurm # CHANGE ME !
 slurm_accounting_mysql_create_database: false
 slurm_accounting_mysql_create_user: false
+slurm_accounting_mysql_unix_socket: /var/run/mysqld/mysqld.sock
 ### mariadb
 slurm_innodb_buffer_pool_size: 1024M
 slurm_innodb_log_file_size: 64M

--- a/collections/infrastructure/roles/slurm/tasks/accounting_local_mysql.yml
+++ b/collections/infrastructure/roles/slurm/tasks/accounting_local_mysql.yml
@@ -16,6 +16,12 @@
   tags:
     - template
 
+- name: service <|> Manage MariaDB state
+  ansible.builtin.service:
+    name: mariadb
+    enabled: "{{ (slurm_enable_services | default(bb_enable_services) | default(true) | bool) | ternary('yes', 'no') }}"
+    state: "{{ (slurm_start_services | default(bb_start_services) | default(true) | bool) | ternary('started', omit) }}"
+
 - name: file <|> Configure MariaDB to listen on all interfaces
   lineinfile:
     path: /etc/mysql/mariadb.conf.d/50-server.cnf
@@ -27,14 +33,14 @@
   notify: service <|> restart mariadb
   register: mariadb_config
 
-- name: Force handlers
-  meta: flush_handlers
+- name: meta <|> Run handler tasks to restart services
+  ansible.builtin.meta: flush_handlers
 
 - name: mysql_db <|> Create slurm_acct_db database
   community.mysql.mysql_db:
     name: slurm_acct_db
     state: present
-    login_unix_socket: /run/mysqld/mysqld.sock
+    login_unix_socket: "{{ slurm_accounting_mysql_unix_socket }}"
   when: slurm_accounting_mysql_create_database
 
 - name: mysql_user <|> Ensure slurm user exists in the database
@@ -43,7 +49,7 @@
     password: "{{ slurm_accounting_mysql_slurm_password }}"
     state: present
     priv: 'slurm_acct_db.*:ALL'
-    login_unix_socket: /var/run/mysqld/mysqld.sock
     column_case_sensitive: false
+    login_unix_socket: "{{ slurm_accounting_mysql_unix_socket }}"
   when:
     - slurm_accounting_mysql_create_user

--- a/collections/infrastructure/roles/slurm/tasks/main.yml
+++ b/collections/infrastructure/roles/slurm/tasks/main.yml
@@ -111,5 +111,10 @@
   ansible.builtin.include_tasks: "submitter.yml"
   when: slurm_profile == 'submitter'
 
+# Setup slurm_adoption
+- name: include_tasks ░ Configure slurm_adopt
+  ansible.builtin.include_tasks: "pam_slurm_adopt.yml"
+  when: slurm_pam_slurm_adopt_enable is defined and slurm_pam_slurm_adopt_enable and slurm_profile == 'compute'
+
 - name: meta <|> Run handler tasks to restart services
   ansible.builtin.meta: flush_handlers

--- a/collections/infrastructure/roles/slurm/tasks/pam_slurm_adopt.yml
+++ b/collections/infrastructure/roles/slurm/tasks/pam_slurm_adopt.yml
@@ -1,0 +1,22 @@
+- name: "package █ Install pam_slurm_adopt"
+  ansible.builtin.package:
+    name: "slurm-pam_slurm"
+    state: present
+  tags:
+    - package
+
+- name: "Ensure pam_slurm_adopt is configured on PAM ssh rules"
+  ansible.builtin.lineinfile:
+    path: /etc/pam.d/sshd 
+    insertafter: '^account'
+    line: "-account    required      pam_slurm_adopt.so #bluebanquise managed" 
+
+- name: "Disable pam_systemd in sshd & system-auth - https://slurm.schedmd.com/pam_slurm_adopt.html"
+  ansible.builtin.lineinfile:
+    path: "/etc/pam.d/{{item}}"
+    regexp: '^.*pam_systemd\.so.*'
+    state: absent
+  with_items:
+    - password-auth
+    - system-auth
+    - sshd

--- a/collections/infrastructure/roles/slurm/templates/slurm.conf.j2
+++ b/collections/infrastructure/roles/slurm/templates/slurm.conf.j2
@@ -56,8 +56,13 @@ GresTypes={{ slurm_grestypes }}
 ProctrackType=proctrack/cgroup
 TaskPlugin=affinity,cgroup
 SelectTypeParameters=CR_Core_Memory,CR_CORE_DEFAULT_DIST_BLOCK,CR_ONE_TASK_PER_CORE
-
 {% endif %}
+
+{% if slurm_pam_slurm_adopt_enable is defined and slurm_pam_slurm_adopt_enable %}
+# pam_slurm_adoption
+PrologFlags=contain
+{% endif %}
+
 {% if slurm_enable_accounting %}
 ## Accounting
 AccountingStorageHost={{ slurm_controller_hostname }}

--- a/collections/infrastructure/roles/slurm/vars/RedHat_9.yml
+++ b/collections/infrastructure/roles/slurm/vars/RedHat_9.yml
@@ -1,6 +1,7 @@
 ---
 slurm_home_path: /etc/slurm
 slurm_mysql_cnf_dir: /etc/my.cnf.d
+slurm_accounting_mysql_socket_file: /var/lib/mysql/mysql.sock
 slurm_packages_to_install:
   controller:
     - munge

--- a/collections/infrastructure/roles/slurm/vars/RedHat_9.yml
+++ b/collections/infrastructure/roles/slurm/vars/RedHat_9.yml
@@ -1,7 +1,7 @@
 ---
 slurm_home_path: /etc/slurm
 slurm_mysql_cnf_dir: /etc/my.cnf.d
-slurm_accounting_mysql_socket_file: /var/lib/mysql/mysql.sock
+slurm_accounting_mysql_unix_socket: /var/lib/mysql/mysql.sock
 slurm_packages_to_install:
   controller:
     - munge


### PR DESCRIPTION
## Describe your changes

This PR will address 2 sets of commits:

### 1. Local accounting configuration  

on EL9, the local accounting configuration was using the incorrect unix_socket path, leading to this:

```bash
TASK [bluebanquise.infrastructure.slurm : mysql_db <|> Create slurm_acct_db database] *************************************************************************************************************************************************
Saturday 30 August 2025  01:26:42 +0200 (0:00:00.011)       0:00:23.479 ******* 
fatal: [mngt01]: FAILED! => changed=false 
  msg: 'unable to find /root/.my.cnf. Exception message: (2003, "Can''t connect to MySQL server on ''localhost'' ([Errno 2] No such file or directory)")'
```

So, to overcome this, I created a new variable called "slurm_accounting_mysql_unix_socket" on the slurm role so we can keep different paths for different OS versions. 

As I did not had a chance to test it on other OS versions yet, I did added this variable with the previous value on the defaults for the role, so it keeps working just the same as it was for other OS versions.

Also, this role did not had a service state management section for the MariaDB service, so that was also added.

### 2. Add support for pam_slurm_adoption

Support for pam_slurm_addoption was added so it can already be deployed with slurm role, adding more this level of security specially required on production systems  

## Checklist before requesting a review
- [x] Document introduced changes / variables in role README.md if any
- [x] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml
- [x] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG
