### PR TITLE
Fix: dhcp_server - bmc mac required

### DIFF
--- a/collections/infrastructure/roles/dhcp_server/README.md
+++ b/collections/infrastructure/roles/dhcp_server/README.md
@@ -263,6 +263,7 @@ This allows for example to have an heterogenous cluster, with a group of hosts b
 
 ## Changelog
 
+* 1.8.1: BMCs no longer must have a MAC defined. Thiago Cardozo <boubee.thiago@gmail.com>
 * 1.8.0: Import external matching patterns. Thiago Cardozo <boubee.thiago@gmail.com>
 * 1.7.1: Fix global logic. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.7.0: Allow services and services_ip together. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/dhcp_server/templates/dhcpd.subnet.conf.j2
+++ b/collections/infrastructure/roles/dhcp_server/templates/dhcpd.subnet.conf.j2
@@ -127,7 +127,7 @@
   {% endif %}
   {%- if current_hostvars['bmc'] is defined %}
     {% set bmc_args = current_hostvars['bmc'] %}
-    {% if bmc_args.network is defined and bmc_args.network == item and (bmc_args.name is defined and bmc_args.name is not none) and (bmc_args.mac is defined and (bmc_args.mac | ansible.utils.hwaddr)) and (bmc_args.ip4 is defined and (bmc_args.ip4 | ansible.utils.ipaddr)) %}
+    {% if bmc_args.network is defined and bmc_args.network == item and (bmc_args.name is defined and bmc_args.name is not none) and (bmc_args.ip4 is defined and (bmc_args.ip4 | ansible.utils.ipaddr)) %}
 {{ write_host(bmc_args.name, bmc_args, None, None, None) }}
     {% endif %}
   {% endif %}

--- a/collections/infrastructure/roles/dhcp_server/vars/main.yml
+++ b/collections/infrastructure/roles/dhcp_server/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-dhcp_server_role_version: 1.8.0
+dhcp_server_role_version: 1.8.1


### PR DESCRIPTION
A check in the subnet jinja2 template is forcing a BMC to have a MAC address defined,
causing the write to skip if for instance just dhcp_client_identifier is used.

Removed the check since it's already present in the write_host macro.
