### PR TITLE
Fix bmc without mac skipping

### DIFF
--- a/collections/infrastructure/roles/dhcp_server/README.md
+++ b/collections/infrastructure/roles/dhcp_server/README.md
@@ -72,7 +72,7 @@ Example of network configuration, advanced dhcp server:
           - ip: 8.8.4.4
         ntp4:                                          # Is optional
           - hostname: time-a-g.nist.gov
-            ip: 129.6.15.28 
+            ip: 129.6.15.28
         pxe4:                                          # Is optional, needed for pxe
           - hostname: mg1
             ip: 10.11.0.1
@@ -150,7 +150,7 @@ It is possible to combine networks into shared-networks when multiple subnets
 are on the same NIC, or when using opt82/option_match parameter.
 To do so, add a dedicated optional `shared_network` key in the network definition.
 
-Networks of the same shared network must have the same `shared_network` value, 
+Networks of the same shared network must have the same `shared_network` value,
 which is the name of this share.
 
 For example to add net-1 and net-2 into the same shared network, define them
@@ -222,6 +222,7 @@ This allows for example to have an heterogenous cluster, with a group of hosts b
 **Please now update CHANGELOG file at repository root instead of adding logs in this file.
 These logs bellow are only kept for archive.**
 
+* 1.7.2: BMCs no longer must have a MAC defined. Thiago Cardozo <boubee.thiago@gmail.com>
 * 1.7.1: Fix global logic. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.7.0: Allow services and services_ip together. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.6.3: Fix double character for ipxe rom. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/dhcp_server/templates/dhcpd.subnet.conf.j2
+++ b/collections/infrastructure/roles/dhcp_server/templates/dhcpd.subnet.conf.j2
@@ -114,7 +114,7 @@
   {% endif %}
   {%- if current_hostvars['bmc'] is defined %}
     {% set bmc_args = current_hostvars['bmc'] %}
-    {% if bmc_args.network is defined and bmc_args.network == item and (bmc_args.name is defined and bmc_args.name is not none) and (bmc_args.mac is defined and (bmc_args.mac | ansible.utils.hwaddr)) and (bmc_args.ip4 is defined and (bmc_args.ip4 | ansible.utils.ipaddr)) %}
+    {% if bmc_args.network is defined and bmc_args.network == item and (bmc_args.name is defined and bmc_args.name is not none) and (bmc_args.ip4 is defined and (bmc_args.ip4 | ansible.utils.ipaddr)) %}
 {{ write_host(bmc_args.name, bmc_args, None, None, None) }}
     {% endif %}
   {% endif %}

--- a/collections/infrastructure/roles/dhcp_server/vars/main.yml
+++ b/collections/infrastructure/roles/dhcp_server/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-dhcp_server_role_version: 1.7.1
+dhcp_server_role_version: 1.7.2


### PR DESCRIPTION
A check in the subnet jinja2 template is forcing a BMC to have a MAC address defined,
causing the write to skip if for instance just dhcp_client_identifier is used.

Removed the check since it's already present in the write_host macro.
