### PR TITLE
[BUG] alertmanager: Ubuntu vars package is prometheus-alertmanager

### DIFF
--- a/collections/infrastructure/roles/prometheus/vars/Ubuntu.yml
+++ b/collections/infrastructure/roles/prometheus/vars/Ubuntu.yml
@@ -2,7 +2,7 @@
 prometheus_server_prometheus_packages_to_install:
   - prometheus
 prometheus_server_alertmanager_packages_to_install:
-  - alertmanager
+  - prometheus-alertmanager
 prometheus_server_ipmi_exporter_packages_to_install:
   - ipmi-exporter
   - freeipmi


### PR DESCRIPTION
## Describe your changes
In Ubuntu noble (24.04.3 LTS), the package `alertmanager` does not exists. It is named `prometheus-alertmanager`.

All other packages are fine.

## Issue ticket number and link if any

## Checklist before requesting a review
- [ ] Document introduced changes / variables in role README.md if any
- [ ] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml
- [ ] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG
