### PR TITLE
pxe_stack: create an empty vendor-data to avoid timeout in cloud-init

### DIFF
--- a/collections/infrastructure/roles/pxe_stack/tasks/diskful/Ubuntu.yml
+++ b/collections/infrastructure/roles/pxe_stack/tasks/diskful/Ubuntu.yml
@@ -96,6 +96,23 @@
   tags:
     - file
 
+- name: file <|> Create cloud-init empty vendor-data
+  ansible.builtin.copy:
+    dest: "{{ pxe_stack_htdocs_path }}/pxe/equipment_profiles/{{ item | trim }}.cloud-init/vendor-data"
+    content: ""
+    mode: 0644
+    owner: "{{ pxe_stack_apache_user }}"
+    group: "{{ pxe_stack_apache_group }}"
+  vars:
+    equipment: "{{ bb_equipments[item] | default({}, true) }}"
+  with_items: "{{ bb_equipments | default({}, true) }}"
+  when:
+    - (bb_equipments[item]['hw']['hw_equipment_type'] | default(pxe_stack_hw_equipment_type)) == "server"
+    - (bb_equipments[item]['os']['os_operating_system']['distribution'] | default(pxe_stack_os_operating_system.distribution) | lower) in ['ubuntu']
+    - (bb_equipments[item]['os']['os_operating_system']['distribution_major_version'] | default(pxe_stack_os_operating_system.distribution_major_version) | int) in [20, 22, 24]
+  tags:
+    - file
+
 - name: template <|> Generate cloud-init user-data
   ansible.builtin.template:
     src: "Ubuntu/user-data.j2"


### PR DESCRIPTION
During Ubuntu autoinstall, cloud-init tries to download 3 files:
* `meta-data`
* `user-data`
* `vendor-data`

Currently `meta-data` is created empty, `user-data` contains the actual autoinstall configuration.   
The installers tries 10 download of vendor-data before giving out. Purpose of this PR is just to avoid that by creating an empty file to avoid timeout and speed up process.