### PR TITLE
add support for apt customization

### DIFF
--- a/collections/infrastructure/roles/pxe_stack/templates/Ubuntu/user-data.j2
+++ b/collections/infrastructure/roles/pxe_stack/templates/Ubuntu/user-data.j2
@@ -25,8 +25,8 @@ autoinstall:
   apt:
     geoip: false
     preserve_sources_list: {{ pxe_stack_preserve_repositories }}
-    {% if equipment['os']['os_pxe_apt_configuration'] is defined %}
-{{ equipment['os']['os_pxe_apt_configuration'] | indent(2, True) }}
+    {% if equipment['os']['os_pxe_ubuntu_apt_configuration'] is defined %}
+{{ equipment['os']['os_pxe_ubuntu_apt_configuration'] | indent(2, True) }}
     {% endif %}
   keyboard: {layout: {{ (equipment['os']['os_keyboard_layout'] | default(pxe_stack_os_keyboard_layout)) | lower }}, toggle: null, variant: ''}
   locale: {{ equipment['os']['os_system_language'] | default(pxe_stack_os_system_language) }}


### PR DESCRIPTION
To use local repositories instead of Internet one during OS deployment with Ubuntu, we need to be able to add directives to the `apt` section of the `user-data` cloud-init file.  
  
This is done by creating an `os_pxe_apt_configuration` key in the `os` dictionary that can be filled with raw cloud-init configuration format content.
