### PR TITLE
Enhance way to apply connection modifications

### DIFF
--- a/collections/infrastructure/roles/nic/handlers/main.yml
+++ b/collections/infrastructure/roles/nic/handlers/main.yml
@@ -1,7 +1,11 @@
 ---
 - name: command <|> Reload connections
-  ansible.builtin.command: nmcli con reload
-  when: nic_reload_connections
+  community.general.nmcli:
+    conn_name: "{{ item.item.conn_name | default(item.item.interface) | string }}"
+    state: up
+    conn_reload: true
+  loop: "{{ nic_apply.results }}"
+  when: nic_reload_connections and item.changed
 
 # - name: command <|> netplan generate
 #   command: netplan generate


### PR DESCRIPTION
Hi,
Before this change I frequently needed to do `nmcli con up xxx` to properly apply connection changes, especially on bond setups when slave member where already partially configured.   
With this change it is automatically done at connection reload. I also preferred to use the decicated nmcli module instead of a shell command, probably more efficient.  
