### PR TITLE
Allow to define Ubuntu autoinstall ssh.allow-pw

### DIFF
--- a/collections/infrastructure/roles/pxe_stack/defaults/main.yml
+++ b/collections/infrastructure/roles/pxe_stack/defaults/main.yml
@@ -13,6 +13,9 @@ pxe_stack_diskful_os_suse: true
 pxe_stack_diskful_os_debian: true
 pxe_stack_diskful_os_dgx: false
 
+# Allow SSH password authentication
+pxe_stack_ssh_allow_passwords: true
+
 # Enable root user as default user
 pxe_stack_enable_root: false
 # Sudo user if root not enabled

--- a/collections/infrastructure/roles/pxe_stack/templates/Ubuntu/user-data.j2
+++ b/collections/infrastructure/roles/pxe_stack/templates/Ubuntu/user-data.j2
@@ -67,7 +67,7 @@ autoinstall:
   {% endif %}
   ssh:
     install-server: true
-    allow-pw: true
+    allow-pw: "{{ pxe_stack_ssh_allow_passwords }}"
   {% if pxe_stack_post_install_action in ['poweroff', 'halt', 'shutdown'] %}
   shutdown: poweroff
   {% else %}


### PR DESCRIPTION
Sysadmins should be able to disable allow-pw during the deployment to enhance security.

## Describe your changes

Add a new variable `pxe_stack_ssh_allow_pw` which allows to define `ssh.allow-pw` in Ubuntu Autoinstall.
Defaults to `true` for backward-compatibility.