### PR TITLE
Ensure nic_allow_reboot is checked as a boolean

### DIFF
--- a/collections/infrastructure/roles/nic/README.md
+++ b/collections/infrastructure/roles/nic/README.md
@@ -177,7 +177,7 @@ To achieve that, few variables are at disposal:
 * `nic_reload_connections`: this variable will trigger a handler that will ask NetworkManager to reload its configuration.
 * `nic_force_nic_restart`: this variable will trigger a task that will manually down and up interfaces. To be used with care.
 * `nic_restart_timeout`: this variable is used with nic_force_nic_restart to specify the time to wait between connection down and up actions. Default value is 2s.
-* `nic_reboot`: this variable will trigger a reboot if any nic configuration changed. To be used with care.
+* `nic_allow_reboot`: this variable will trigger a reboot if any nic configuration changed. To be used with care.
 
 ## Changelog
 

--- a/collections/infrastructure/roles/nic/handlers/main.yml
+++ b/collections/infrastructure/roles/nic/handlers/main.yml
@@ -19,7 +19,7 @@
   ansible.builtin.reboot:
     reboot_timeout: "{{ nic_reboot_timeout }}"
   when:
-    - nic_allow_reboot
+    - nic_allow_reboot | bool
 
 - name: "service <|> Restart nic services"
   ansible.builtin.service:

--- a/collections/infrastructure/roles/nic/tasks/nmcli.yml
+++ b/collections/infrastructure/roles/nic/tasks/nmcli.yml
@@ -127,4 +127,4 @@
     - nic_force_reboot
     - item.changed
     - not (reboot_status.changed | d(false))
-    - nic_allow_reboot
+    - nic_allow_reboot | bool


### PR DESCRIPTION
Otherwise `ansible-playbook ... -e nic_allow_reboot=false` will be `true` because false is a string in the command.
