### PR TITLE
Restart NetworkManager before reloading nmcli conn

### DIFF
--- a/collections/infrastructure/roles/nic/handlers/main.yml
+++ b/collections/infrastructure/roles/nic/handlers/main.yml
@@ -1,26 +1,4 @@
 ---
-- name: command <|> Reload connections
-  community.general.nmcli:
-    conn_name: "{{ item.item.conn_name | default(item.item.interface) | string }}"
-    state: up
-    conn_reload: true
-  loop: "{{ nic_apply.results }}"
-  when: nic_reload_connections and item.changed
-
-# - name: command <|> netplan generate
-#   command: netplan generate
-#   notify:
-#     - command <|> networkctl reload
-
-# - name: command <|> networkctl reload
-#   command: networkctl reload
-
-- name: reboot <|> Reboot system
-  ansible.builtin.reboot:
-    reboot_timeout: "{{ nic_reboot_timeout }}"
-  when:
-    - nic_allow_reboot | bool
-
 - name: "service <|> Restart nic services"
   ansible.builtin.service:
     name: "{{ item }}"
@@ -29,3 +7,17 @@
   when:
     - "'service' not in ansible_skip_tags"
     - nic_start_services | default(bb_start_services) | default(true) | bool
+
+- name: command <|> Reload connections
+  community.general.nmcli:
+    conn_name: "{{ item.item.conn_name | default(item.item.interface) | string }}"
+    state: up
+    conn_reload: true
+  loop: "{{ nic_apply.results }}"
+  when: nic_reload_connections and item.changed
+
+- name: reboot <|> Reboot system
+  ansible.builtin.reboot:
+    reboot_timeout: "{{ nic_reboot_timeout }}"
+  when:
+    - nic_allow_reboot | bool


### PR DESCRIPTION
After transitioning from systemd-networkd to NetworkManager, bond member interfaces fail to reload if nmcli connections are reloaded first. This happens because:

1. systemd-networkd may leave bond members in a partially configured state, causing NetworkManager to fail when reapplying configurations.
2. NetworkManager's `reload` does not reset interface states, while a full restart ensures all interfaces are reinitialized cleanly.
3. Bond members require a fresh state to enslave correctly, which only a restart guarantees.

Fix: Restart NetworkManager before reloading connections to ensure all interfaces are properly reset and reconfigured.