### PR TITLE
update kernel_config role to add support for ubuntu (#10)

### DIFF
--- a/collections/infrastructure/roles/kernel_config/defaults/main.yml
+++ b/collections/infrastructure/roles/kernel_config/defaults/main.yml
@@ -1,2 +1,5 @@
 ---
 kernel_config_sysctl_reload: true
+os_kernel_parameters: ""
+hw_kernel_parameters: ""
+hw_console: ""

--- a/collections/infrastructure/roles/kernel_config/handlers/main.yml
+++ b/collections/infrastructure/roles/kernel_config/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: command <|> Update GRUB settings
+  ansible.builtin.command: update-grub

--- a/collections/infrastructure/roles/kernel_config/tasks/RedHat/main.yml
+++ b/collections/infrastructure/roles/kernel_config/tasks/RedHat/main.yml
@@ -1,0 +1,26 @@
+---
+- name: package <|> Install grubby
+  ansible.builtin.package:
+    name: grubby
+    state: present
+
+- name: shell <|> Get current kernel parameters
+  ansible.builtin.shell: "set -o pipefail && grubby --info=DEFAULT | grep args"
+  args:
+    executable: /bin/bash
+  register: current_kernel_parameters
+  changed_when: False
+
+- name: command <|> Update os kernel parameters
+  ansible.builtin.command: "grubby --args='{{ item }}' --update-kernel=DEFAULT"
+  loop: "{{ os_kernel_parameters.split(' ') | default([]) }}"
+  when:
+    - os_kernel_parameters is defined and os_kernel_parameters is not none
+    - item not in current_kernel_parameters.stdout
+
+- name: command <|> Update hw kernel parameters
+  ansible.builtin.command: "grubby --args='{{ item }}' --update-kernel=DEFAULT"
+  loop: "{{ hw_kernel_parameters.split(' ') | default([]) }}"
+  when:
+    - hw_kernel_parameters is defined and hw_kernel_parameters is not none
+    - item not in current_kernel_parameters.stdout

--- a/collections/infrastructure/roles/kernel_config/tasks/Ubuntu/main.yml
+++ b/collections/infrastructure/roles/kernel_config/tasks/Ubuntu/main.yml
@@ -1,0 +1,35 @@
+---
+- name: package <|> Install grub2-common
+  ansible.builtin.package:
+    name: grub2-common
+    state: present
+
+- name: shell <|> Read current GRUB_CMDLINE_LINUX_DEFAULT value
+  ansible.builtin.shell: |
+    grep '^GRUB_CMDLINE_LINUX_DEFAULT=' /etc/default/grub | sed -e 's/GRUB_CMDLINE_LINUX_DEFAULT="//' -e 's/"$//'
+  register: current_default_params
+  changed_when: false
+
+- name: set_fact <|> Merge existing, combine, and join the final parameter string
+  ansible.builtin.set_fact:
+    final_grub_line: >
+      {{
+        ((current_default_params.stdout | trim).split(' ') | default([]))
+        | union((os_kernel_parameters | trim).split(' ') | default([]))
+        | union((hw_kernel_parameters | trim).split(' ') | default([]))
+        | union((hw_console | trim).split(' ') | default([]))
+        | reject('equalto', '')
+        | unique
+        | list
+        | sort
+        | join(' ')
+      }}
+
+- name: lineinfile <|> Update GRUB_CMDLINE_LINUX_DEFAULT with merged, deduplicated parameters
+  ansible.builtin.lineinfile:
+    path: /etc/default/grub
+    regexp: "^GRUB_CMDLINE_LINUX_DEFAULT="
+    line: "GRUB_CMDLINE_LINUX_DEFAULT=\"{{ final_grub_line | replace('\n', '') }}\""
+    state: present
+    backup: true
+  notify: command <|> Update GRUB settings

--- a/collections/infrastructure/roles/kernel_config/tasks/main.yml
+++ b/collections/infrastructure/roles/kernel_config/tasks/main.yml
@@ -1,28 +1,17 @@
-- name: package <|> Install grubby
-  ansible.builtin.package:
-    name: grubby
-    state: present
-
-- name: shell <|> Get current kernel parameters
-  ansible.builtin.shell: "set -o pipefail && grubby --info=DEFAULT | grep args"
-  args:
-    executable: /bin/bash
-  register: current_kernel_parameters
-  changed_when: False
-
-- name: command <|> Update os kernel parameters
-  ansible.builtin.command: "grubby --args='{{ item }}' --update-kernel=DEFAULT"
-  loop: "{{ os_kernel_parameters.split(' ') | default([]) }}"
-  when:
-    - os_kernel_parameters is defined and os_kernel_parameters is not none
-    - item not in current_kernel_parameters.stdout
-
-- name: command <|> Update hw kernel parameters
-  ansible.builtin.command: "grubby --args='{{ item }}' --update-kernel=DEFAULT"
-  loop: "{{ hw_kernel_parameters.split(' ') | default([]) }}"
-  when:
-    - hw_kernel_parameters is defined and hw_kernel_parameters is not none
-    - item not in current_kernel_parameters.stdout
+---
+- name: include_tasks <|> Use OS dedicated task
+  ansible.builtin.include_tasks: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_version }}/main.yml"
+        - "{{ ansible_facts.distribution | replace(' ','_') }}_{{ ansible_facts.distribution_major_version }}/main.yml"
+        - "{{ ansible_facts.os_family | replace(' ','_') }}_{{ ansible_facts.distribution_version }}/main.yml"
+        - "{{ ansible_facts.os_family | replace(' ','_') }}_{{ ansible_facts.distribution_major_version }}/main.yml"
+        - "{{ ansible_facts.distribution | replace(' ','_') }}/main.yml"
+        - "{{ ansible_facts.os_family | replace(' ','_') }}/main.yml"
+      skip: true
+  tags:
+    - internal
 
 - name: sysctl <|> Update sysctl parameters
   ansible.posix.sysctl:


### PR DESCRIPTION
By default only Redhat is supported (grubby is not in ubuntu repositories). Here we use the standard update-grub method.