### PR TITLE
enforce networkmanager configuration  (#20)

### DIFF
--- a/collections/infrastructure/roles/nic/defaults/main.yml
+++ b/collections/infrastructure/roles/nic/defaults/main.yml
@@ -7,3 +7,4 @@ nic_allow_reboot: true  # Reboot after switch from netplan to network-manager on
 nic_start_services: true
 nic_reboot_timeout: 600
 nic_nmcli_device_is_connection_name: true  # If true, the role will force existing connections to have the same name as their related device.
+nic_enforce_configuration: true # Don't keep existing configurations made outside of NetworkManager

--- a/collections/infrastructure/roles/nic/tasks/main.yml
+++ b/collections/infrastructure/roles/nic/tasks/main.yml
@@ -29,6 +29,18 @@
     - package
   notify: service <|> Restart nic services
 
+- name: ini_file <|> Configure NetworkManager to enforce configuration
+  community.general.ini_file:
+    path: '/etc/NetworkManager/NetworkManager.conf'
+    section: 'device'
+    option: 'keep-configuration'
+    value: 'no'
+    no_extra_spaces: true
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when: nic_enforce_configuration
+
 - name: "service <|> Start services"
   ansible.builtin.service:
     name: "{{ item }}"


### PR DESCRIPTION
Enforce networkmanager configuration to override existing network configuration.
For example when booting with ip=x:dhcp kernel parameter, the interface gets configured before the start of NetworkManager.  
Without this setting, NetworkManager will not override this configuration, and it generally causes trouble. 
With this setting, we are sure NetworkManager applies its configuration completely.