### PR TITLE
Skip debug task in Slurm role by default

### DIFF
--- a/collections/infrastructure/roles/slurm/tasks/main.yml
+++ b/collections/infrastructure/roles/slurm/tasks/main.yml
@@ -44,6 +44,7 @@
   ansible.builtin.debug:
     msg: "{{ bb_nodes_profiles }}"
   tags:
+    - never
     - templates
     - debug
 #


### PR DESCRIPTION
The task will still execute if Ansible runs with `--tags debug`.

This prevents the task to clobber the output with 5 lines per host in a cluster with 1000+ hosts.