### PR TITLE
Fix is_in_dhcp condition

### DIFF
--- a/collections/infrastructure/roles/dhcp_server/tasks/main.yml
+++ b/collections/infrastructure/roles/dhcp_server/tasks/main.yml
@@ -78,7 +78,7 @@
   when:
     - networks is defined and networks is iterable and networks is not string and networks is mapping
     - networks[item] is defined and networks[item] is not none
-    - networks[item].is_in_dhcp | default(true, true)
+    - networks[item].is_in_dhcp | default(true)
   notify: service <|> Restart dhcp server
   tags:
     - template


### PR DESCRIPTION
Do not use `default(true, true)` when the variable is a boolean.

From the Ansible documentation:

> If you want to use the default value when variables evaluate to false or an
> empty string you have to set the second parameter to true:

We obviously don't want to use the default value `true` when `is_in_dhcp` evaluates to `false`.