### PR TITLE
fix: Restart slurmctld when the topology changes (#38)

### DIFF
--- a/collections/infrastructure/roles/slurm/tasks/controller.yml
+++ b/collections/infrastructure/roles/slurm/tasks/controller.yml
@@ -64,7 +64,7 @@
   tags:
     - template
   when: slurm_topology == 'topology/block' or slurm_topology == 'topology/tree'
-  notify: service <|> restart slurmd
+  notify: service <|> restart slurmctld
 
 - name: service <|> Manage slurmctld state
   ansible.builtin.service:


### PR DESCRIPTION
There is no slurmd service on the Slurm controllers.