### PR TITLE
Copy hosts file, don't generate (#42)

### DIFF
--- a/collections/infrastructure/roles/hosts_file/defaults/main.yml
+++ b/collections/infrastructure/roles/hosts_file/defaults/main.yml
@@ -8,3 +8,6 @@ hosts_file_fqdn_first: false
 # If set to true, hostname, alias, nic-network and nic-alias will be written info hosts file
 # If set to false, only hostname and alias will be written into hosts file
 hosts_file_enable_extended_names: true
+
+# Copy hosts file instead of generate it for all hosts
+hosts_file_copy: false

--- a/collections/infrastructure/roles/hosts_file/tasks/main.yml
+++ b/collections/infrastructure/roles/hosts_file/tasks/main.yml
@@ -1,11 +1,23 @@
 ---
 
-- name: "template <|> Generate /etc/hosts"
+- name: "template <|> generate /etc/hosts"
   ansible.builtin.template:
     src: hosts.j2
     dest: /etc/hosts
     owner: root
     group: root
     mode: 0644
+  when: not hosts_file_copy or "fn_management" in group_names
+  tags:
+    - template
+
+- name: "copy <|> copy /etc/hosts"
+  ansible.builtin.copy:
+    src: /etc/hosts
+    dest: /etc/hosts
+    owner: root
+    group: root
+    mode: 0644
+  when: hosts_file_copy and "fn_management" not in group_names
   tags:
     - template


### PR DESCRIPTION
Introduce an option (disabled by default) to copy instead of generate hosts file on all hosts. Copy is unefficient: too long and unneeded.
On nodes with management roles, hosts file is always generated.