### PR TITLE
Fix new line in slurm.conf.j2 template

### DIFF
--- a/collections/infrastructure/roles/slurm/templates/slurm.conf.j2
+++ b/collections/infrastructure/roles/slurm/templates/slurm.conf.j2
@@ -159,5 +159,5 @@ NodeName={{ hw_pack_vars['nodes'] | bluebanquise.infrastructure.nodeset }} {{ no
     {%- endif %}
     {%- set partition_nodes = (partition_nodes | unique) %}
 PartitionName={{ partition.partition_name }}{% for arg, arg_value in partition.partition_configuration.items() %} {{ arg }}={{ arg_value }}{% endfor %} Nodes={{ partition_nodes | bluebanquise.infrastructure.nodeset }}
-  {%- endfor %}
+  {% endfor %}
 {%- endif %}


### PR DESCRIPTION
Follows https://github.com/bluebanquise/bluebanquise/pull/1206

There was a problem with multiple partitions a new line was forgotten between partitions