### PR TITLE
[pxe_stack] fix debian preseed

### DIFF
--- a/collections/infrastructure/roles/pxe_stack/templates/Debian/preseed.cfg.j2
+++ b/collections/infrastructure/roles/pxe_stack/templates/Debian/preseed.cfg.j2
@@ -129,8 +129,7 @@ d-i preseed/late_command string \
       echo "Running post-script $N"; \
       in-target sh -c "$(echo "$script" | base64 -d)"; \
     fi; \
-  done
-
+  done; \
 {% if pxe_stack_enable_root %}
   in-target sh -c 'mkdir /root/.ssh'; \
   {% for ssh_key in (equipment['os']['os_admin_ssh_keys'] | default(pxe_stack_os_admin_ssh_keys)) %}


### PR DESCRIPTION
Fixing my previous PR #1192. The lack of line continuation meant that part of the initialization was silently skipped, including the SSH configuration.

I'm not sure why my tests didn't find it before, but I just noticed it now.