### PR TITLE
SMC: Fix - credentials host error and add REDFISH support

### DIFF
--- a/collections/infrastructure/roles/conman/templates/conman.pswd.j2
+++ b/collections/infrastructure/roles/conman/templates/conman.pswd.j2
@@ -3,7 +3,7 @@
 ## {{ ansible_managed }}
 
 {% for host in (j2_hosts_range | sort) -%}
-  {% if (hostvars[host]['hw_equipment_type'] | default("server")) == "server" and hostvars[host]['hw_board_authentication'] is defined %}
+  {% if (hostvars[host]['hw_equipment_type'] | default("server")) == "server" %}
     {% if hostvars[host]['bmc'] is defined and hostvars[host]['bmc']['name'] is defined %}
       {# Gather BMC network settings #}
       {% if hostvars[host]['bmc']['ip4'] is defined %}{# BMC is defined inside host #}
@@ -17,10 +17,18 @@
       {% if hostvars[credentials_host]['hw_board_authentication'] is not defined %}
       {% continue %}
       {% endif %}
-      {% if (hostvars[host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','IPMI') | list | length) >= 1 %}
+      {% if (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','IPMI') | list | length) >= 1 %}
         {# Gather BMC credentials settings #}
-        {% set host_bmc_user = (hostvars[host]['hw_board_authentication'] | selectattr('protocol','defined') | map(attribute='user') | list | first | default(none)) %}
-        {% set host_bmc_password = (hostvars[host]['hw_board_authentication'] | selectattr('protocol','defined') | map(attribute='password') | list | first | default(none)) %}
+        {% set host_bmc_user = (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','defined') | map(attribute='user') | list | first | default(none)) %}
+        {% set host_bmc_password = (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','defined') | map(attribute='password') | list | first | default(none)) %}
+        {% if host_bmc_user is defined and host_bmc_user is not none and host_bmc_password is defined and host_bmc_password is not none %}
+{{ host_bmc['ip4'] }} : {{ host_bmc_user }} : {{ host_bmc_password }}
+        {% endif %}
+      {% endif %}
+      {% if (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','defined') | selectattr('protocol','match','REDFISH') | list | length) >= 1 %}
+        {# Gather BMC credentials settings #}
+        {% set host_bmc_user = (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','defined') | map(attribute='user') | list | first | default(none)) %}
+        {% set host_bmc_password = (hostvars[credentials_host]['hw_board_authentication'] | selectattr('protocol','defined') | map(attribute='password') | list | first | default(none)) %}
         {% if host_bmc_user is defined and host_bmc_user is not none and host_bmc_password is defined and host_bmc_password is not none %}
 {{ host_bmc['ip4'] }} : {{ host_bmc_user }} : {{ host_bmc_password }}
         {% endif %}


### PR DESCRIPTION
* Added missing REDFISH matching block
* Removed initial _hw_board_authentication_ var definition check
* Use _credentials_host_ var instead of _host_ because _hw_board_authentication_ might be defined in BMCs
