### PR TITLE
SMC: dhcp_server role referecing old variable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@
 
 Format: <date> - <author (username or mail or both)> - [role] <change description>
 
+# 3.2.8
+* 03/19/26 - thiagocardozo - [dhcp_server] Updated reference to old variable.
+
 # 3.2.7
 * 11/27/25 - thiagocardozo - [conman] Passwords in database file for increased security.
 

--- a/collections/infrastructure/roles/dhcp_server/tasks/main.yml
+++ b/collections/infrastructure/roles/dhcp_server/tasks/main.yml
@@ -89,7 +89,7 @@
   when:
     - networks is defined and networks is iterable and networks is not string and networks is mapping
     - networks[item] is defined and networks[item] is not none
-    - networks[item].is_in_dhcp | default(true, true)
+    - networks[item].dhcp_server | default(true, true)
   notify: service <|> Restart dhcp server
   tags:
     - template

--- a/collections/infrastructure/roles/dhcp_server/vars/main.yml
+++ b/collections/infrastructure/roles/dhcp_server/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-dhcp_server_role_version: 1.8.1
+dhcp_server_role_version: 1.8.2


### PR DESCRIPTION
Task still checks "is_in_dhcp" variable pre BB 3.0. Updated to newer "dhcp_server".