### PR TITLE
users: fix absent user handling and refresh role documentation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # To 3.4 or 4.0
 
+* 21/04/2026 - hmeScaler - [users] fix absent user handling and refresh role documentation (#1234)
 * 31/03/2026 - sgaosdgr      - [nic] set permission on /etc/netplan/01-netcfg.yaml to 0600 (#1228)
 * 19/03/2026 - thiagocardozo - [dhcp_server] Fixed reference to old variable (#1226)
 * 10/03/2026 - thiagocardozo - [conman] Fix conman pswd template skipping BMC credentials and added REDFISH (#1222)

--- a/collections/infrastructure/roles/users/README.md
+++ b/collections/infrastructure/roles/users/README.md
@@ -35,6 +35,36 @@ users:
       - <ssh key 3>
 ```
 
+It is also possible to build the final `users` list from multiple inventory variables:
+
+```
+default_users:
+  - name: clusteradmin
+    home: /home/clusteradmin
+    shell: /bin/bash
+    comment: Cluster administrators
+    password: '*'
+    ssh_authorized_keys: "{{ admin_ssh_keys | default([]) }}"
+  - name: ubuntu
+    home: /home/ubuntu
+    shell: /bin/bash
+    password: '*'
+    ssh_authorized_keys: "{{ customer_ssh_keys | default([]) }}"
+
+additional_users: []
+
+users: "{{ default_users + additional_users }}"
+```
+
+To delete a user:
+
+```
+users:
+  - name: johnnykeats
+    state: absent
+    remove: true
+```
+
 Available arguments for each user are:
 
 * name
@@ -61,6 +91,8 @@ are available for each user:
 
 * ssh_authorized_keys: a list of ssh public keys to be added to user's authorized_keys file
 * ssh_authorized_keys_exclusive: if the provided list must be exclusive (will erase other existing keys in authorized_keys file)
+
+`ssh_authorized_keys` must be provided as a list.
 
 To generate an sha512 password, use the following command (python >3.3):
 

--- a/collections/infrastructure/roles/users/README.md
+++ b/collections/infrastructure/roles/users/README.md
@@ -3,7 +3,7 @@
 ## Description
 
 This role provides a very basic users management, for simple clusters.
-The role generates a dedicated group for each users, then users themselves, and can add ssh keys to their authorized_keys file.
+The role generates a dedicated group for each users, then users themselves, and can add ssh keys to their `authorized_keys` file.
 
 ## Instructions
 
@@ -56,6 +56,9 @@ additional_users: []
 users: "{{ default_users + additional_users }}"
 ```
 
+To ensure a user is not on a system, set state to "absent". To also remove its
+home, set remove to "yes".
+
 To delete a user:
 
 ```
@@ -83,8 +86,7 @@ Available arguments for each user are:
 * remove (optional)
 * comment (optional)
 
-To ensure a user is not on a system, set state to "absent". To also remove its
-home, set remove to "yes".
+
 
 It is also possible to add ssh public keys for users. The following parameters
 are available for each user:

--- a/collections/infrastructure/roles/users/tasks/main.yml
+++ b/collections/infrastructure/roles/users/tasks/main.yml
@@ -1,10 +1,39 @@
 ---
+- name: user <|> Remove users (before groups)
+  ansible.builtin.user:
+    name: "{{ item.name }}"
+    comment: "{{ item.comment | default(omit) }}"
+    uid: "{{ item.uid | default(omit) }}"
+    group: "{{ item.name | default(omit)}}"
+    groups: "{{ item.groups | default(omit) }}"
+    create_home: "{{ item.create_home | default(omit) }}"
+    update_password: "{{ item.update_password | default(omit) }}"
+    shell: "{{ item.shell | default(omit) }}"
+    home: "{{ item.home | default(omit) }}"
+    password: "{{ item.password | default(omit) }}"
+    generate_ssh_key: "{{ item.generate_ssh_key | default(omit) }}"
+    ssh_key_bits: "{{ item.ssh_key_bits | default(omit) }}"
+    ssh_key_file: "{{ item.ssh_key_file | default(omit) }}"
+    remove: "{{ item.remove | default('no') }}"
+    state: absent
+  loop: "{{ users | default([]) | flatten(levels=1) }}"
+  when: item.state | default('present') == 'absent'
+
+- name: group <|> Remove users groups
+  ansible.builtin.group:
+    name: "{{ item.name }}"
+    gid: "{{ item.gid | default(omit) }}"
+    state: absent
+  loop: "{{ users | default([]) | flatten(levels=1) }}"
+  when: item.state | default('present') == 'absent'
+
 - name: group <|> Add users groups
   ansible.builtin.group:
     name: "{{ item.name }}"
     gid: "{{ item.gid | default(omit) }}"
-    state: "{{ item.state | default('present') }}"
+    state: present
   loop: "{{ users | default([]) | flatten(levels=1) }}"
+  when: item.state | default('present') != 'absent'
 
 - name: user <|> Add/remove users
   ansible.builtin.user:
@@ -17,13 +46,14 @@
     update_password: "{{ item.update_password | default(omit) }}"
     shell: "{{ item.shell | default(omit) }}"
     home: "{{ item.home | default(omit) }}"
-    password: "{{ item.password }}"
+    password: "{{ item.password | default(omit) }}"
     generate_ssh_key: "{{ item.generate_ssh_key | default(omit) }}"
     ssh_key_bits: "{{ item.ssh_key_bits | default(omit) }}"
     ssh_key_file: "{{ item.ssh_key_file | default(omit) }}"
     remove: "{{ item.remove | default('no') }}"
     state: "{{ item.state | default('present') }}"
   loop: "{{ users | default([]) | flatten(levels=1) }}"
+  when: item.state | default('present') != 'absent'
 
 - name: authorized_key <|> Manage user authorized_keys if exist
   ansible.posix.authorized_key:
@@ -32,4 +62,7 @@
     state: present
     exclusive: "{{ item.ssh_authorized_keys_exclusive | default(omit) }}"
   loop: "{{ users | default([]) | flatten(levels=1) }}"
-  when: item.ssh_authorized_keys is defined and item.ssh_authorized_keys
+  when:
+    - item.state | default('present') != 'absent'
+    - item.ssh_authorized_keys is defined
+    - item.ssh_authorized_keys

--- a/collections/infrastructure/roles/users/vars/main.yml
+++ b/collections/infrastructure/roles/users/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-users_basic_role_version: 1.1.1
+users_basic_role_version: 1.1.2


### PR DESCRIPTION
Hello 👋
Here a new PR for users role enhancements, especially the users and groups deletion.
Thanks


## Describe your changes

This PR proposes a small, backward-compatible improvement to the `users` role.

Summary:
- ensure users are removed before their dedicated primary groups
- allow `state: absent` entries without requiring a `password`
- improve the role README with a more realistic inventory composition example
- clarify how `ssh_authorized_keys`, `ssh_authorized_keys_exclusive`, and locked passwords are expected to be used

This change does not redesign the role and keeps the current `users` input contract intact.

## Issue ticket number and link if any

No existing issue.

This proposal comes from production usage feedback on cluster inventories.

## Checklist before requesting a review

- [ ] Document introduced changes in main documentation (see documentation folder)
- [x] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml (optional, up to you)
- [x] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG