### PR TITLE
Fix bluebanquise-bootset when missing arguments

### DIFF
--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-bootset
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-bootset
@@ -46,7 +46,7 @@ import pwd
 import re
 from argparse import ArgumentParser
 import yaml
-
+import sys
 
 # Colors, from https://stackoverflow.com/questions/287871/how-to-print-colored-text-in-terminal-in-python
 class bcolors:
@@ -58,6 +58,16 @@ class bcolors:
     ENDC = '\033[0m'
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
+
+
+BOOT_OPTIONS = [
+    "osdeploy",
+    "diskless",
+    "next",
+    "clone",
+    "clonedeploy",
+    "disk",
+]
 
 
 def load_file(filename):
@@ -125,12 +135,12 @@ if ( not is_admin) :
 
 # Get arguments passed to bootset
 parser = ArgumentParser()
-parser.add_argument("-n", "--nodes", dest="nodes",
+parser.add_argument("-n", "--nodes", dest="nodes", required=True,
                     help="Target node(s). Use nodeset format for ranges.", metavar="NODE")
-parser.add_argument("-s", "--status", dest="status", nargs='?', const='',
+parser.add_argument("-s", "--status", dest="status", action="store_true",
                     help="Display current nodes boot target status.")
-parser.add_argument("-b", "--boot", dest="boot",
-                    help="Next pxe boot: can be osdeploy, diskless, next, clone, clonedeploy, or disk.")
+parser.add_argument("-b", "--boot", dest="boot", choices=BOOT_OPTIONS,
+                    help=f"Next pxe boot: can be {', '.join(BOOT_OPTIONS)}.")
 parser.add_argument("-f", "--force", dest="force", default=" ",
                     help="Force. 'dhcp' = better dracut dhcp, 'network' = static ip. Combine using comma separator.")
 parser.add_argument("-i", "--image", dest="image", default="none",
@@ -142,7 +152,15 @@ parser.add_argument("-k", "--kickstart", action="store_true",
 parser.add_argument("-q", "--quiet", action="store_true",
                     help="Do not print INFO messages.")
 
+# Show help if no argument is supplied
+if len(sys.argv) == 1:
+    parser.print_help()
+    sys.exit(1)
+
 passed_arguments = parser.parse_args()
+
+if not any([passed_arguments.status, passed_arguments.boot, passed_arguments.kickstart]):
+    parser.error(bcolors.FAIL + "At least one of --status, --boot, or --kickstart must be provided." + bcolors.ENDC)
 
 print("""\
 
@@ -173,7 +191,7 @@ htdocs_path = pxe_parameters["pxe_parameters"]["htdocs_path"]
 pxe_nodes_path = htdocs_path + '/pxe/nodes/'
 
 
-if passed_arguments.status is not None:
+if passed_arguments.status:
     diskfull = []
     diskless = dict()
     _next = []
@@ -217,12 +235,7 @@ if passed_arguments.status is not None:
         for image in diskless:
             print(' - {image}: {nodes}'.format(image=image, nodes=','.join(diskless[image])))
 
-elif passed_arguments.boot is not None:
-
-    # Ensure passed boot argument exists
-    if passed_arguments.boot is not None and 'osdeploy' not in passed_arguments.boot and 'diskless' not in passed_arguments.boot and 'clone' not in passed_arguments.boot and 'clonedeploy' not in passed_arguments.boot and 'disk' not in passed_arguments.boot and 'next' not in passed_arguments.boot:
-        logging.error(bcolors.FAIL+'Passed argument "'+passed_arguments.boot+'" for boot not know. Please check syntax.'+bcolors.ENDC)
-        quit()
+elif passed_arguments.boot:
 
     # Iteration on nodes
     for node in nodesetexpand(passed_arguments.nodes):
@@ -276,10 +289,10 @@ elif passed_arguments.boot is not None:
     if pxe_parameters["pxe_parameters"]["ansible_selinux_status"] == "enabled":
         os.system('restorecon -Rv /var/www/html/pxe/nodes/')
 
-elif passed_arguments.kickstart is not None:
+elif passed_arguments.kickstart:
 
     node = passed_arguments.nodes
-    if len(NodeSet(node)) != 1:
+    if len(nodesetexpand(node)) != 1:
         logging.error(bcolors.FAIL + 'Specify a single node with -n to display its kickstart file.' + bcolors.ENDC)
         exit(1)
 


### PR DESCRIPTION
Thank you for opening a pull request. This helps a lot! :hearts:

:point_down: Please read the bellow instructions to ease the review process. :point_down:

## Describe your changes

Modifies bluebanquise-bootset to make it more friendly for users.

The following modifications were introduced:
- When calling bluenbanquise-bootset without args, the help menu is displayed;
- Make `nodes` a required argument;
- Display an error message when none of `status`, `boot` or `kickstart` arguments is set when calling the script;
- Simplifies conditional logic (`if passed_arguments.status is not None` -> `if passed_arguments.status`, `elif passed_arguments.boot is not None` -> `elif passed_arguments.boot`, `elif passed_arguments.kickstart is not None`-> `elif passed_arguments.kickstart`)
- Validates boot options using `ArgumentParser`.

## Issue ticket number and link if any

Add here any references to an already opened issue (can even be outside this repository).

## Checklist before requesting a review

Please use this checklist to help me fasten the review.

- [ ] Document introduced changes in main documentation (see documentation folder)
- [ ] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml (optional, up to you)
- [ ] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG

:warning: Ensure your PR does not break static code analysis (see automatic checks).