### PR TITLE
docs: fix ansible-playbook command name

### DIFF
--- a/documentation/introduction/installation.rst
+++ b/documentation/introduction/installation.rst
@@ -33,11 +33,11 @@ Now you can load the BlueBanquise environment (Python, Ansible and tools), using
 
 This command will have loaded a Python virtual environment located at ``/var/lib/bluebanquise/ansible_venv/`` and added ``/var/lib/bluebanquise/bluebanquise/stack/bin`` into PATH.
 
-Test you can now use the ``bluebanquise-ansible-playbook`` command:
+Test you can now use the ``ansible-playbook`` command:
 
 .. code-block:: text
   
-  $ bluebanquise-ansible-playbook --version
+  $ ansible-playbook --version
   ansible-playbook [core 2.19.2]
   config file = None
   ...


### PR DESCRIPTION
Fixes #1229

Changes:
- ```bluebanquise-ansible-playbook`` command` -> ```ansible-playbook`` command` in `documentation/introduction/installation.rst` (1 occurrence(s))
- `$ bluebanquise-ansible-playbook --version` -> `$ ansible-playbook --version` in `documentation/introduction/installation.rst` (1 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Confirmed the pull request diff contains only the intended documentation typo fix(es).
