### PR TITLE
OpenSM deployment improved

### DIFF
--- a/collections/infrastructure/roles/interconnect/README.md
+++ b/collections/infrastructure/roles/interconnect/README.md
@@ -18,10 +18,11 @@ Currently supported interconnect stacks are:
 
 ### OFED
 
+#### Client setup
+
 To install client driver and libs, set `interconnect_ofed_client` to `true` at role invocation vars.
 
-To install subnet manager daemon, set `interconnect_ofed_subnet_manager` to `true` at role
-invocation vars.
+
 
 By default, role will set memlock soft and hard rlimits to unlimited, via pam module.
 
@@ -30,6 +31,18 @@ It is possible to define other values than unlimited by setting the following va
 ```yaml
 interconnect_ofed_memlock_soft: 'unlimited'
 interconnect_ofed_memlock_hard: 'unlimited'
+```
+
+#### Manager setup
+When the Infiniband switches are unmanaged, a manager daemon must be deployed. Moreover several manager daemons can optionaly be deployed in a failover configuration (only one must be active).
+ 
+To install subnet manager daemon, set `interconnect_ofed_subnet_manager` to `true` at role
+invocation vars or in the description of the node (where this daemon should run) in the inventory.
+
+Optionnally add a priority level (default: 0, maximum value: 15) if a failover setup is required. If several manager daemons are configured with the same priority,  the active service will be elected based on the GUID of the infiniband interface.
+```
+interconnect_ofed_subnet_manager: true
+interconnect_ofed_subnet_manager_priority: 8
 ```
 
 ## To be done
@@ -41,6 +54,7 @@ Need to add support for Ubuntu and OpenSuse if exist.
 **Please now update CHANGELOG file at repository root instead of adding logs in this file.
 These logs bellow are only kept for archive.**
 
+* 1.2.3: Improve openSM deployment <Patrick.Begou@free.fr>
 * 1.2.2: Fix bad variables names. Reported by @corentin-g. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.2.1: Replace package list by a group. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.2.0: Merge ofed and ofed_sm roles. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/interconnect/defaults/main.yml
+++ b/collections/infrastructure/roles/interconnect/defaults/main.yml
@@ -7,3 +7,4 @@ interconnect_ofed_memlock_soft: 'unlimited'
 interconnect_ofed_memlock_hard: 'unlimited'
 interconnect_ofed_client: false
 interconnect_ofed_subnet_manager: false
+interconnect_ofed_subnet_manager_priority: 0

--- a/collections/infrastructure/roles/interconnect/tasks/ofed/RedHat/subnet_manager.yml
+++ b/collections/infrastructure/roles/interconnect/tasks/ofed/RedHat/subnet_manager.yml
@@ -32,7 +32,7 @@
   ansible.builtin.find:
     paths: /sys/class/infiniband
     file_type: directory
-  register: ib_devices
+  register: interconnect_ib_devices
 
 - name: Find the first valid and active infiniband device
   ansible.builtin.shell: |
@@ -46,19 +46,19 @@
         fi
       done
     done
-  register: ib_device
+  register: interconnect_ib_device
   changed_when: false
-  failed_when: ib_device.stdout == ""
+  failed_when: interconnect_ib_device.stdout == ""
 
 - name: Read the node_guid of the detected device
   ansible.builtin.slurp:
-    src: "/sys/class/infiniband/{{ ib_device.stdout }}/node_guid"
-  register: ib_guid_raw
+    src: "/sys/class/infiniband/{{ interconnect_ib_device.stdout }}/node_guid"
+  register: interconnect_ib_guid_raw
 
 - name: Convert node_guid format for OpenSM use
   ansible.builtin.set_fact:
-    opensm_guid: >-
-      0x{{ ib_guid_raw.content
+    interconnect_opensm_guid: >-
+      0x{{ interconnect_ib_guid_raw.content
             | b64decode
             | trim
             | replace(':', '') }}
@@ -67,7 +67,7 @@
   ansible.builtin.lineinfile:
     path: /etc/rdma/opensm.conf
     regexp: '^guid\s+'
-    line: "guid {{ opensm_guid }}"
+    line: "guid {{ interconnect_opensm_guid }}"
     state: present
 
 - name: service <|> Manage opensm state

--- a/collections/infrastructure/roles/interconnect/tasks/ofed/RedHat/subnet_manager.yml
+++ b/collections/infrastructure/roles/interconnect/tasks/ofed/RedHat/subnet_manager.yml
@@ -4,11 +4,71 @@
   ansible.builtin.package:
     name: "{{ item }}"
     state: present
-  loop:
+  with_items:
     - opensm
     - opensm-libs
   tags:
     - package
+
+- name: Check OpenSM priority is in range [0,15]
+  ansible.builtin.assert:
+    that:
+      - interconnect_ofed_subnet_manager_priority is match('^(?:[0-9]|1[0-5])$')
+    fail_msg: >
+      interconnect_ofed_subnet_manager_priority
+      must be in the range [0,15].
+    success_msg: >
+      Subnetmanager priority set to : {{ interconnect_ofed_subnet_manager_priority }}
+
+- name: Configure OpenSM priority
+  ansible.builtin.lineinfile:
+    path: /etc/rdma/opensm.conf
+    regexp: '^sm_priority\s+'
+    line: "sm_priority {{ interconnect_ofed_subnet_manager_priority }}"
+    backup: true
+    state: present
+
+- name: List all InfiniBand devices
+  ansible.builtin.find:
+    paths: /sys/class/infiniband
+    file_type: directory
+  register: ib_devices
+
+- name: Find the first valid and active infiniband device
+  ansible.builtin.shell: |
+    for dev in /sys/class/infiniband/*; do
+      for port in $dev/ports/*; do
+        if [ -f "$port/link_layer" ] && grep -qi "InfiniBand" "$port/link_layer"; then
+           if [ -f "$port/state" ] && grep -qi "ACTIVE" "$port/state"; then
+              basename $dev
+              exit 0
+           fi
+        fi
+      done
+    done
+  register: ib_device
+  changed_when: false
+  failed_when: ib_device.stdout == ""
+
+- name: Read the node_guid of the detected device
+  ansible.builtin.slurp:
+    src: "/sys/class/infiniband/{{ ib_device.stdout }}/node_guid"
+  register: ib_guid_raw
+
+- name: Convert node_guid format for OpenSM use
+  ansible.builtin.set_fact:
+    opensm_guid: >-
+      0x{{ ib_guid_raw.content
+            | b64decode
+            | trim
+            | replace(':', '') }}
+
+- name: Configure OpenSM GUID to access the selected interface
+  ansible.builtin.lineinfile:
+    path: /etc/rdma/opensm.conf
+    regexp: '^guid\s+'
+    line: "guid {{ opensm_guid }}"
+    state: present
 
 - name: service <|> Manage opensm state
   ansible.builtin.service:

--- a/collections/infrastructure/roles/interconnect/vars/main.yml
+++ b/collections/infrastructure/roles/interconnect/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-interconnect_role_version: 1.2.2
+interconnect_role_version: 1.2.3


### PR DESCRIPTION
Thank you for opening a pull request. This helps a lot! :hearts:

:point_down: Please read the bellow instructions to ease the review process. :point_down:

## Describe your changes

This commit improve the OpenSM deployment.
- solves wrong infiniband interface automatic selection: in /sys/class/infiniband/ folder other rdma devices can exists like ethernet 25Gb/s (/sys/class/infiniband/irdma0...) and openSM select the first interface available in alphabetical order. Now the role looks for an infiniband device with link_layer set to "InfiniBand", get its GUID and set this GUID in opensm.conf file.
- allow to set different priorities for the openSM instances  when failover is required. Default priority is 0


## Issue ticket number and link if any

Add here any references to an already opened issue (can even be outside this repository).

## Checklist before requesting a review

Please use this checklist to help me fasten the review.

- [ ] Document introduced changes in main documentation (see documentation folder)
      Documentation updated in the role.
- [ ] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml (optional, up to you)
- [ ] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG

:warning: Ensure your PR does not break static code analysis (see automatic checks).