### PR TITLE
roles/prometheus: initial support for modbus_exporter for SMC

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 Format: <date> - <author (username or mail or both)> - [role] <change description>
 
 # 3.2.8
+* 2026-06-10 - jethi05, sc-alex - [prometheus] Initial support for modbus_exporter
 * 13/05/2026 - neoteam - [pxe_stack] bluebanquise-disklesset accepts el10 (#1235)
 * 20/04/2026 - thiagocardozo - [prometheus] Fixed role using wrong credentials (#1227)
 * 26/03/2026 - patrice-duc-jacquet - [dns_server] Reverse zone generation very slow (#1220)

--- a/collections/infrastructure/roles/prometheus/README.md
+++ b/collections/infrastructure/roles/prometheus/README.md
@@ -21,7 +21,7 @@ This role relies on [data model](https://github.com/bluebanquise/bluebanquise/bl
     + [Karma configuration](#karma-configuration)
   * [4. Basic Client configuration](#4-basic-client-configuration)
     + [Exporters](#exporters)
-  * [5. IPMI and SNMP](#5-ipmi-and-snmp)
+  * [5. IPMI, SNMP and Modbus](#5-ipmi-snmp-and-modbus)
   * [6. Advanced usage](#6-advanced-usage)
     + [Monitoring High Availability](#monitoring-high-availability)
     + [Set custom launch parameters](#set-custom-launch-parameters)
@@ -47,6 +47,7 @@ This role deploys Prometheus (server/client) with related ecosystem:
 * Am-executor
 * ipmi_exporter
 * snmp_exporter
+* modbus_exporter
 * other exporters:
    * slurm_exporter
    * node_exporter
@@ -66,8 +67,8 @@ You can refer to this diagram to help understanding of the following readme.
 ### Server or/and client
 
 **Server part** of the role deploys Prometheus, Alertmanager, Karma, Am-executor,
-ipmi_exporter, snmp_exporter, and their respective configuration files and
-service files.
+ipmi_exporter, snmp_exporter, modbus_exporter and their respective configuration
+files and service files.
 
 To install server part, set `prometheus_server` to `true` at role invocation
 vars. See server configuration bellow for more details.
@@ -110,6 +111,7 @@ In the basic usage, the server role will install and setup the following tools:
 * Am-executor: trigger actions in case of alert fired. (**Am-executor is still not implemented**)
 * ipmi_exporter: translate ipmi data to http scrapable by Prometheus.
 * snmp_exporter: translate snmp data to http scrapable by Prometheus.
+* modbus_exporter: translate Modbus-TCP data to http scrapable by Prometheus.
 
 Which means all of these services will, by default, be running on the same
 management host.
@@ -125,6 +127,7 @@ prometheus_server_manage_karma: true
 prometheus_server_manage_am_executor: false
 prometheus_server_manage_ipmi_exporter: false
 prometheus_server_manage_snmp_exporter: false
+prometheus_server_manage_modbus_exporter: false
 ```
 
 ### Prometheus configuration
@@ -388,9 +391,9 @@ prometheus_exporters_groups_to_scrape:
         - RestartSec=1
 ```
 
-## 5. IPMI and SNMP
+## 5. IPMI, SNMP and Modbus
 
-ipmi_exporter and snmp_exporter behave differently: they act as translation
+ipmi_-, snmp_- and modbus_exporter behave differently: they act as translation
 gateways between Prometheus and the target. Which means, if you wish for example
 to query IPMI data of a node, you do not install the exporter on the node itself.
 You query the ipmi_exporter, which will itself query the target for IPMI data.
@@ -401,8 +404,9 @@ To have the exporter installed by the server part of the role, set their
 respective variables to true or false, according to your needs:
 
 ```yaml
-prometheus_server_manage_ipmi: true
-prometheus_server_manage_snmp: false
+prometheus_server_manage_ipmi_exporter: true
+prometheus_server_manage_snmp_exporter: false
+prometheus_server_manage_modbus_exporter: false
 ```
 
 You then need to specify which hardware groups of nodes have to be
@@ -421,7 +425,7 @@ prometheus_ipmi_scrape_hardware_groups:
 This will add these into prometheus targets configuration for scraping via
 ipmi_exporter.
 
-Note that you can set custom scrape_interval and scrape_timeout for ipmi or snmp
+Note that you can set custom scrape_interval and scrape_timeout for ipmi, snmp or Modbus
 using dedicated variables shown in the example above.
 
 Note also that ipmi_exporter will need `hw_board_authentication` dictionary
@@ -438,6 +442,39 @@ prometheus_snmp_scrape_hardware_groups:
   - name: hw_wcd
     snmp_module: wcd
 ```
+
+For Modbus it's `prometheus_modbus_tcp_scrape_hardware_group`, e.g.:
+
+```yaml
+prometheus_modbus_scrape_hardware_groups:
+  - name: wilo_pumps
+    scrape_interval: 15s
+    scrape_timeout: 15s
+    labels:
+      device_type: "pump"
+```
+
+but also definitions on device level are required, e.g.:
+
+```yaml
+all:
+  hosts:
+    wilo1:
+      labels:
+        rack: "rack42"
+      modbus_tcp_devices:
+        - id: 1
+          exporter_module: "wilo_stratos_maxo"
+          labels:
+            __scrape_interval__: "30s"
+```
+
+All the `label` variables specified above are optional prometheus labels.
+
+The rather complicated structure of the configuration of modbus_exporter is due
+to the exporter being the "gateway" to query Modbus-TCP devices which are
+technically "gateways" to a Modbus-RTU network containing an arbitrary amount
+of devices.
 
 ## 6. Advanced usage
 
@@ -593,6 +630,9 @@ ipmi_exporter_launch_parameters: |
 
 snmp_exporter_launch_parameters: |
   --config.file=/etc/snmp_exporter/snmp.yml
+
+prometheus_server_modbus_exporter_launch_parameters: |
+  --config.file=/etc/modbus_exporter/modbus.yml
 ```
 
 For example, to manipulate data retention (default 15 days) and ask for 60 days,
@@ -660,6 +700,7 @@ prometheus_server_manage_karma: true
 prometheus_server_manage_am_executor: false
 prometheus_server_manage_ipmi_exporter: false
 prometheus_server_manage_snmp_exporter: false
+prometheus_server_manage_modbus_exporter: false
 ```
 
 And activate them on the host you wish them to run (host2), using the opposite values for host2 dedicated hostvars:
@@ -671,6 +712,7 @@ prometheus_server_manage_karma: false
 prometheus_server_manage_am_executor: false
 prometheus_server_manage_ipmi_exporter: true
 prometheus_server_manage_snmp_exporter: true
+prometheus_server_manage_modbus_exporter: true
 ```
 
 To ensure everyone can communicate, set now these global variables in
@@ -683,6 +725,7 @@ prometheus_server_karma_host: host1
 prometheus_server_am_executor_host:
 prometheus_server_ipmi_exporter_host: host2
 prometheus_server_snmp_exporter_host: host2
+prometheus_server_modbus_exporter_host: host2
 ```
 
 This can be used to spread all main services.

--- a/collections/infrastructure/roles/prometheus/defaults/main.yml
+++ b/collections/infrastructure/roles/prometheus/defaults/main.yml
@@ -26,6 +26,7 @@ prometheus_server_am_executor_host: localhost
 prometheus_server_ipmi_exporter_host: localhost
 prometheus_server_snmp_exporter_host: localhost
 prometheus_server_modbus_exporter_host: localhost
+prometheus_server_modbus_exporter_listen_address: "{{ prometheus_server_modbus_exporter_host }}"
 prometheus_server_modbus_exporter_port: 9602
 
 prometheus_server_prometheus_user_gid: 909
@@ -59,6 +60,9 @@ prometheus_server_ipmi_exporter_launch_parameters: |
 prometheus_server_snmp_exporter_launch_parameters: |
   --config.file=/etc/snmp_exporter/snmp.yml
 
+prometheus_server_modbus_exporter_service_template: "modbus_exporter.service.j2"
+prometheus_server_modbus_exporter_config_template: "modbus.yml.j2"
+prometheus_server_modbus_exporter_additional_modules: []
 prometheus_server_modbus_exporter_launch_parameters: |
   --config.file=/etc/modbus_exporter/modbus.yml
 

--- a/collections/infrastructure/roles/prometheus/defaults/main.yml
+++ b/collections/infrastructure/roles/prometheus/defaults/main.yml
@@ -16,6 +16,8 @@ prometheus_server_manage_karma: true
 prometheus_server_manage_am_executor: false
 prometheus_server_manage_ipmi_exporter: false
 prometheus_server_manage_snmp_exporter: false
+prometheus_server_manage_modbus_exporter: false
+
 
 prometheus_server_prometheus_host: localhost
 prometheus_server_alertmanager_host: localhost
@@ -23,6 +25,7 @@ prometheus_server_karma_host: localhost
 prometheus_server_am_executor_host: localhost
 prometheus_server_ipmi_exporter_host: localhost
 prometheus_server_snmp_exporter_host: localhost
+prometheus_server_modbus_exporter_host: localhost
 
 prometheus_server_prometheus_user_gid: 909
 prometheus_server_prometheus_user_uid: 909
@@ -34,6 +37,8 @@ prometheus_server_ipmi_exporter_user_gid: 912
 prometheus_server_ipmi_exporter_user_uid: 912
 prometheus_server_snmp_exporter_user_gid: 913
 prometheus_server_snmp_exporter_user_uid: 913
+prometheus_server_modbus_exporter_user_gid: 914
+prometheus_server_modbus_exporter_user_uid: 914
 
 prometheus_server_prometheus_launch_parameters: |
   --config.file /etc/prometheus/prometheus.yml \
@@ -52,6 +57,9 @@ prometheus_server_ipmi_exporter_launch_parameters: |
 
 prometheus_server_snmp_exporter_launch_parameters: |
   --config.file=/etc/snmp_exporter/snmp.yml
+
+prometheus_server_modbus_exporter_launch_parameters: |
+  --config.file=/etc/modbus_exporter/modbus.yml
 
 prometheus_server_prometheus_prefix: ""
 prometheus_server_alertmanager_prefix: ""
@@ -95,12 +103,15 @@ prometheus_exporters_to_scrape: []
 
 prometheus_ipmi_scrape: false
 prometheus_snmp_scrape: false
+prometheus_modbus_scrape: false
 
 prometheus_ipmi_scrape_hardware_groups: []
 prometheus_snmp_scrape_hardware_groups: []
+prometheus_modbus_tcp_scrape_hardware_groups: []
 
 prometheus_server_snmp_exporter_with_generator: false
 prometheus_server_snmp_exporter_raw_configuration:
+prometheus_server_modbus_exporter_raw_configuration:
 
 prometheus_server_enable_basic_auth: false
 

--- a/collections/infrastructure/roles/prometheus/defaults/main.yml
+++ b/collections/infrastructure/roles/prometheus/defaults/main.yml
@@ -26,6 +26,7 @@ prometheus_server_am_executor_host: localhost
 prometheus_server_ipmi_exporter_host: localhost
 prometheus_server_snmp_exporter_host: localhost
 prometheus_server_modbus_exporter_host: localhost
+prometheus_server_modbus_exporter_port: 9602
 
 prometheus_server_prometheus_user_gid: 909
 prometheus_server_prometheus_user_uid: 909

--- a/collections/infrastructure/roles/prometheus/handlers/main.yml
+++ b/collections/infrastructure/roles/prometheus/handlers/main.yml
@@ -46,6 +46,15 @@
     - "'service' not in ansible_skip_tags"
     - prometheus_start_services | default(bb_start_services) | default(true) | bool
 
+- name: service <|> Restart modbus_exporter service
+  ansible.builtin.service:
+    name: modbus_exporter
+    state: restarted
+  when:
+    - "'service' not in ansible_skip_tags"
+    - prometheus_start_services | default(bb_start_services) | default(true) | bool
+
+
 - name: systemd <|> Reload systemd configuration
   ansible.builtin.systemd:
     daemon_reload: yes

--- a/collections/infrastructure/roles/prometheus/tasks/server.yml
+++ b/collections/infrastructure/roles/prometheus/tasks/server.yml
@@ -35,6 +35,12 @@
   tags:
     - internal
 
+- name: include_tasks <|> Setup modbus_exporter
+  ansible.builtin.include_tasks: "server_modbus_exporter.yml"
+  when: prometheus_server_manage_modbus_exporter
+  tags:
+    - internal
+
 - name: include_tasks <|> Setup tls and/or basic authentication
   ansible.builtin.include_tasks: "server_security.yml"
   when: prometheus_server_enable_tls or prometheus_server_enable_basic_auth

--- a/collections/infrastructure/roles/prometheus/tasks/server_modbus_exporter.yml
+++ b/collections/infrastructure/roles/prometheus/tasks/server_modbus_exporter.yml
@@ -28,9 +28,9 @@
     owner: root
     group: root
     mode: 0644
-  notify:
-    - systemd <|> Reload systemd configuration for prometheus
-    - service <|> Restart modbus_exporter service
+    #notify:
+    #  - systemd <|> Reload systemd configuration for prometheus
+    #  - service <|> Restart modbus_exporter service
   tags:
     - template
 
@@ -52,13 +52,13 @@
     group: modbus_exporter
     mode: 0640
   when: prometheus_server_modbus_exporter_raw_configuration is defined and prometheus_server_modbus_exporter_raw_configuration is not none
-  notify:
-    - service <|> Restart modbus_exporter service
+  #notify:
+  #  - service <|> Restart modbus_exporter service
   tags:
     - template
 
-- name: meta <|> Run handler tasks
-  ansible.builtin.meta: flush_handlers
+      #- name: meta <|> Run handler tasks
+      #  ansible.builtin.meta: flush_handlers
 
 - name: stat <|> Check /etc/modbus_exporter/modbus.yml exists
   ansible.builtin.stat:

--- a/collections/infrastructure/roles/prometheus/tasks/server_modbus_exporter.yml
+++ b/collections/infrastructure/roles/prometheus/tasks/server_modbus_exporter.yml
@@ -23,7 +23,7 @@
 
 - name: template <|> Generate modbus_exporter service file
   ansible.builtin.template:
-    src: modbus_exporter.service.j2
+    src: "{{ prometheus_server_modbus_exporter_service_template | default('modbus_exporter.service.j2') }}"
     dest: /etc/systemd/system/modbus_exporter.service
     owner: root
     group: root
@@ -46,16 +46,25 @@
 
 - name: Template <|> Generate /etc/modbus_exporter/modbus.yml
   ansible.builtin.template:
-    src: "{{ modbus_exporter_template | default('modbus.yml.j2') }}"
+    src: "{{ prometheus_server_modbus_exporter_config_template | default('modbus.yml.j2') }}"
     dest: /etc/modbus_exporter/modbus.yml
     owner: modbus_exporter
     group: modbus_exporter
     mode: 0640
-  when: prometheus_server_modbus_exporter_raw_configuration is defined and prometheus_server_modbus_exporter_raw_configuration is not none
   notify:
     - service <|> Restart modbus_exporter service
   tags:
     - template
+
+- name: copy <|> Copy additional modbus exporter module files
+  ansible.builtin.copy:
+    src: "modbus_exporter/{{ item }}.yml"
+    dest: "/etc/modbus_exporter/{{ item }}.yml"
+    owner: modbus_exporter
+    group: modbus_exporter
+    mode: 0640
+  loop: "{{ prometheus_server_modbus_exporter_additional_modules }}"
+  when: prometheus_server_modbus_exporter_additional_modules is defined and prometheus_server_modbus_exporter_additional_modules
 
 - name: meta <|> Run handler tasks
   ansible.builtin.meta: flush_handlers

--- a/collections/infrastructure/roles/prometheus/tasks/server_modbus_exporter.yml
+++ b/collections/infrastructure/roles/prometheus/tasks/server_modbus_exporter.yml
@@ -14,12 +14,12 @@
     home: /var/lib/modbus_exporter
     state: present
 
-#- name: Package <|> Install modbus_exporter package
-#  ansible.builtin.package:
-#    name: "{{ prometheus_server_modbus_exporter_packages_to_install }}"
-#    state: present
-#  tags:
-#    - package
+- name: Package <|> Install modbus_exporter package
+  ansible.builtin.package:
+    name: "{{ prometheus_server_modbus_exporter_packages_to_install }}"
+    state: present
+  tags:
+    - package
 
 - name: template <|> Generate modbus_exporter service file
   ansible.builtin.template:
@@ -28,9 +28,9 @@
     owner: root
     group: root
     mode: 0644
-    #notify:
-    #  - systemd <|> Reload systemd configuration for prometheus
-    #  - service <|> Restart modbus_exporter service
+  notify:
+    - systemd <|> Reload systemd configuration for prometheus
+    - service <|> Restart modbus_exporter service
   tags:
     - template
 
@@ -52,13 +52,13 @@
     group: modbus_exporter
     mode: 0640
   when: prometheus_server_modbus_exporter_raw_configuration is defined and prometheus_server_modbus_exporter_raw_configuration is not none
-  #notify:
-  #  - service <|> Restart modbus_exporter service
+  notify:
+    - service <|> Restart modbus_exporter service
   tags:
     - template
 
-      #- name: meta <|> Run handler tasks
-      #  ansible.builtin.meta: flush_handlers
+- name: meta <|> Run handler tasks
+  ansible.builtin.meta: flush_handlers
 
 - name: stat <|> Check /etc/modbus_exporter/modbus.yml exists
   ansible.builtin.stat:

--- a/collections/infrastructure/roles/prometheus/tasks/server_modbus_exporter.yml
+++ b/collections/infrastructure/roles/prometheus/tasks/server_modbus_exporter.yml
@@ -1,0 +1,81 @@
+---
+- name: group <|> Add modbus_exporter group
+  ansible.builtin.group:
+    name: modbus_exporter
+    gid: "{{ prometheus_server_modbus_exporter_user_gid }}"
+    state: present
+
+- name: user <|> Add modbus_exporter user
+  ansible.builtin.user:
+    name: modbus_exporter
+    shell: /bin/false
+    uid: "{{ prometheus_server_modbus_exporter_user_uid }}"
+    group: modbus_exporter
+    home: /var/lib/modbus_exporter
+    state: present
+
+#- name: Package <|> Install modbus_exporter package
+#  ansible.builtin.package:
+#    name: "{{ prometheus_server_modbus_exporter_packages_to_install }}"
+#    state: present
+#  tags:
+#    - package
+
+- name: template <|> Generate modbus_exporter service file
+  ansible.builtin.template:
+    src: modbus_exporter.service.j2
+    dest: /etc/systemd/system/modbus_exporter.service
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - systemd <|> Reload systemd configuration for prometheus
+    - service <|> Restart modbus_exporter service
+  tags:
+    - template
+
+- name: file <|> Create modbus_exporter directories structure
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0750
+    owner: modbus_exporter
+    group: modbus_exporter
+  loop:
+    - /etc/modbus_exporter/
+
+- name: Template <|> Generate /etc/modbus_exporter/modbus.yml
+  ansible.builtin.template:
+    src: "{{ modbus_exporter_template | default('modbus.yml.j2') }}"
+    dest: /etc/modbus_exporter/modbus.yml
+    owner: modbus_exporter
+    group: modbus_exporter
+    mode: 0640
+  when: prometheus_server_modbus_exporter_raw_configuration is defined and prometheus_server_modbus_exporter_raw_configuration is not none
+  notify:
+    - service <|> Restart modbus_exporter service
+  tags:
+    - template
+
+- name: meta <|> Run handler tasks
+  ansible.builtin.meta: flush_handlers
+
+- name: stat <|> Check /etc/modbus_exporter/modbus.yml exists
+  ansible.builtin.stat:
+    path: /etc/modbus_exporter/modbus.yml
+  register: prometheus_stat_result
+
+- name: assert <|> Assert that modbus.yml file exist
+  ansible.builtin.assert:
+    that:
+      - prometheus_stat_result.stat.exists
+    fail_msg: "/etc/modbus_exporter/modbus.yml file does not exist, cannot start modbus_exporter"
+    success_msg: "/etc/modbus_exporter/modbus.yml file does exist, proceeding"
+
+- name: service <|> Manage modbus_exporter service state
+  ansible.builtin.service:
+    name: modbus_exporter
+    enabled: "{{ (prometheus_enable_services | default(bb_enable_services) | default(true) | bool) | ternary('yes', 'no') }}"
+    state: "{{ (prometheus_start_services | default(bb_start_services) | default(true) | bool) | ternary('started', omit) }}"
+  tags:
+    - service

--- a/collections/infrastructure/roles/prometheus/templates/modbus.yml.j2
+++ b/collections/infrastructure/roles/prometheus/templates/modbus.yml.j2
@@ -1,0 +1,4 @@
+#### Blue Banquise file ####
+## {{ansible_managed}}
+
+{{ prometheus_server_modbus_exporter_raw_configuration }}

--- a/collections/infrastructure/roles/prometheus/templates/modbus.yml.j2
+++ b/collections/infrastructure/roles/prometheus/templates/modbus.yml.j2
@@ -1,4 +1,4 @@
 #### Blue Banquise file ####
 ## {{ansible_managed}}
 
-{{ prometheus_server_modbus_exporter_raw_configuration }}
+{{ prometheus_server_modbus_exporter_raw_configuration | default('') }}

--- a/collections/infrastructure/roles/prometheus/templates/modbus_exporter.service.j2
+++ b/collections/infrastructure/roles/prometheus/templates/modbus_exporter.service.j2
@@ -1,0 +1,15 @@
+[unit]
+  Description=modbus_exporter
+  Wants=network-online.target
+  After=network-online.target
+
+[Service]
+  User=modbus_exporter
+  Group=modbus_exporter
+  Type=simple
+  WorkingDirectory=/etc/modbus_exporter/
+  ExecStart=/usr/local/bin/modbus_exporter \
+  {{ prometheus_server_modbus_exporter_launch_parameters | indent(2, True) }} 
+
+[Install]
+  WantedBy=multi-user.target

--- a/collections/infrastructure/roles/prometheus/templates/modbus_exporter.service.j2
+++ b/collections/infrastructure/roles/prometheus/templates/modbus_exporter.service.j2
@@ -1,4 +1,4 @@
-[unit]
+[Unit]
   Description=modbus_exporter
   Wants=network-online.target
   After=network-online.target
@@ -8,7 +8,7 @@
   Group=modbus_exporter
   Type=simple
   WorkingDirectory=/etc/modbus_exporter/
-  ExecStart=/usr/local/bin/modbus_exporter \
+  ExecStart=/usr/bin/modbus_exporter --web.listen-address={{ prometheus_server_modbus_exporter_host | default('localhost') }}:{{ prometheus_server_modbus_exporter_port | default('9602') }} \
   {{ prometheus_server_modbus_exporter_launch_parameters | indent(2, True) }} 
 
 [Install]

--- a/collections/infrastructure/roles/prometheus/templates/modbus_exporter.service.j2
+++ b/collections/infrastructure/roles/prometheus/templates/modbus_exporter.service.j2
@@ -8,7 +8,10 @@
   Group=modbus_exporter
   Type=simple
   WorkingDirectory=/etc/modbus_exporter/
-  ExecStart=/usr/bin/modbus_exporter --web.listen-address={{ prometheus_server_modbus_exporter_host | default('localhost') }}:{{ prometheus_server_modbus_exporter_port | default('9602') }} \
+  ExecStart=/usr/bin/modbus_exporter --web.listen-address={{ prometheus_server_modbus_exporter_listen_address | default('') }}:{{ prometheus_server_modbus_exporter_port | default('9602') }} \
+  {% for module in prometheus_server_modbus_exporter_additional_modules %}
+    --config.file="/etc/modbus_exporter/{{ module }}.yml" \
+  {% endfor %}
   {{ prometheus_server_modbus_exporter_launch_parameters | indent(2, True) }} 
 
 [Install]

--- a/collections/infrastructure/roles/prometheus/templates/prometheus.yml.j2
+++ b/collections/infrastructure/roles/prometheus/templates/prometheus.yml.j2
@@ -124,40 +124,39 @@ scrape_configs:
 {% endfor %}
 
 # MODBUS_EXPORTER
-{% if prometheus_modbus_tcp_scrape_hardware_groups is defined and prometheus_modbus_tcp_scrape_hardware_groups %}
-{% for hw_group in prometheus_modbus_tcp_scrape_hardware_groups %}
-  - job_name: 'modbus_exporter_tcp_{{ hw_group.name }}'
-    scrape_interval: {{ hw_group.scrape_interval | default('') }}
-    scrape_timeout: {{ hw_group.scrape_timeout | default('') }}
+{% for hardware in prometheus_modbus_tcp_scrape_hardware_groups %}
+  - job_name: 'modbus_tcp_{{ hardware.name }}'
+    scrape_interval: {{ hardware.scrape_interval | default('') }}
+    scrape_timeout: {{ hardware.scrape_timeout | default('') }}
     metrics_path: /modbus
     static_configs:
-{% for modbus_tcp_host in groups[hw_group.name] | default([]) %}
-{% for modbus_rtu_device in hostvars[modbus_tcp_host]['modbus_rtu_devices'] | default ([]) %}
-    - targets: ["{{ modbus_rtu_device.name }}"]
+{% for tcp_host in groups[hardware.name] | default([]) %}
+{% for modbus_device in hostvars[tcp_host].modbus_tcp_devices | default ([]) %}
+    - targets: ["{{ modbus_device.name | default(tcp_host) }}"]
       labels:
-        module: "{{ modbus_rtu_device.modbus_module }}"
-        target: "{{ modbus_tcp_host }}:{{ hw_group.port | default('502') }}"
-        sub_target: "{{ modbus_rtu_device.modbus_rtu_address }}"
-{% if modbus_rtu_device.labels is defined and modbus_rtu_device.labels %}
-{% for label_key, label_value in modbus_rtu_device.labels.items() %}
-        {{ label_key }}: "{{ label_value }}"
-{% endfor %}
+        module: "{{ modbus_device.exporter_module }}"
+        target: "{{ tcp_host }}:{{ hostvars[tcp_host].modbus_tcp_port | default(hardware.port) | default('502') }}"
+        sub_target: "{{ modbus_device.id | default('1') }}"
+{% if modbus_device.labels is defined and modbus_device.labels %}
+  {% for label, value in modbus_device.labels.items() %}
+        {{ label }}: "{{ value }}"
+  {% endfor %}
 {% endif %}
-{% if modbus_tcp_host.labels is defined and modbus_tcp_host.labels %}
-{% for label_key, label_value in modbus_tcp_host.labels.items() %}
-{% if modbus_rtu_device.labels is not defined or not modbus_rtu_device.labels or label_key not in modbus_rtu_device.keys() %}
-        {{ label_key }}: "{{ label_value }}"
-{% endif %}]
-{% endfor %}
+{% if hostvars[tcp_host].labels is defined and hostvars[tcp_host].labels %}
+  {% for label, value in hostvars[tcp_host].labels.items() %}
+    {% if modbus_device.labels is not defined or not modbus_device.labels or label not in modbus_device.labels.keys() %}
+        {{ label }}: "{{ value }}"
+    {% endif %}
+  {% endfor %}
 {% endif %}
-{% if hw_group.labels is defined %}
-{% for label_key, label_value in hw_group.labels.items() %}
-{% if modbus_rtu_device.labels is not defined or not modbus_rtu_device.labels or label_key not in modbus_rtu_device.keys() %}
-{% if modbus_tcp_host.labels is not defined or not modbus_tcp_host.labels or label_key not in modbus_tcp_host.keys() %}
-        {{ label_key }}: "{{ label_value }}"
-{% endif %}
-{% endif %}]
-{% endfor %}
+{% if hardware.labels is defined and hardware.labels %}
+  {% for label, value in hardware.labels.items() %}
+    {% if modbus_device.labels is not defined or not modbus_device.labels or label not in modbus_device.labels.keys() %}
+      {% if hostvars[tcp_host].labels is not defined or not hostvars[tcp_host].labels or label not in hostvars[tcp_host].labels.keys() %}
+        {{ label }}: "{{ value }}"
+      {% endif %}
+    {% endif %}
+  {% endfor %}
 {% endif %}
 {% endfor %}
 {% endfor %}
@@ -173,7 +172,6 @@ scrape_configs:
       - target_label: __address__
         replacement: "{{ prometheus_server_modbus_exporter_host | default('localhost') }}:{{ prometheus_server_modbus_exporter_port | default('9602') }}"
 {% endfor %}
-{% endif %} 
 
 # BMC - IPMI_EXPORTER
 {% for hardware in prometheus_ipmi_scrape_hardware_groups %}

--- a/collections/infrastructure/roles/prometheus/templates/prometheus.yml.j2
+++ b/collections/infrastructure/roles/prometheus/templates/prometheus.yml.j2
@@ -124,38 +124,54 @@ scrape_configs:
 {% endfor %}
 
 # MODBUS_EXPORTER
-{% if prometheus_modbus_scrape_hardware_groups is defined %}
-{% for hw_group in prometheus_modbus_scrape_hardware_groups %}
-  - job_name: 'modbus_{{ hw_group.name }}'
+{% if prometheus_modbus_tcp_scrape_hardware_groups is defined and prometheus_modbus_tcp_scrape_hardware_groups %}
+{% for hw_group in prometheus_modbus_tcp_scrape_hardware_groups %}
+  - job_name: 'modbus_exporter_tcp_{{ hw_group.name }}'
     scrape_interval: {{ hw_group.scrape_interval | default('') }}
     scrape_timeout: {{ hw_group.scrape_timeout | default('') }}
     metrics_path: /modbus
     static_configs:
-{% for gateway_host in groups[hw_group.name] | default([]) %}
-{% for device in hostvars[gateway_host]['modbus_rtu_devices' ] | default ([]) %}
-    - target: ["{{ gateway_host }}:502"]
+{% for modbus_tcp_host in groups[hw_group.name] | default([]) %}
+{% for modbus_rtu_device in hostvars[modbus_tcp_host]['modbus_rtu_devices'] | default ([]) %}
+    - targets: ["{{ modbus_rtu_device.name }}"]
       labels:
-        instance: "{{ device.name }}"
-	    module: "{{ device.modbus_module }}"
-	    sub_target: "{{ device.modbus_rtu_address }}"
-{% if device.labels is defined %}
-{% for label_key, label_value in device.labels.items() %}
-	    {{ label_key }}: "{{ label_value }}"
+        module: "{{ modbus_rtu_device.modbus_module }}"
+        target: "{{ modbus_tcp_host }}:{{ hw_group.port | default('502') }}"
+        sub_target: "{{ modbus_rtu_device.modbus_rtu_address }}"
+{% if modbus_rtu_device.labels is defined and modbus_rtu_device.labels %}
+{% for label_key, label_value in modbus_rtu_device.labels.items() %}
+        {{ label_key }}: "{{ label_value }}"
+{% endfor %}
+{% endif %}
+{% if modbus_tcp_host.labels is defined and modbus_tcp_host.labels %}
+{% for label_key, label_value in modbus_tcp_host.labels.items() %}
+{% if modbus_rtu_device.labels is not defined or not modbus_rtu_device.labels or label_key not in modbus_rtu_device.keys() %}
+        {{ label_key }}: "{{ label_value }}"
+{% endif %}]
+{% endfor %}
+{% endif %}
+{% if hw_group.labels is defined %}
+{% for label_key, label_value in hw_group.labels.items() %}
+{% if modbus_rtu_device.labels is not defined or not modbus_rtu_device.labels or label_key not in modbus_rtu_device.keys() %}
+{% if modbus_tcp_host.labels is not defined or not modbus_tcp_host.labels or label_key not in modbus_tcp_host.keys() %}
+        {{ label_key }}: "{{ label_value }}"
+{% endif %}
+{% endif %}]
 {% endfor %}
 {% endif %}
 {% endfor %}
 {% endfor %}
     relabel_configs:
-	  - source_labels: [module]
-	    target_label: __param_module
-	  - source_labels: [__address__]
-	    target_label: __param_target
-	  - source_labels: [sub_target]
-	    target_label: __param_sub_target
-	  - source_labels: [__address__]
-	    target_label: gateway_address
-	  - target_label: __address__
-	    replacement: "{{ prometheus_server_modbus_exporter_host | default('127.0.0.1') }}:9602"
+      - source_labels: [module]
+        target_label: __param_module
+      - source_labels: [target]
+        target_label: __param_target
+      - source_labels: [sub_target]
+        target_label: __param_sub_target
+      - source_labels: [__address__]
+        target_label: instance
+      - target_label: __address__
+        replacement: "{{ prometheus_server_modbus_exporter_host | default('localhost') }}:{{ prometheus_server_modbus_exporter_port | default('9602') }}"
 {% endfor %}
 {% endif %} 
 

--- a/collections/infrastructure/roles/prometheus/templates/prometheus.yml.j2
+++ b/collections/infrastructure/roles/prometheus/templates/prometheus.yml.j2
@@ -123,6 +123,41 @@ scrape_configs:
         replacement: {{ prometheus_server_snmp_exporter_host }}:9116
 {% endfor %}
 
+# MODBUS_EXPORTER
+{% if prometheus_modbus_scrape_hardware_groups is defined %}
+{% for hw_group in prometheus_modbus_scrape_hardware_groups %}
+  - job_name: 'modbus_{{ hw_group.name }}'
+    scrape_interval: {{ hw_group.scrape_interval | default('') }}
+    scrape_timeout: {{ hw_group.scrape_timeout | default('') }}
+    metrics_path: /modbus
+    static_configs:
+{% for gateway_host in groups[hw_group.name] | default([]) %}
+{% for device in hostvars[gateway_host]['modbus_rtu_devices' ] | default ([]) %}
+    - target: ["{{ gateway_host }}:502"]
+      labels:
+        instance: "{{ device.name }}"
+	    module: "{{ device.modbus_module }}"
+	    sub_target: "{{ device.modbus_rtu_address }}"
+{% if device.labels is defined %}
+{% for label_key, label_value in device.labels.items() %}
+	    {{ label_key }}: "{{ label_value }}"
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+    relabel_configs:
+	  - source_labels: [module]
+	    target_label: __param_module
+	  - source_labels: [__address__]
+	    target_label: __param_target
+	  - source_labels: [sub_target]
+	    target_label: __param_sub_target
+	  - source_labels: [__address__]
+	    target_label: gateway_address
+	  - target_label: __address__
+	    replacement: "{{ prometheus_server_modbus_exporter_host | default('127.0.0.1') }}:9602"
+{% endfor %}
+{% endif %} 
 
 # BMC - IPMI_EXPORTER
 {% for hardware in prometheus_ipmi_scrape_hardware_groups %}

--- a/collections/infrastructure/roles/prometheus/vars/Debian.yml
+++ b/collections/infrastructure/roles/prometheus/vars/Debian.yml
@@ -15,5 +15,8 @@ prometheus_server_snmp_exporter_additional_packages_to_install:
   - net-snmp-utils
   - net-snmp-libs
   - net-snmp-devel
+prometheus_server_modbus_exporter_packages_to_install:
+  - prometheus-modbus-exporter
 prometheus_server_karma_packages_to_install:
   - prometheus
+

--- a/collections/infrastructure/roles/prometheus/vars/RedHat.yml
+++ b/collections/infrastructure/roles/prometheus/vars/RedHat.yml
@@ -16,6 +16,6 @@ prometheus_server_snmp_exporter_additional_packages_to_install:
   - net-snmp-libs
   - net-snmp-devel
 prometheus_server_modbus_exporter_packages_to_install:
-  - modbus_exporter
+  - prometheus-modbus-exporter
 prometheus_server_karma_packages_to_install:
   - karma

--- a/collections/infrastructure/roles/prometheus/vars/RedHat.yml
+++ b/collections/infrastructure/roles/prometheus/vars/RedHat.yml
@@ -15,5 +15,7 @@ prometheus_server_snmp_exporter_additional_packages_to_install:
   - net-snmp-utils
   - net-snmp-libs
   - net-snmp-devel
+prometheus_server_modbus_exporter_packages_to_install:
+  - modbus_exporter
 prometheus_server_karma_packages_to_install:
   - karma

--- a/collections/infrastructure/roles/prometheus/vars/Suse.yml
+++ b/collections/infrastructure/roles/prometheus/vars/Suse.yml
@@ -15,5 +15,7 @@ prometheus_server_snmp_exporter_additional_packages_to_install:
   - net-snmp-utils
   - net-snmp-libs
   - net-snmp-devel
+prometheus_server_modbus_exporter_packages_to_install:
+  - prometheus-modbus-exporter
 prometheus_server_karma_packages_to_install:
   - karma

--- a/collections/infrastructure/roles/prometheus/vars/Ubuntu.yml
+++ b/collections/infrastructure/roles/prometheus/vars/Ubuntu.yml
@@ -15,5 +15,7 @@ prometheus_server_snmp_exporter_additional_packages_to_install:
   - net-snmp-utils
   - net-snmp-libs
   - net-snmp-devel
+prometheus_server_modbus_exporter_packages_to_install:
+  - prometheus-modbus-exporter
 prometheus_server_karma_packages_to_install:
   - prometheus


### PR DESCRIPTION
## Describe your changes

Initial support for deployment and configuration of [`modbus_exporter`](https://github.com/RichiH/modbus_exporter) and scrape configuration for Prometheus for SMC @ginomcevoy.

## Issue ticket number and link if any

- Main branch PR: #1249 
- The software package was introduced in [infrastructure PR#44](https://github.com/bluebanquise/infrastructure/pull/44).
- The exporter repo itself will hopefully move to [prometheus-community](https://github.com/prometheus-community/community/issues/59) soon.

## Checklist before requesting a review

Please use this checklist to help me fasten the review.

- [x] Document introduced changes in main documentation (see documentation folder)
- [ ] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml (optional, up to you)
- [x] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG

:warning: Ensure your PR does not break static code analysis (see automatic checks).