### PR TITLE
[dns_server] Fix dns server override mechanism

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # To 3.4 or 4.0
 
+* 2026-07-22 - santos-lucas - [dns_server] Fix dns server override mechanism (#1265)
 * 2026-07-22 - santos-lucas - [README] Just improving bootstrap command on main README.md
 * 2026-07-10 - psblldv - [bootstrap] Increasing verbosity in inner script
 * 25/06/2026 - oxedions [multiple] Fix multiple roles, and add experimental RHCOS support (#1252)

--- a/collections/infrastructure/roles/dns_server/tasks/main.yml
+++ b/collections/infrastructure/roles/dns_server/tasks/main.yml
@@ -113,7 +113,6 @@
 - name: set_fact <|> Set SOA Serial for reverse zone
   ansible.builtin.set_fact:
     dns_server_serial: "{{ lookup('pipe', 'date +%s') }}"
-  when: dns_server_zoneconf.changed  # noqa no-handler
   tags:
     - template
     - internal
@@ -162,7 +161,7 @@
     group: root
     mode: 0644
   notify: service <|> Restart dns services
-  when: dns_overrides is defined and dns_server_zoneconf.changed  # noqa no-handler
+  when: dns_server_overrides is defined # noqa no-handler
   tags:
     - template
 

--- a/collections/infrastructure/roles/dns_server/templates/override.j2
+++ b/collections/infrastructure/roles/dns_server/templates/override.j2
@@ -1,6 +1,6 @@
 $TTL 60
-@            IN    SOA  {{ inventory_hostname }}.{{ domain_name }}. root.{{ domain_name }}.  (
-                          {{ serial }} ; serial
+@            IN    SOA  {{ inventory_hostname }}.{{ dns_server_domain_name | default(bb_domain_name, true) | default('cluster.local', true) }}. root.{{ dns_server_domain_name | default(bb_domain_name, true) | default('cluster.local', true) }}.  (
+                          {{ dns_server_serial }} ; serial
                           1h           ; refresh
                           30m          ; retry
                           1w           ; expiry


### PR DESCRIPTION
2 related changes on this PR:

1. Removed the condition `dns_server_zoneconf.changed` to generate the dns_server_serial and to generate the override file - otherwise the step to generate will be skipped and changing only `dns_server_overrides` will have no effect when running the role.

2. Fixed broken variables in [collections/infrastructure/roles/dns_server/templates/override.j2](/bluebanquise/bluebanquise/blob/master/collections/infrastructure/roles/dns_server/templates/override.j2)


Please use this checklist to help me fasten the review.

- [x] Document introduced changes in main documentation (see documentation folder)
- [x] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml (optional, up to you)
- [x] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG

:warning: Ensure your PR does not break static code analysis (see automatic checks).