### PR TITLE
grafana: fix { => unified_}alerting #1269

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # To 3.4 or 4.0
 
+* 2026-08-10 - sc-alex - [grafana] Fix broken conditionals, { => unified_}alerting in grafana.ini
 * 2026-07-22 - santos-lucas - [README] Just improving bootstrap command on main README.md
 * 2026-07-10 - psblldv - [bootstrap] Increasing verbosity in inner script
 * 25/06/2026 - oxedions [multiple] Fix multiple roles, and add experimental RHCOS support (#1252)

--- a/collections/infrastructure/roles/grafana/templates/grafana.ini.j2
+++ b/collections/infrastructure/roles/grafana/templates/grafana.ini.j2
@@ -105,7 +105,7 @@ enabled = true
 path = {{ grafana_data_dir }}/dashboards
 
 # Alerting
-[alerting]
+[unified_alerting]
 {% if grafana_alerting != {} %}
 enabled = true
 {%   for k,v in grafana_alerting.items() %}


### PR DESCRIPTION
Role error was:

```
TASK [bluebanquise.infrastructure.grafana : service <|> Wait for grafana to start (http/s)]
[…]
[ERROR]: Task failed: Module failed: Timeout when waiting for 0.0.0.0:3000
Origin: /home/bb/.ansible/collections/ansible_collections/bluebanquise/infrastructure/roles/grafana/tasks/main.yml:80:3

78   ansible.builtin.meta: flush_handlers
79
80 - name: service <|> Wait for grafana to start (http/s)
     ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "elapsed": 300, "msg": "Timeout when waiting for 0.0.0.0:3000"}
```

Grafana v13.1.1 error was:

```
logger=settings t=2026-08-10T18:37:26.197688584+02:00 level=info msg="Starting Grafana" version=13.1.1 commit=a9cee6e1724a455676bb6c05eef7fc54aa4b19f4 branch=release-13.1.1#patched compiled=2026-07-20T18:46:34+02:00
logger=settings t=2026-08-10T18:37:26.198677108+02:00 level=error msg="Option '[alerting].enabled' cannot be true. Legacy Alerting is removed. It is no longer deployed, enhanced, or supported. Delete '[alerting].enabled' and use '[unified_alerting].enabled' to enable Graf>
Error: ✗ invalid setting [alerting].enabled
```

## Describe your changes

Rename section `alerting` to `unified_alerting` in `grafana.ini`.

## Issue ticket number and link if any

#1269

## Checklist before requesting a review

Please use this checklist to help me fasten the review.

- [ ] Document introduced changes in main documentation (see documentation folder)
- [ ] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml (optional, up to you)
- [x] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG

:warning: Ensure your PR does not break static code analysis (see automatic checks).