### PR TITLE
[bluebanquise-diskless] Handle extended file attributes in bootstrap images

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 Format: <date> - <author (username or mail or both)> - [role] <change description>
 
 # 3.2.8
+* 14/08/2026 - lgt-bull [pxe_stack] Fix bluebanquise-diskless to handle extended file attributes in bootstrap image archives (#1272)
 * 04/08/2026 - teo-blachere [dns_client] Disabling NetworkManager's DNS processing (#1267)
 * 23/07/2026 - patrice-duc-jacquet [nic]  add 2s sleep after  'nmcli con up' command
 * 10/07/2026 - bouzonnl [hosts_file] Generate FQDN for services (#1255)

--- a/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
+++ b/collections/infrastructure/roles/pxe_stack/files/bluebanquise-diskless
@@ -7,6 +7,7 @@
 # ██████╔╝███████╗╚██████╔╝███████╗██████╔╝██║  ██║██║ ╚████║╚██████╔╝╚██████╔╝██║███████║███████╗
 # ╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═══╝ ╚══▀▀═╝  ╚═════╝ ╚═╝╚══════╝╚══════╝
 #
+# 2.3.1: (SMC fix) Fix missing extended file attributes when extracting bootstrap image archives. Neo Team <dl-fr-bds-hpc-neocore@bull.com>
 # 2.3.0: (SMC feature) Added support to el10 images. Neo Team <dl-fr-bds-hpc-neocore@bull.com>
 # 2.2.5: (SMC fix) Fix NFS mount (-u uid) and SELinux (avoid chroot) in aarch64 images. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
 # 2.2.4: (SMC fix) Allow + character when sanitizing user input, needed for kernel-64k in aarch64 images. Neo Team <dl-fr-bds-hpc-neocore@eviden.com>
@@ -505,7 +506,7 @@ while True:
 
         logging.info(bcolors.OKBLUE + "Extracting bootstrap image copy in " + reference_image_nfs_path + bcolors.ENDC)
         protected_os_system("mkdir -p " + reference_image_nfs_path)
-        protected_os_system("tar --numeric-owner -x -z -f " + bootstrap_image_path + "/image.tar.gz -C " + reference_image_nfs_path + "/")
+        protected_os_system("tar --numeric-owner --xattrs-include='*.*' -x -z -f " + bootstrap_image_path + "/image.tar.gz -C " + reference_image_nfs_path + "/")
         protected_os_system("rm -f " + reference_image_nfs_path + "/metadata.yaml")
         logging.info(bcolors.OKBLUE + "Creating image folder at " + reference_image_pxe_path + bcolors.ENDC)
         protected_os_system("mkdir -p " + reference_image_pxe_path)


### PR DESCRIPTION
Thank you for opening a pull request. This helps a lot! :hearts:

:point_down: Please read the bellow instructions to ease the review process. :point_down:

## Describe your changes

Handle extended file attributes in bootstrap images:

Bootstrap image archives may contain extended file attributes. These attributes must be included explicitly during extraction of the archive using tar '--xattrs-include' parameter.

## Issue ticket number and link if any

Add here any references to an already opened issue (can even be outside this repository).

## Checklist before requesting a review

Please use this checklist to help me fasten the review.

- [ ] Document introduced changes in main documentation (see documentation folder)
- [ ] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml (optional, up to you)
- [x] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG

:warning: Ensure your PR does not break static code analysis (see automatic checks).