### PR TITLE
added override_repositories_environment feature 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # To 3.4 or 4.0
 
+* 2026-08-23 - santos-lucas - [repositories] Added override_repositories_environment feature (#1275)
 * 2026-08-10 - sc-alex - [grafana] Fix broken conditionals, { => unified_}alerting in grafana.ini
 * 2026-07-22 - santos-lucas - [dns_server] Fix dns server override mechanism (#1265)
 * 2026-07-22 - santos-lucas - [README] Just improving bootstrap command on main README.md

--- a/collections/infrastructure/roles/repositories/README.md
+++ b/collections/infrastructure/roles/repositories/README.md
@@ -113,6 +113,8 @@ os_operating_system:
 
 Then path will be: repositories/production/centos/8.1/$basearch/
 
+Note: `os_operating_system['repositories_environment']` can be overriden at any group (including all) with the variable `override_repositories_environment`. `override_repositories_environment` will always win precedence.
+
 ### Remove native repositories
 
 If you wish to remove native OS repositories, to rely only on local ones (air gapped cluster for example), you need to use the pxe_stack role of the collection. (This role does not support removing repositories for now.)
@@ -130,6 +132,7 @@ And native repositories will be removed during nodes deployment (PXE install, no
 **Please now update CHANGELOG file at repository root instead of adding logs in this file.
 These logs bellow are only kept for archive.**
 
+* 1.4.0: Added override_repositories_environment feature. Lucas Santos <lucassouzasantos@gmail.com>
 * 1.3.9: Fix variables names. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.3.7: Fix services ip precedence. Benoit Leveugle <benoit.leveugle@gmail.com>
 * 1.3.6: Fix extra space in automatic url. Benoit Leveugle <benoit.leveugle@gmail.com>

--- a/collections/infrastructure/roles/repositories/vars/main.yml
+++ b/collections/infrastructure/roles/repositories/vars/main.yml
@@ -1,5 +1,34 @@
 ---
-repositories_role_version: 1.3.9
+repositories_role_version: 1.4.0
 
-repositories_j2_simple_url: "http://{{ networks[repositories_network | default((network_interfaces | default([]) | selectattr('network','defined') | selectattr('interface','defined') | selectattr('ip4','defined') | selectattr('network','match','^net-[a-zA-Z0-9]+') | map(attribute='network') | list | first | default(none)), true)]['services']['repositories4'][0]['ip4'] | default(networks[repositories_network | default((network_interfaces | default([]) | selectattr('network','defined') | selectattr('interface','defined') | selectattr('ip4','defined') | selectattr('network','match','^net-[a-zA-Z0-9]+') | map(attribute='network') | list | first | default(none)), true)]['services']['repositories'][0]['hostname'], true) | default(networks[repositories_network | default((network_interfaces | default([]) | selectattr('network','defined') | selectattr('interface','defined') | selectattr('ip4','defined') | selectattr('network','match','^net-[a-zA-Z0-9]+') | map(attribute='network') | list | first | default(none)), true)]['services']['repositories'][0]['ip4'], true) | default(networks[repositories_network | default((network_interfaces | default([]) | selectattr('network','defined') | selectattr('interface','defined') | selectattr('ip4','defined') | selectattr('network','match','^net-[a-zA-Z0-9]+') | map(attribute='network') | list | first | default(none)), true)]['services_ip'], true) | default('', true) }}/repositories/{{ os_operating_system['repositories_environment'] | default('', true) }}/{{ os_operating_system['distribution'] | default('', true) }}/{{ os_operating_system['distribution_version'] | default(os_operating_system['distribution_major_version']) | default('', true)}}/{{ ansible_architecture }}/"
+_repositories_network_name: >-
+  {{ repositories_network | default(
+    (network_interfaces | default([])
+      | selectattr('network','defined')
+      | selectattr('interface','defined')
+      | selectattr('ip4','defined')
+      | selectattr('network','match','^net-[a-zA-Z0-9]+')
+      | map(attribute='network')
+      | list | first | default(none)), true)
+    }}
+
+_repositories_path: >-
+  repositories/{{ override_repositories_environment
+    | default(os_operating_system['repositories_environment'], true)
+    | default('', true) }}/{{ os_operating_system['distribution']
+    | default('', true) }}/{{ os_operating_system['distribution_version']
+    | default(os_operating_system['distribution_major_version'])
+    | default('', true)}}/{{ ansible_architecture }}/
+
+_repositories_network_obj: "{{ networks[_repositories_network_name] }}"
+
+repositories_j2_simple_url: >-
+  http://{{
+    _repositories_network_obj['services']['repositories4'][0]['ip4']
+    | default(_repositories_network_obj['services']['repositories'][0]['hostname'], true)
+    | default(_repositories_network_obj['services']['repositories'][0]['ip4'], true)
+    | default(_repositories_network_obj['services_ip'], true)
+    | default('', true)
+  }}/{{_repositories_path}}
+
 # Lol, no more that simple :D


### PR DESCRIPTION

added override_repositories_environment feature  + make variable rendering more readable

override_repositories_environment enables the user to override the definition under os_operating_system['repositories_environment'] variable.

## Checklist before requesting a review

Please use this checklist to help me fasten the review.

- [x] Document introduced changes in main documentation (see documentation folder)
- [x] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml (optional, up to you)
- [x] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG

:warning: Ensure your PR does not break static code analysis (see automatic checks).