### PR TITLE
add ansible.utils collection dependency to bootstrap script

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Format: <date> - <author (username or mail or both)> - [role] <change descriptio
 
 # To 3.4
 
+* 2026-08-27 - santos-lucas - [bootstrap] Added ansible.utils dependency on bootstrap process (#1279)
 * 2026-08-23 - santos-lucas - [repositories] Added override_repositories_environment feature (#1275)
 * 22/08/2026 - oxedions, Ummon [pxe_stack] wired TFTP_ADDRESS/OPTIONS/DIRECTORY into the tftp-hpa migration — Debian/Ubuntu via /etc/default/tftpd-hpa, RHEL 9+/Suse via a systemd drop-in overriding tftp.service's ExecStart (socket-activated, no env file). Also fixed the restart handler, which was silently never restarting the tftp service on config change.
 * 22/08/2026 - oxedions, Ummon [pxe_stack] add bluebanquise-netboots-installer CLI tool to install, uninstall, and list OS netboots (ubuntu_24.04, debian_13, rhel_9, rhel_10, opensuse_16) with download progress, SHA256 verification, airgap support, and automatic major-version symlinks.

--- a/bootstrap/configure_environment.sh
+++ b/bootstrap/configure_environment.sh
@@ -37,6 +37,8 @@ pip3 install -r $CURRENT_DIR/requirements.txt
 
 echo "Trying 3 times to grab community.general..."
 ansible-galaxy collection install community.general || sleep 30 && ansible-galaxy collection install community.general || sleep 30 && ansible-galaxy collection install community.general
+echo "Installing ansible.utils..."
+ansible-galaxy collection install ansible.utils 
 # Install BlueBanquise collections
 if [[ $COLLECTIONS_LOCAL_PATH != "none" ]]; then
   ansible-galaxy collection install $COLLECTIONS_LOCAL_PATH


### PR DESCRIPTION
## Describe your changes

Just added ansible.utils collection to be installed on the bootstrap process, since it is being used in a couple roles. So we can avoid issues like this:
```
TASK [bluebanquise.infrastructure.dns_server : template <|> Generate named options configuration file] ********************************************************
Thursday 27 August 2026  20:27:09 +0000 (0:00:01.870)       0:00:16.942 *******
[ERROR]: Task failed: Error rendering template: No filter named 'ansible.utils.ipaddr' found.

Task failed.
Origin: /var/lib/bluebanquise/.ansible/ansible_collections/bluebanquise/infrastructure/roles/dns_server/tasks/main.yml:87:3

85     - template
86
87 - name: template <|> Generate named options configuration file
     ^ column 3

<<< caused by >>>

Error rendering template: No filter named 'ansible.utils.ipaddr' found.
```

Add here a small description of your changes.

## Checklist before requesting a review

Please use this checklist to help me fasten the review.

- [x] Document introduced changes in main documentation (see documentation folder)
- [x] Make sure your name is present in the authors list in galaxy.yml: https://github.com/bluebanquise/bluebanquise/blob/master/collections/infrastructure/galaxy.yml (optional, up to you)
- [x] Update CHANGELOG file at repository root: https://github.com/bluebanquise/bluebanquise/blob/master/CHANGELOG

:warning: Ensure your PR does not break static code analysis (see automatic checks).