### PR TITLE
fix: replace broken awesome-prometheus-alerts link

### DIFF
--- a/documentation/old/monitoring/prometheus.rst
+++ b/documentation/old/monitoring/prometheus.rst
@@ -593,4 +593,4 @@ You can find more about it here:
 
 And here are examples of some alerts:
 
-.. seealso:: https://awesome-prometheus-alerts.grep.to/rules.html
+.. seealso:: https://samber.github.io/awesome-prometheus-alerts/rules.html

--- a/resources/bibliography.md
+++ b/resources/bibliography.md
@@ -142,7 +142,7 @@ https://prometheus.io/docs/prometheus/latest/federation/
 https://github.com/prometheus/pushgateway
 https://medium.com/@rdavix/how-to-export-alerts-from-prometheus-to-grafana-8f1de059a8c8
 https://github.com/soundcloud/ipmi_exporter
-https://awesome-prometheus-alerts.grep.to/rules.html
+https://samber.github.io/awesome-prometheus-alerts/rules.html
 https://grafana.com/grafana/plugins/camptocamp-prometheus-alertmanager-datasource
 https://github.com/MiteshSharma/PrometheusAlertManagerWithAnsible
 https://www.digitalocean.com/community/tutorials/how-to-use-alertmanager-and-blackbox-exporter-to-monitor-your-web-server-on-ubuntu-16-04


### PR DESCRIPTION
Hi!

The `awesome-prometheus-alerts.grep.to` domain is no longer maintained: the site is gone and the domain now shows a parking page, so the link in this repo is broken.

This PR replaces it with the current home of the project:

https://samber.github.io/awesome-prometheus-alerts

No other changes. Thanks!
